### PR TITLE
It turns out we really want to retile sometimes.

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -319,6 +319,18 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
                 }
             } else {
 
+                // if the bounds have changed such that they are not even 
+                // *partially* contained by our tiles (e.g. when user has 
+                // programmatically panned to the other side of the earth on
+                // zoom level 18), then moveGriddedTime could potentially have
+                // to run through thousands of cycles, so we want to reTile
+                // instead (thus, partial true).  
+                forceReTile = forceReTile ||
+                    !tilesBounds.intersectsBounds(bounds, {
+                        worldBounds: this.map.baseLayer.wrapDateLine &&
+                            this.map.getMaxExtent()
+                    });
+
                 if(resolution !== serverResolution) {
                     bounds = this.map.calculateBounds(null, serverResolution);
                     if(forceReTile) {

--- a/tests/Layer/Grid.html
+++ b/tests/Layer/Grid.html
@@ -169,7 +169,7 @@
     
     function test_Layer_Grid_moveTo(t) {
 
-    t.plan(12);
+    t.plan(14);
 
         var map = new OpenLayers.Map('map');
         layer = new OpenLayers.Layer.WMS(name, url, params);
@@ -300,6 +300,14 @@
             t.ok(g_WhichFunc == "MoveGridded", "if tiles not drastically out of bounds, we call moveGriddedTile()");
             t.ok(g_Bounds.equals(b), "if tiles not drastically out of bounds, we call moveGriddedTile() with correct bounds");
         });
+
+        // drastic pan
+        clearTestBounds();
+        tilesBounds = new OpenLayers.Bounds(-150,-150,-120,-120);
+        layer.moveTo(null, zoomChanged);
+        t.ok(g_WhichFunc == "InitGridded", "if tiles drastically out of bounds, we call initGriddedTile()");
+        t.ok(g_Bounds.equals(b), "if tiles drastically out of bounds, we call initGriddedTile() with correct bounds");
+
     }
 
     /** THIS WOULD BE WHERE THE TESTS WOULD GO FOR 


### PR DESCRIPTION
The reason is that we want to avoid moveGriddedTiles to run through hundreds of cycles to shift tiles until we reach the new bounds. But containsBounds does not work if extents that cross the date line start on different worlds, so we use intersectsBounds where we can pass the world bounds to handle this case.
