### PR TITLE
Remove requires of Format/WKT from Geometry.js

### DIFF
--- a/lib/OpenLayers/Geometry.js
+++ b/lib/OpenLayers/Geometry.js
@@ -5,8 +5,9 @@
  
 /**
  * @requires OpenLayers/BaseTypes/Class.js
- * @requires OpenLayers/Format/WKT.js
  * @requires OpenLayers/Feature/Vector.js
+ * 
+ * uses OpenLayers/Format/WKT.js
  */
 
 /**


### PR DESCRIPTION
Can we please remove this requires, so it's no longer included in all vector builds. It is only used by the de/serialize functions, which I would imagine is a minority usage. Would suggest putting a note in the release notes that anyone wanting to use these functions should ensure they have Format/WKT in their build config.

No logic change. Only affects builds.
