### PR TITLE
Solution for ...

### DIFF
--- a/lib/OpenLayers/Filter/Comparison.js
+++ b/lib/OpenLayers/Filter/Comparison.js
@@ -113,7 +113,22 @@ OpenLayers.Filter.Comparison = OpenLayers.Class(OpenLayers.Filter, {
             context = context.attributes;
         }
         var result = false;
-        var got = context[this.property];
+        
+        var got;
+        var propertyType = typeof this.property;
+        
+        switch (propertyType) {
+            case 'function':
+                got = this.property.call(context);
+                break;
+            case 'string':
+                got = context[this.property];
+                break;
+            default:
+                throw new Error(propertyType + ' is an unsupported property type. Property may be a String or Function ' +
+                            'OpenLayers.Filter.Comparison');
+        }
+        
         var exp;
         switch(this.type) {
             case OpenLayers.Filter.Comparison.EQUAL_TO:


### PR DESCRIPTION
http://stackoverflow.com/questions/8323576/openlayers-comparison-filter-object-property

Usecase:

feature.attributes (the context) is sth. like:

```
{
    'foo': 'bar',
    'baz': {
        'lorem': 'ipsum',
        'dolor': 'sit'
    },
    'amet': 1337
}
```

And the Filter looks like that:

```
 var filter = new OpenLayers.Filter.Comparison({
     type: '==',
     property: function () {
         return this.baz.lorem;
     },
     value: 'sit'
 });
```
