### PR TITLE
Improve maxExtent documentation

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -299,11 +299,14 @@ OpenLayers.Map = OpenLayers.Class({
     /**
      * APIProperty: maxExtent
      * {<OpenLayers.Bounds>} The maximum extent for the map.  Defaults to the
-     *                       whole world in decimal degrees 
-     *                       (-180, -90, 180, 90).  Specify a different
-     *                        extent in the map options if you are not using a 
-     *                        geographic projection and displaying the whole 
-     *                        world.
+     *     whole world in decimal degrees 
+     *     (-180, -90, 180, 90).  Specify a different
+     *     extent in the map options if you are not using a 
+     *     geographic projection and displaying the whole 
+     *     world. To restrict user panning and
+     *     zooming of the map, use restrictedExtent instead.
+     *     The value for maxExtent will change calculations for
+     *     tile URLs.
      */
     maxExtent: null,
     


### PR DESCRIPTION
I've seen many, many users misusing maxExtent when what they want is restrictedExtent, or a maxExtent that changes tile loading - for maps that are rendered 'as if' the world exists but a subset is rendered (aka, most spherical mercator new-world maps).

I think a quick change to the documentation might help this situation a little bit, to steer users with the restrictedExtent use case to the right place instead of dying in maxExtent-land.
