### PR TITLE
Default pixel tolerance of 2.

### DIFF
--- a/lib/OpenLayers/Control/GetFeature.js
+++ b/lib/OpenLayers/Control/GetFeature.js
@@ -232,7 +232,8 @@ OpenLayers.Control.GetFeature = OpenLayers.Class(OpenLayers.Control, {
             this.handlers.hover = new OpenLayers.Handler.Hover(
                 this, {'move': this.cancelHover, 'pause': this.selectHover},
                 OpenLayers.Util.extend(this.handlerOptions.hover, {
-                    'delay': 250
+                    'delay': 250,
+                    'pixelTolerance': 2
                 })
             );
         }


### PR DESCRIPTION
This avoids requests to be aborted during hover due to the cursor change caused in some browsers by applying the olCursorWait class.
