### PR TITLE
Track failing tiles with loadError property

### DIFF
--- a/lib/OpenLayers/Tile/Image.js
+++ b/lib/OpenLayers/Tile/Image.js
@@ -261,7 +261,7 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile.BackBufferable, {
      */
     initImage: function() {
         var img = this.imgDiv || this.createImage();
-        if (this.url && img.getAttribute("src") == this.url) {
+        if (!this.loadError && this.url && img.getAttribute("src") == this.url) {
             this.onImageLoad();
         } else {
             // We need to start with a blank image, to make sure that no
@@ -343,6 +343,7 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile.BackBufferable, {
         var img = this.imgDiv;
         OpenLayers.Event.stopObservingElement(img);
         img.style.display = "";
+        this.loadError = false;
         this.isLoading = false;
         this.events.triggerEvent("loadend");
 
@@ -378,8 +379,9 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile.BackBufferable, {
             if (this.imageReloadAttempts <= OpenLayers.IMAGE_RELOAD_ATTEMPTS) {
                 this.setImgSrc(this.layer.getURL(this.bounds));
             } else {
-                OpenLayers.Element.addClass(img, "olImageLoadError");
                 this.onImageLoad();
+                OpenLayers.Element.addClass(img, "olImageLoadError");
+                this.loadError = true;
             }
         }
     },

--- a/tests/Tile/Image.html
+++ b/tests/Tile/Image.html
@@ -334,6 +334,32 @@
         t.ok(tile.imgDiv == null, "image reference removed from tile");
         map.destroy();
     }
+
+    function test_olImageLoadError(t) {
+        t.plan(2);
+        var map = new OpenLayers.Map('map');
+        var layer = new OpenLayers.Layer.WMS("invalid",  "", {layers: 'basic'});
+        map.addLayer(layer);
+
+        var size = new OpenLayers.Size(5, 6);
+        var position = new OpenLayers.Pixel(20, 30);
+        var bounds = new OpenLayers.Bounds(1, 2, 3, 4);
+
+        var tile = new OpenLayers.Tile.Image(layer, position, bounds, null, size);
+        tile.draw();
+
+        t.delay_call(0.1, function() {
+            t.ok(OpenLayers.Element.hasClass(tile.imgDiv, 'olImageLoadError'), "");
+
+            layer.setVisibility(false);
+            layer.setVisibility(true);
+
+            t.delay_call(0.1, function() {
+                t.ok(OpenLayers.Element.hasClass(tile.imgDiv, 'olImageLoadError'), "");
+                map.destroy();
+            });
+        });
+    }
     
   </script>
 </head>


### PR DESCRIPTION
This issue can be reproduced here: http://goo.gl/SYRiO

The tiles of the "triangle" layer loads, some tiles are flagged with the `olImageLoadError` css class (this is normal, because we don't have data we send an HTTP 204 status code).

Now if the visibility layer is changed from visible to invisible and back again, the css class is lost: the fact that a tile failed to load must be tracked in `OpenLayers.Tile.Image`
