### PR TITLE
make Layer.redraw not unconditionally set zoomChanged to true when calling Layer.moveTo

### DIFF
--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -541,7 +541,9 @@ OpenLayers.Layer = OpenLayers.Class({
      * Returns:
      * {Boolean} The layer was redrawn.
      */
-    redraw: function() {
+    redraw: function(zoomChanged) {
+        // zoomChanged forces a zoom change in the layer's moveTo
+        // call. This isn't documented because not part of the API.
         var redrawn = false;
         if (this.map) {
 
@@ -552,7 +554,9 @@ OpenLayers.Layer = OpenLayers.Class({
             var extent = this.getExtent();
 
             if (extent && this.inRange && this.visibility) {
-                var zoomChanged = true;
+                zoomChanged = zoomChanged ||
+                              this._resolution === undefined ||
+                              this._resolution !== this.map.getResolution();
                 this.moveTo(extent, zoomChanged, false);
                 this.events.triggerEvent("moveend",
                     {"zoomChanged": zoomChanged});
@@ -577,6 +581,7 @@ OpenLayers.Layer = OpenLayers.Class({
             display = display && this.inRange;
         }
         this.display(display);
+        this._resolution = this.map.getResolution();
     },
 
     /**
@@ -632,6 +637,8 @@ OpenLayers.Layer = OpenLayers.Class({
             
             // deal with gutters
             this.setTileSize();
+
+            delete this._resolution;
         }
     },
     

--- a/tests/Layer.html
+++ b/tests/Layer.html
@@ -672,18 +672,80 @@
         // test that the moveend event was triggered
         t.ok(log.event, "an event was logged");
         t.eq(log.event.type, "moveend", "moveend was triggered");
-        t.eq(log.event.zoomChanged, true, "event says zoomChanged true - poor name");
+        t.eq(log.event.zoomChanged, false, "event says zoomChanged false");
 
         layer.moveTo = function(bounds, zoomChanged, dragging) {
             var extent = layer.map.getExtent();
             t.ok(bounds.equals(extent),
                  "redraw calls moveTo with the map extent");
-            t.ok(zoomChanged,
-                 "redraw calls moveTo with zoomChanged true");
+            t.ok(!zoomChanged,
+                 "redraw calls moveTo with zoomChanged false");
             t.ok(!dragging,
                  "redraw calls moveTo with dragging false");
         }
         layer.redraw();
+    }
+
+    // This function includes integration tests to verify that the
+    // layer's moveTo function is called with the expected value
+    // for zoomChanged
+    function test_moveTo_zoomChanged(t) {
+        t.plan(6);
+
+        var log = {};
+        var map = new OpenLayers.Map('map');
+
+        var l1 = new OpenLayers.Layer('l1', {isBaseLayer: true});
+        l1.moveTo = function(bounds, zoomChanged, dragging) {
+            log.moveTo = {zoomChanged: zoomChanged};
+            OpenLayers.Layer.prototype.moveTo.apply(this, arguments);
+        };
+
+        map.addLayer(l1);
+        map.zoomToMaxExtent();
+
+        log = {};
+        l1.redraw();
+        t.eq(log.moveTo.zoomChanged, false,
+                "[a] redraw calls moveTo with zoomChanged false");
+
+        log = {};
+        l1.redraw(true);
+        t.eq(log.moveTo.zoomChanged, true,
+             "[b] redraw calls moveTo with zoomChanged true");
+
+        l1.setVisibility(false);
+        log = {};
+        l1.setVisibility(true);
+        t.eq(log.moveTo.zoomChanged, false,
+             "[c] redraw calls moveTo with zoomChanged false");
+
+        l1.setVisibility(false);
+        map.zoomIn();
+        log = {};
+        l1.setVisibility(true);
+        t.eq(log.moveTo.zoomChanged, true,
+             "[d] redraw calls moveTo with zoomChanged true");
+
+        l1.moveTo = OpenLayers.Layer.prototype.moveTo;
+
+        var l2 = new OpenLayers.Layer('l2');
+        l2.moveTo = function(bounds, zoomChanged, dragging) {
+            log.moveTo = {zoomChanged: zoomChanged};
+            OpenLayers.Layer.prototype.moveTo.apply(this, arguments);
+        };
+        log = {};
+        map.addLayer(l2);
+        t.eq(log.moveTo.zoomChanged, true,
+             "[e] redraw calls moveTo with zoomChanged true");
+
+        map.removeLayer(l2);
+        log = {};
+        map.addLayer(l2);
+        t.eq(log.moveTo.zoomChanged, true,
+             "[f] redraw calls moveTo with zoomChanged true");
+
+        map.destroy();
     }
       
     function test_layer_setIsBaseLayer(t) {

--- a/tests/Tile/Image.html
+++ b/tests/Tile/Image.html
@@ -342,6 +342,38 @@
         t.ok(tile.imgDiv == null, "image reference removed from tile");
         map.destroy();
     }
+
+    // test for https://github.com/openlayers/openlayers/pull/36
+    // (more an integration test than a unit test)
+    function test_olImageLoadError(t) {
+        t.plan(2);
+
+        var map = new OpenLayers.Map('map');
+        var layer = new OpenLayers.Layer.WMS("invalid",  "", {layers: 'basic'});
+        map.addLayer(layer);
+
+        var size = new OpenLayers.Size(5, 6);
+        var position = new OpenLayers.Pixel(20, 30);
+        var bounds = new OpenLayers.Bounds(1, 2, 3, 4);
+
+        var tile = new OpenLayers.Tile.Image(layer, position, bounds, null, size);
+        tile.draw();
+
+        t.delay_call(0.1, function() {
+
+            // check initial state
+            t.ok(OpenLayers.Element.hasClass(tile.imgDiv, 'olImageLoadError'),
+                 'tile image has the olImageLoadError class (init state)');
+
+            layer.setVisibility(false);
+            layer.setVisibility(true);
+
+            t.ok(OpenLayers.Element.hasClass(tile.imgDiv, 'olImageLoadError'),
+                 'tile image still has the olImageLoadError class');
+
+            map.destroy();
+        });
+    }
     
   </script>
 </head>


### PR DESCRIPTION
This pull request supersedes #36, and fixes the issue reported there. It also addresses a 5-year old comment from @schuyler: http://trac.osgeo.org/openlayers/changeset/1448.

Tests pass in FireFox 8.0.1.
