### PR TITLE
Layer.KaMap cleanup

### DIFF
--- a/lib/OpenLayers/Layer/KaMap.js
+++ b/lib/OpenLayers/Layer/KaMap.js
@@ -23,18 +23,6 @@ OpenLayers.Layer.KaMap = OpenLayers.Class(OpenLayers.Layer.Grid, {
     isBaseLayer: true,
 
     /**
-     * APIProperty: units
-     * {?}
-     */    
-    units: null,
-
-    /**
-     * APIProperty: resolution
-     * {Float}
-     */
-    resolution: OpenLayers.DOTS_PER_INCH,
-    
-    /**
      * Constant: DEFAULT_PARAMS
      * {Object} parameters set by default. The default parameters set 
      * the format via the 'i' parameter to 'jpeg'.    
@@ -62,9 +50,7 @@ OpenLayers.Layer.KaMap = OpenLayers.Class(OpenLayers.Layer.Grid, {
      *     extends, can be overridden through the options parameter. 
      */
     initialize: function(name, url, params, options) {
-        var newArguments = [];
-        newArguments.push(name, url, params, options);
-        OpenLayers.Layer.Grid.prototype.initialize.apply(this, newArguments);
+        OpenLayers.Layer.Grid.prototype.initialize.apply(this, arguments);
         this.params = OpenLayers.Util.applyDefaults(
             this.params, this.DEFAULT_PARAMS
         );


### PR DESCRIPTION
Remove unused units and resolution properties
Simplify Grid.initialize call

Tests continue to pass
