### PR TITLE
Duplicate feature title while rendering layer styles

### DIFF
--- a/lib/OpenLayers/Renderer/SVG.js
+++ b/lib/OpenLayers/Renderer/SVG.js
@@ -252,9 +252,15 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
                 if (style.graphicTitle) {
                     node.setAttributeNS(null, "title", style.graphicTitle);
                     //Standards-conformant SVG
-                    var label = this.nodeFactory(null, "title");
-                    label.textContent = style.graphicTitle;
-                    node.appendChild(label);
+                    // Prevent duplicate nodes. See issue https://github.com/openlayers/openlayers/issues/92 
+                    var titleNode = node.getElementsByTagName("title");
+                    if (titleNode.length > 0) {
+                        titleNode[0].firstChild.textContent = style.graphicTitle;
+                    } else {
+                        var label = this.nodeFactory(null, "title");
+                        label.textContent = style.graphicTitle;
+                        node.appendChild(label);
+                    }
                 }
                 if (style.graphicWidth && style.graphicHeight) {
                   node.setAttributeNS(null, "preserveAspectRatio", "none");

--- a/lib/OpenLayers/Renderer/SVG2.js
+++ b/lib/OpenLayers/Renderer/SVG2.js
@@ -183,9 +183,15 @@ OpenLayers.Renderer.SVG2 = OpenLayers.Class(OpenLayers.Renderer.NG, {
                 if (style.graphicTitle) {
                     node.setAttributeNS(null, "title", style.graphicTitle);
                     //Standards-conformant SVG 
-                    var label = this.nodeFactory(null, "title"); 
-                    label.textContent = style.graphicTitle; 
-                    node.appendChild(label); 
+                    // Prevent duplicate nodes. See issue https://github.com/openlayers/openlayers/issues/92 
+                    var titleNode = node.getElementsByTagName("title");
+                    if (titleNode.length > 0) {
+                        titleNode[0].firstChild.textContent = style.graphicTitle;
+                    } else {
+                        var label = this.nodeFactory(null, "title");
+                        label.textContent = style.graphicTitle;
+                        node.appendChild(label);
+                    }
                 }
                 if (style.graphicWidth && style.graphicHeight) {
                     node.setAttributeNS(null, "preserveAspectRatio", "none");


### PR DESCRIPTION
External graphic child node title duplicated as long as the layer is redrawn if vector layer has style with 'graphicTitle'.
