### PR TITLE
mobile: responsive button

### DIFF
--- a/lib/OpenLayers/Control/Panel.js
+++ b/lib/OpenLayers/Control/Panel.js
@@ -249,8 +249,11 @@ OpenLayers.Control.Panel = OpenLayers.Class(OpenLayers.Control, {
             if (controls[i].title != "") {
                 controls[i].panel_div.title = controls[i].title;
             }
+            OpenLayers.Event.observe(controls[i].panel_div, "touchstart",
+                OpenLayers.Function.bind(this.onTouchStart, this, controls[i]));
             OpenLayers.Event.observe(controls[i].panel_div, "click", 
                 OpenLayers.Function.bind(this.onClick, this, controls[i]));
+
             OpenLayers.Event.observe(controls[i].panel_div, "dblclick", 
                 OpenLayers.Function.bindAsEventListener(OpenLayers.Event.stop));
             OpenLayers.Event.observe(controls[i].panel_div, "mousedown", 
@@ -309,6 +312,14 @@ OpenLayers.Control.Panel = OpenLayers.Class(OpenLayers.Control, {
         var re = new RegExp(this.displayClass + 'ItemActive');
         d.className = d.className.replace(re,
                 this.displayClass + "ItemInactive");
+    },
+
+    /**
+     * Method: onTouchStart
+     */
+    onTouchStart: function (ctrl, evt) {
+        OpenLayers.Event.stop(evt ? evt : window.event, false);
+        this.activateControl(ctrl);
     },
 
     /**


### PR DESCRIPTION
On mobile devices, the click event is not immediately triggered: the browser will wait approximately 300ms from the time that you tap the button to fire the click event. The reason for this is that the browser is waiting to see if you are actually performing a double tap. 

We can observe this behavior in our mobile examples for the zoomin / zoomout buttons: http://goo.gl/mrqYH

Listening to the touchstart event instead of the click event solves this issue, demo: http://goo.gl/PmrwT

See: http://code.google.com/intl/fr/mobile/articles/fast_buttons.html
