### PR TITLE
Fixing IFrame tile layers.

### DIFF
--- a/lib/OpenLayers/Tile/Image.js
+++ b/lib/OpenLayers/Tile/Image.js
@@ -339,6 +339,9 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile, {
      * or if it's currently loading.
      */
     createBackBuffer: function() {
+        if (!this.imgDiv || this.isLoading) {
+            return;
+        }
         var backBuffer;
         if (this.frame) {
             backBuffer = this.frame.cloneNode(false);

--- a/lib/OpenLayers/Tile/Image/IFrame.js
+++ b/lib/OpenLayers/Tile/Image/IFrame.js
@@ -204,7 +204,7 @@ OpenLayers.Tile.Image.IFrame = {
      */
     createBackBuffer: function() {
         var backBuffer;
-        if(!this.useIFrame) {
+        if(this.useIFrame === false) {
             backBuffer = OpenLayers.Tile.Image.prototype.createBackBuffer.call(this);
         }
         return backBuffer;


### PR DESCRIPTION
A problem introduced with 5fda8835da627bc97604b68335db724e4fff85e5 can easily be solved by re-adding a check for imgDiv and a strict type check for useIFrame. Thanks @elemoine for pointing out that there could be a problem.
