### PR TITLE
Expose map original options

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -239,6 +239,12 @@ OpenLayers.Map = OpenLayers.Class({
      */
     panRatio: 1.5,    
 
+    /**
+     * APIProperty: options
+     * {Object} The options object passed to the class constructor. Read-only.
+     */
+    options: null,
+
   // Options
 
     /**
@@ -479,6 +485,9 @@ OpenLayers.Map = OpenLayers.Class({
 
         this.theme = OpenLayers._getScriptLocation() + 
                              'theme/default/style.css'; 
+
+        // backup original options
+        this.options = OpenLayers.Util.extend({}, options);
 
         // now override default options 
         OpenLayers.Util.extend(this, options);
@@ -731,6 +740,7 @@ OpenLayers.Map = OpenLayers.Class({
         this.events.destroy();
         this.events = null;
 
+        this.options = null;
     },
 
     /**

--- a/tests/Map.html
+++ b/tests/Map.html
@@ -2000,6 +2000,23 @@
         t.eq(map.layerContainerDiv.style.top, '0px', 'layer container top correct');
     }
 
+    function test_options(t) {
+        t.plan(2);
+
+        var map = new OpenLayers.Map('map');
+        t.eq(map.options, {}, 'map.options is empty with no options');
+        map.destroy();
+
+        var options = {
+            resolutions: [1,2,3,5],
+            projection: "EPSG:4326",
+            units: 'm'
+        };
+        var map = new OpenLayers.Map('map', options);
+        t.eq(map.options, options, 'map.options is a copy of the constructor option');
+        map.destroy();
+    }
+
     function test_adjustZoom(t) {
         t.plan(4);
         var map = new OpenLayers.Map({


### PR DESCRIPTION
A new API property: `OpenLayers.Map.initialOptions` that contains the options passed to the map constructor.
