### PR TITLE
Call moveTo on the marker object instead of the icon.

### DIFF
--- a/lib/OpenLayers/Layer/Markers.js
+++ b/lib/OpenLayers/Layer/Markers.js
@@ -156,8 +156,8 @@ OpenLayers.Layer.Markers = OpenLayers.Class(OpenLayers.Layer, {
             if (!marker.isDrawn()) {
                 var markerImg = marker.draw(px);
                 this.div.appendChild(markerImg);
-            } else if(marker.icon) {
-                marker.icon.moveTo(px);
+            } else {
+                marker.moveTo(px);
             }
         }
     },


### PR DESCRIPTION
The Marker has a moveTo function, which will take care of calling moveTo on the icon (or any icon-like marker).
