### PR TITLE
remove unneeded activate and deactivate functions

### DIFF
--- a/lib/OpenLayers/Control/WMSGetFeatureInfo.js
+++ b/lib/OpenLayers/Control/WMSGetFeatureInfo.js
@@ -211,35 +211,6 @@ OpenLayers.Control.WMSGetFeatureInfo = OpenLayers.Class(OpenLayers.Control, {
     },
 
     /**
-     * Method: activate
-     * Activates the control.
-     * 
-     * Returns:
-     * {Boolean} The control was effectively activated.
-     */
-    activate: function () {
-        if (!this.active) {
-            this.handler.activate();
-        }
-        return OpenLayers.Control.prototype.activate.apply(
-            this, arguments
-        );
-    },
-
-    /**
-     * Method: deactivate
-     * Deactivates the control.
-     * 
-     * Returns:
-     * {Boolean} The control was effectively deactivated.
-     */
-    deactivate: function () {
-        return OpenLayers.Control.prototype.deactivate.apply(
-            this, arguments
-        );
-    },
-    
-    /**
      * Method: getInfoForClick 
      * Called on click
      *


### PR DESCRIPTION
in `OpenLayers.Control.WMSGetFeatureInfo`.

`deactivate` only calls the parent and `activate` activates the handler witch is already done in the parent class.
