### PR TITLE
Handle property inheritance and flat layers list in a single pass

### DIFF
--- a/lib/OpenLayers/Format/WMSCapabilities/v1.js
+++ b/lib/OpenLayers/Format/WMSCapabilities/v1.js
@@ -238,104 +238,78 @@ OpenLayers.Format.WMSCapabilities.v1 = OpenLayers.Class(
                 obj.exception = {formats: []};
                 this.readChildNodes(node, obj.exception);
             },
-            "Layer": (function() {
-                var defaults = {
-                        cascaded: 0,
-                        fixedWidth: 0,
-                        fixedHeight: 0,
-                        queryable: false,
-                        opaque: false,
-                        noSubsets: false
-                    },
-                    attributes = ["queryable", "cascaded", "fixedWidth", 
-                                "fixedHeight", "opaque", "noSubsets", "llbbox",
-                                "minScale", "maxScale", "attribution"],
-                    complexAttr = ["srs", "bbox", "dimensions", "authorityURLs"];
-
-                return function(node, obj) {
-                    var parentLayer, capability;
-                    if (obj.capability) {
-                        capability = obj.capability;
-                        parentLayer = obj;
-                    } else {
-                        capability = obj;
+            "Layer": function(node, obj) {
+                var parentLayer, capability;
+                if (obj.capability) {
+                    capability = obj.capability;
+                    parentLayer = obj;
+                } else {
+                    capability = obj;
+                }
+                var attrNode = node.getAttributeNode("queryable");
+                var queryable = (attrNode && attrNode.specified) ? 
+                    node.getAttribute("queryable") : null;
+                attrNode = node.getAttributeNode("cascaded");
+                var cascaded = (attrNode && attrNode.specified) ?
+                    node.getAttribute("cascaded") : null;
+                attrNode = node.getAttributeNode("opaque");
+                var opaque = (attrNode && attrNode.specified) ?
+                    node.getAttribute('opaque') : null;
+                var noSubsets = node.getAttribute('noSubsets');
+                var fixedWidth = node.getAttribute('fixedWidth');
+                var fixedHeight = node.getAttribute('fixedHeight');
+                var parent = parentLayer || {},
+                    extend = OpenLayers.Util.extend;
+                var layer = {
+                    nestedLayers: [],
+                    styles: parentLayer ? [].concat(parentLayer.styles) : [],
+                    srs: parentLayer ? extend({}, parent.srs) : {}, 
+                    metadataURLs: [],
+                    bbox: parentLayer ? extend({}, parent.bbox) : {},
+                    llbbox: parent.llbbox,
+                    dimensions: parentLayer ? extend({}, parent.dimensions) : {},
+                    authorityURLs: parentLayer ? extend({}, parent.authorityURLs) : {},
+                    identifiers: {},
+                    keywords: [],
+                    queryable: (queryable && queryable !== "") ? 
+                        (queryable === "1" || queryable === "true" ) :
+                        (parent.queryable || false),
+                    cascaded: (cascaded !== null) ? parseInt(cascaded) :
+                        (parent.cascaded || 0),
+                    opaque: opaque ? 
+                        (opaque === "1" || opaque === "true" ) :
+                        (parent.opaque || false),
+                    noSubsets: (noSubsets !== null) ? 
+                        (noSubsets === "1" || noSubsets === "true" ) :
+                        (parent.noSubsets || false),
+                    fixedWidth: (fixedWidth != null) ? 
+                        parseInt(fixedWidth) : (parent.fixedWidth || 0),
+                    fixedHeight: (fixedHeight != null) ? 
+                        parseInt(fixedHeight) : (parent.fixedHeight || 0),
+                    minScale: parent.minScale,
+                    maxScale: parent.maxScale,
+                    attribution: parent.attribution,
+                };
+                obj.nestedLayers.push(layer);
+                layer.capability = capability;
+                this.readChildNodes(node, layer);
+                delete layer.capability;
+                if(layer.name) {
+                    var parts = layer.name.split(":"),
+                        request = capability.request,
+                        gfi = request.getfeatureinfo;
+                    if(parts.length > 0) {
+                        layer.prefix = parts[0];
                     }
-                    var attrNode = node.getAttributeNode("queryable");
-                    var queryable = (attrNode && attrNode.specified) ? 
-                        node.getAttribute("queryable") : null;
-                    attrNode = node.getAttributeNode("cascaded");
-                    var cascaded = (attrNode && attrNode.specified) ?
-                        node.getAttribute("cascaded") : null;
-                    attrNode = node.getAttributeNode("opaque");
-                    var opaque = (attrNode && attrNode.specified) ?
-                        node.getAttribute('opaque') : null;
-                    var noSubsets = node.getAttribute('noSubsets');
-                    var fixedWidth = node.getAttribute('fixedWidth');
-                    var fixedHeight = node.getAttribute('fixedHeight');
-                    var layer = {nestedLayers: [], styles: [], srs: {}, 
-                        metadataURLs: [], bbox: {}, dimensions: {},
-                        authorityURLs: {}, identifiers: {}, keywords: [],
-                        queryable: (queryable && queryable !== "") ? 
-                            ( queryable === "1" || queryable === "true" ) : null,
-                        cascaded: (cascaded !== null) ? parseInt(cascaded) : null,
-                        opaque: opaque ? 
-                            (opaque === "1" || opaque === "true" ) : null,
-                        noSubsets: (noSubsets !== null) ? 
-                            ( noSubsets === "1" || noSubsets === "true" ) : null,
-                        fixedWidth: (fixedWidth != null) ? 
-                            parseInt(fixedWidth) : null,
-                        fixedHeight: (fixedHeight != null) ? 
-                            parseInt(fixedHeight) : null
-                    };
-                    obj.nestedLayers.push(layer);
-                    layer.capability = capability;
-                    this.readChildNodes(node, layer);
-                    delete layer.capability;
-                    if(layer.name) {
-                        var parts = layer.name.split(":"),
-                            request = capability.request,
-                            gfi = request.getfeatureinfo;
-                        if(parts.length > 0) {
-                            layer.prefix = parts[0];
-                        }
-                        capability.layers.push(layer);
-                        if (layer.formats === undefined) {
-                            layer.formats = request.getmap.formats;
-                        }
-                        if (layer.infoFormats === undefined && gfi) {
-                            layer.infoFormats = gfi.formats;
-                        }
-
-                        // deal with property inheritance
-                        if(parentLayer) {
-                            // add style
-                            layer.styles = layer.styles.concat(parentLayer.styles);
-                            var parentValue, key, i, len;
-
-                            for (i=0, len=attributes.length; i<len; i++) {
-                                key = attributes[i];
-                                if (key in parentLayer) {
-                                    // only take parent value if not present (null
-                                    // or undefined)
-                                    if (layer[key] == null) {
-                                        parentValue = parentLayer[key];
-                                        // if we haven't inherited anything from a
-                                        // parent layer set to default value
-                                        layer[key] = parentValue == null ?
-                                            defaults[key] : parentValue;
-                                    }
-                                }
-                            }
-
-                            for (i=0, len=complexAttr.length; i<len; i++) {
-                                key = complexAttr[i];
-                                OpenLayers.Util.applyDefaults(
-                                    layer[key], parentLayer[key]);
-                            }
-                        }
+                    capability.layers.push(layer);
+                    if (layer.formats === undefined) {
+                        layer.formats = request.getmap.formats;
+                    }
+                    if (layer.infoFormats === undefined && gfi) {
+                        layer.infoFormats = gfi.formats;
                     }
                 }
-            })(),
+            },
             "Attribution": function(node, obj) {
                 obj.attribution = {};
                 this.readChildNodes(node, obj.attribution);


### PR DESCRIPTION
Currently, for nested layers in a WMSCapabilities doc, we deal with property inheritance and creation of a flat layers list in a second pass. I suggest changing the code so all happens in a single pass.
