### PR TITLE
Move symbolizer requires

### DIFF
--- a/lib/OpenLayers/Format/SLD/v1.js
+++ b/lib/OpenLayers/Format/SLD/v1.js
@@ -7,6 +7,11 @@
  * @requires OpenLayers/Rule.js
  * @requires OpenLayers/Format/SLD.js
  * @requires OpenLayers/Format/Filter/v1_0_0.js
+ * @requires OpenLayers/Symbolizer/Point.js
+ * @requires OpenLayers/Symbolizer/Line.js
+ * @requires OpenLayers/Symbolizer/Polygon.js
+ * @requires OpenLayers/Symbolizer/Text.js
+ * @requires OpenLayers/Symbolizer/Raster.js
  */
 
 /**

--- a/lib/OpenLayers/Rule.js
+++ b/lib/OpenLayers/Rule.js
@@ -8,11 +8,6 @@
  * @requires OpenLayers/BaseTypes/Class.js
  * @requires OpenLayers/Util.js
  * @requires OpenLayers/Style.js
- * @requires OpenLayers/Symbolizer/Point.js
- * @requires OpenLayers/Symbolizer/Line.js
- * @requires OpenLayers/Symbolizer/Polygon.js
- * @requires OpenLayers/Symbolizer/Text.js
- * @requires OpenLayers/Symbolizer/Raster.js
  */
 
 /**


### PR DESCRIPTION
ISTM the requires for the symbolizer classes are in the wrong place. I use rules with stylemaps, which afaics don't use the symbolizer classes, which are only used by the SLD classes (which instantiate them). By moving the requires statements to their proper place, unneeded classes will no longer be included in my builds.

No logic changes, only affects builds
