### PR TITLE
closure.py: Use temporary file names but manual deletion.

### DIFF
--- a/tools/closure.py
+++ b/tools/closure.py
@@ -8,13 +8,14 @@ if not os.path.exists(path):
 
 def minimize(code):
     ntf = tempfile.NamedTemporaryFile()
-    ntf.write(code)
-    ntf.flush()
+    ntf.close()
+    open(ntf.name, "w").write(code)
 
     ntf2 = tempfile.NamedTemporaryFile()
+    ntf2.close()
 
     os.system("java -jar %s --js %s --js_output_file %s" % (path, ntf.name, ntf2.name))
     data = open(ntf2.name).read()
-    ntf.close()
-    ntf2.close()
+    os.unlink(ntf.name) 
+    os.unlink(ntf2.name) 
     return data


### PR DESCRIPTION
The commit:
 https://github.com/openlayers/openlayers/commit/4226e45260c262dfb49378bdcf87237b7d9a05ad
causes a regression. Now "build.py -c closure" does not work on windows systems.

See http://trac.osgeo.org/openlayers/ticket/3158

This patch works on: Windows XP+python2.4, Vista+python2.7 and Ubuntu10+python2.6
