### PR TITLE
Remove parameters that aren't supported by ArcGIS to improve REST performance

### DIFF
--- a/lib/OpenLayers/Layer/ArcGIS93Rest.js
+++ b/lib/OpenLayers/Layer/ArcGIS93Rest.js
@@ -221,5 +221,66 @@ OpenLayers.Layer.ArcGIS93Rest = OpenLayers.Class(OpenLayers.Layer.Grid, {
                                                              newArguments);
     },
 
+    /** 
+     * Method: getFullRequestString
+     * Combine url with layer's params and these newParams. 
+     *   
+     *    does checking on the serverPath variable, allowing for cases when it 
+     *     is supplied with trailing ? or &, as well as cases where not. 
+     *
+     *    return in formatted string like this:
+     *        "server?key1=value1&key2=value2&key3=value3"
+     * 
+     * WARNING: The altUrl parameter is deprecated and will be removed in 3.0.
+     *
+     * Parameters:
+     * newParams - {Object}
+     * altUrl - {String} Use this as the url instead of the layer's url
+     *   
+     * Returns: 
+     * {String}
+     */
+    getFullRequestString:function(newParams, altUrl) {
+        // if not altUrl passed in, use layer's url
+        var url = altUrl || this.url;
+            
+        // create a new params hashtable with all the layer params and the 
+        // new params together. then convert to string
+        var allParams = OpenLayers.Util.extend({}, this.params);
+        allParams = OpenLayers.Util.extend(allParams, newParams);
+        var paramsString = OpenLayers.Util.getParameterString(allParams);
+        
+        // if url is not a string, it should be an array of strings, 
+        // in which case we will deterministically select one of them in 
+        // order to evenly distribute requests to different urls.
+        //
+        if (OpenLayers.Util.isArray(url)) {
+            url = this.selectUrl(paramsString, url);
+        }   
+ 
+        // ignore parameters that are already in the url search string
+        var urlParams = 
+            OpenLayers.Util.upperCaseObject(OpenLayers.Util.getParameters(url));
+        for(var key in allParams) {
+            if(key.toUpperCase() in urlParams) {
+                delete allParams[key];
+            }
+        }
+ 
+        // Remove parameters that aren't supported by ArcGIS to improve REST performance
+        var allowedParams = {f:0, bbox:0, size:0, dpi:0, imageSR:0, bboxSR:0, format:0, layerDefs:0, layers:0, transparent:0, time:0, layerTimeOptions:0 };
+        for(var key in allParams) {
+	        if(key.toLowerCase() in allowedParams) {
+	           // Nothing
+	        } else {
+	        	delete allParams[key];
+	        }
+        }
+        
+        paramsString = OpenLayers.Util.getParameterString(allParams);
+        
+        return OpenLayers.Util.urlAppend(url, paramsString);
+    },
+
     CLASS_NAME: "OpenLayers.Layer.ArcGIS93Rest"
 });


### PR DESCRIPTION
I recently discovered that sending extra parameter to the ArcGIS REST server increases loading time. 

Example url 1

http://gisak.alingsas.se/ArcGIS/rest/services/Busslinjer/MapServer/export?URL=http%3A%2F%2Fgisak.alingsas.se%2FArcGIS%2Frest%2Fservices%2FBusslinjer%2FMapServer&LAYERS=&PARAMS=[object%20Object]&OPTIONS=[object%20Object]&ARCGIS_METHOD=rest&LAYER_TYPE=openlayers_layer_type_arcgis&PROJECTION=EPSG%3A3007&LAYER_HANDLER=arcgis&VECTOR=true&BASELAYER=false&TERMS=&TRANSPARENT=true&TITLE=Busslinjer&WEIGHT=16&DRUPALID=Busslinjer&BUFFER=2&FORMAT=png24&BBOX=178732.468321%2C6422204.68643%2C179816.203822%2C6423288.421931&SIZE=256%2C256&F=image&BBOXSR=3007&IMAGESR=3007

Takes about 500ms - 1s to load. 

Example url 2

http://gisak.alingsas.se/ArcGIS/rest/services/Busslinjer/MapServer/export?VECTOR=true&BASELAYER=false&TRANSPARENT=true&FORMAT=png24&BBOX=178732.468321%2C6422204.68643%2C179816.203822%2C6423288.421931&SIZE=256%2C256&F=image

Takes about 140-170 ms to load

I added an extra getFullRequestString function in OpenLayers.Layer.ArcGIS93Rest that removes all parameters that are not supported by ArcGIS REST API. http://sampleserver1.arcgisonline.com/ArcGIS/SDK/REST/index.html
