### PR TITLE
Don't update the map size on 'movestart'

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -539,9 +539,6 @@ OpenLayers.Map = OpenLayers.Class({
             this.events.on(this.eventListeners);
         }
  
-        // update the map size and location before the map moves
-        this.events.register("movestart", this, this.updateSize);
-
         // Because Mozilla does not support the "resize" event for elements 
         // other than "window", we need to put a hack here. 
         if (OpenLayers.String.contains(navigator.appName, "Microsoft")) {


### PR DESCRIPTION
On every `movestart`, `Map.updateSize()` is called. This is not necessary and is an expensive operation: the browser has to force a reflow.

The call was introduce in 160722a1 apparently to reset `this.events.element.offsets` but this variable do not exists anymore.
