### PR TITLE
Remove unused variable

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -741,8 +741,6 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
         var tilelon = tileLayout.tilelon;
         var tilelat = tileLayout.tilelat;
 
-        this.origin = new OpenLayers.Pixel(tileoffsetx, tileoffsety);
-
         var startX = tileoffsetx; 
         var startLon = tileoffsetlon;
 


### PR DESCRIPTION
`this.origin` is created in `OpenLayers.Layer.Grid` but never used (nor in the children classes).

Tests continue to pass.
