### PR TITLE
Ignore build artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/build/OpenLayers.js


### PR DESCRIPTION
This patch adds a `.gitignore` file to tell git to ignore `/build/OpenLayers.js`. This keeps your working copy clean, even after building OpenLayers.
