### PR TITLE
Don't let wrapDateLine maps be wider than one world width.

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -1701,6 +1701,30 @@ OpenLayers.Map = OpenLayers.Class({
             this.events.triggerEvent("move");
         }
     },
+    
+    /**
+     * Method: adjustZoom
+     *
+     * Parameters:
+     * zoom - {Number} The zoom level to adjust
+     *
+     * Returns:
+     * {Integer} Adjusted zoom level that shows a map not wider than its
+     * <baseLayer>'s maxExtent.
+     */
+    adjustZoom: function(zoom) {
+        var resolution, resolutions = this.baseLayer.resolutions,
+            maxResolution = this.getMaxExtent().getWidth() / this.getSize().w;
+        if (this.getResolutionForZoom(zoom) > maxResolution) {
+            for (var i=zoom|0, ii=resolutions.length; i<ii; ++i) {
+                if (resolutions[i] <= maxResolution) {
+                    zoom = i;
+                    break;
+                }
+            }
+        }
+        return zoom;
+    },
 
     /**
      * Method: moveTo
@@ -1722,6 +1746,9 @@ OpenLayers.Map = OpenLayers.Class({
             if (!this.fractionalZoom) {
                 zoom = Math.round(zoom);
             }
+        }
+        if (this.baseLayer.wrapDateLine) {
+            zoom = this.adjustZoom(zoom);
         }
         // dragging is false by default
         var dragging = options.dragging || this.dragging;

--- a/tests/Layer/WrapDateLine.html
+++ b/tests/Layer/WrapDateLine.html
@@ -131,7 +131,7 @@
 
         var url = "http://octo.metacarta.com/cgi-bin/mapserv";
         layer = new OpenLayers.Layer.WMS(name, url, params, {'wrapDateLine':true,encodeBBOX:true, buffer: 2});
-        var m = new OpenLayers.Map('map');
+        var m = new OpenLayers.Map('map', {adjustZoom: function(z) {return z;}});
         m.addLayer(layer);
         m.zoomToMaxExtent();
         t.eq(layer.grid[3][0].url, "http://octo.metacarta.com/cgi-bin/mapserv?MAP=%2Fmapdata%2Fvmap_wms.map&LAYERS=basic&FORMAT=image%2Fpng&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&SRS=EPSG%3A4326&BBOX=0%2C-90%2C180%2C90&WIDTH=256&HEIGHT=256", "cell [3][0] is wrapped around the world.");
@@ -147,7 +147,7 @@
              "http://www.openlayers.org/world/index.php",
              {g: "satellite", map: "world"},
              {wrapDateLine: true, buffer: 2} ); 
-        var m = new OpenLayers.Map('map');
+        var m = new OpenLayers.Map('map', {adjustZoom: function(z) {return z;}});
         m.addLayer(layer);
         m.zoomToMaxExtent();
         t.eq(layer.grid[0][0].url, "http://www.openlayers.org/world/index.php?g=satellite&map=world&i=jpeg&t=-1280&l=0&s=221471921.25", "grid[0][0] kamap is okay");
@@ -165,7 +165,7 @@
                      "prov_bound,fedlimit,rail,road,popplace",
              transparent: "true", format: "image/png"},
             {wrapDateLine: true, reproject: false,encodeBBOX:true, buffer:2});
-        var m = new OpenLayers.Map('map');
+        var m = new OpenLayers.Map('map', {adjustZoom: function(z) {return z;}});
         m.addLayers([baselayer,layer]);
         m.zoomToMaxExtent();
         t.eq(layer.grid[0][0].url, "http://www2.dmsolutions.ca/cgi-bin/mswms_gmap?LAYERS=bathymetry%2Cland_fn%2Cpark%2Cdrain_fn%2Cdrainage%2Cprov_bound%2Cfedlimit%2Crail%2Croad%2Cpopplace&TRANSPARENT=true&FORMAT=image%2Fpng&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&SRS=EPSG%3A4326&BBOX=0%2C450%2C180%2C630&WIDTH=256&HEIGHT=256", "grid[0][0] wms overlay is okay");

--- a/tests/Map.html
+++ b/tests/Map.html
@@ -1967,6 +1967,23 @@
         t.eq(map.layerContainerDiv.style.top, '0px', 'layer container top correct');
     }
 
+    function test_adjustZoom(t) {
+        t.plan(3);
+        var map = new OpenLayers.Map({
+            div: 'map',
+            layers: [
+                new OpenLayers.Layer('name', {
+                    isBaseLayer: true,
+                    wrapDateLine: true
+                })
+            ]
+        });
+        map.zoomToMaxExtent();
+        t.ok(map.getResolution() <= map.getMaxExtent().getWidth() / map.getSize().w, "wrapDateLine map not wider than world");
+        
+        t.eq(map.adjustZoom(9), 9, "valid zoom maintained");
+        t.eq(map.adjustZoom(1), 2, "zoom adjusted to not exceed world width");
+    }
 
   </script>
 </head>


### PR DESCRIPTION
Google Maps does it, and now that we got proper dateline handling for vector layers we should also do it. The reason is that we only display vector layer features once, and by avoiding map extents that exceed the world width we make sure that we're not missing features.
