### PR TITLE
Making date parsing a bit more lenient.

### DIFF
--- a/lib/OpenLayers/BaseTypes/Date.js
+++ b/lib/OpenLayers/BaseTypes/Date.js
@@ -87,7 +87,7 @@ OpenLayers.Date = {
      */
     parse: function(str) {
         var date;
-        var match = str.match(/^(?:(\d{4})(?:-(\d{2})(?:-(\d{2}))?)?)?(?:T(\d{1,2}):(\d{2}):(\d{2}(?:\.\d+)?)(Z|(?:[+-]\d{1,2}(?::(\d{2}))?)))?$/);
+        var match = str.match(/^(?:(\d{4})(?:-(\d{2})(?:-(\d{2}))?)?)?(?:(?:T(\d{1,2}):(\d{2}):(\d{2}(?:\.\d+)?)(Z|(?:[+-]\d{1,2}(?::(\d{2}))?)))|Z)?$/);
         if (match && (match[1] || match[7])) { // must have at least year or time
             var year = parseInt(match[1], 10) || 0;
             var month = (parseInt(match[2], 10) - 1) || 0;

--- a/tests/BaseTypes/Date.html
+++ b/tests/BaseTypes/Date.html
@@ -35,7 +35,7 @@
     
     function test_Date_parse(t) {
         
-        t.plan(93);
+        t.plan(114);
         
         var cases = {
             "2000": {
@@ -127,6 +127,18 @@
                 minutes: 51,
                 seconds: 25,
                 milliseconds: 123
+            },
+            "2000Z": { // lenient (Chrome accepts this)
+                year: 2000
+            },
+            "2000-02Z": { // lenient (Chrome accepts this)
+                year: 2000,
+                month: 1
+            },
+            "2000-04-15Z": { // lenient (Chrome accepts this)
+                year: 2000,
+                month: 3,
+                date: 15
             }
         };
 


### PR DESCRIPTION
RFC 3339 doesn't say what timezone to assume for date strings without time.  Some servers append "Z" to dates (e.g. "2001-02-03Z") and some clients accept this (e.g. Chrome).  The OpenLayers date parser should accept dates without times and with "Z" at the end.
