### PR TITLE
Add an interception point to allow image URLs to be rewritten

### DIFF
--- a/lib/OpenLayers/Control/LayerSwitcher.js
+++ b/lib/OpenLayers/Control/LayerSwitcher.js
@@ -550,10 +550,8 @@ OpenLayers.Control.LayerSwitcher =
             OpenLayers.Rico.Corner.changeOpacity(this.layersDiv, 0.75);
         }
 
-        var imgLocation = OpenLayers.Util.getImagesLocation();
-
         // maximize button div
-        var img = imgLocation + 'layer-switcher-maximize.png';
+        var img = OpenLayers.Util.getImageLocation('layer-switcher-maximize.png');
         this.maximizeDiv = OpenLayers.Util.createAlphaImageDiv(
                                     "OpenLayers_Control_MaximizeDiv", 
                                     null, 
@@ -569,7 +567,7 @@ OpenLayers.Control.LayerSwitcher =
         this.div.appendChild(this.maximizeDiv);
 
         // minimize button div
-        var img = imgLocation + 'layer-switcher-minimize.png';
+        var img = OpenLayers.Util.getImageLocation('layer-switcher-minimize.png');
         this.minimizeDiv = OpenLayers.Util.createAlphaImageDiv(
                                     "OpenLayers_Control_MinimizeDiv", 
                                     null, 

--- a/lib/OpenLayers/Control/OverviewMap.js
+++ b/lib/OpenLayers/Control/OverviewMap.js
@@ -238,9 +238,8 @@ OpenLayers.Control.OverviewMap = OpenLayers.Class(OpenLayers.Control, {
         // map viewport.
         if(!this.outsideViewport) {
             this.div.className += " " + this.displayClass + 'Container';
-            var imgLocation = OpenLayers.Util.getImagesLocation();
             // maximize button div
-            var img = imgLocation + 'layer-switcher-maximize.png';
+            var img = OpenLayers.Util.getImageLocation('layer-switcher-maximize.png');
             this.maximizeDiv = OpenLayers.Util.createAlphaImageDiv(
                                         this.displayClass + 'MaximizeButton', 
                                         null, 
@@ -256,7 +255,7 @@ OpenLayers.Control.OverviewMap = OpenLayers.Class(OpenLayers.Control, {
             this.div.appendChild(this.maximizeDiv);
     
             // minimize button div
-            var img = imgLocation + 'layer-switcher-minimize.png';
+            var img = OpenLayers.Util.getImageLocation('layer-switcher-minimize.png');
             this.minimizeDiv = OpenLayers.Util.createAlphaImageDiv(
                                         'OpenLayers_Control_minimizeDiv', 
                                         null, 

--- a/lib/OpenLayers/Control/PanZoom.js
+++ b/lib/OpenLayers/Control/PanZoom.js
@@ -119,7 +119,7 @@ OpenLayers.Control.PanZoom = OpenLayers.Class(OpenLayers.Control, {
      *     image of the button, and has all the proper event handlers set.
      */
     _addButton:function(id, img, xy, sz) {
-        var imgLocation = OpenLayers.Util.getImagesLocation() + img;
+        var imgLocation = OpenLayers.Util.getImageLocation(img);
         var btn = OpenLayers.Util.createAlphaImageDiv(
                                     this.id + "_" + id, 
                                     xy, sz, imgLocation, "absolute");

--- a/lib/OpenLayers/Control/PanZoomBar.js
+++ b/lib/OpenLayers/Control/PanZoomBar.js
@@ -193,14 +193,13 @@ OpenLayers.Control.PanZoomBar = OpenLayers.Class(OpenLayers.Control.PanZoom, {
     * location - {<OpenLayers.Pixel>} where zoombar drawing is to start.
     */
     _addZoomBar:function(centered) {
-        var imgLocation = OpenLayers.Util.getImagesLocation();
-        
+        var imgLocation = OpenLayers.Util.getImageLocation("slider.png");
         var id = this.id + "_" + this.map.id;
         var zoomsToEnd = this.map.getNumZoomLevels() - 1 - this.map.getZoom();
         var slider = OpenLayers.Util.createAlphaImageDiv(id,
                        centered.add(-1, zoomsToEnd * this.zoomStopHeight), 
                        new OpenLayers.Size(20,9), 
-                       imgLocation+"slider.png",
+                       imgLocation,
                        "absolute");
         slider.style.cursor = "move";
         this.slider = slider;
@@ -221,6 +220,7 @@ OpenLayers.Control.PanZoomBar = OpenLayers.Class(OpenLayers.Control.PanZoom, {
         var sz = new OpenLayers.Size();
         sz.h = this.zoomStopHeight * this.map.getNumZoomLevels();
         sz.w = this.zoomStopWidth;
+        var imgLocation = OpenLayers.Util.getImageLocation("zoombar.png");
         var div = null;
         
         if (OpenLayers.Util.alphaHack()) {
@@ -228,7 +228,7 @@ OpenLayers.Control.PanZoomBar = OpenLayers.Class(OpenLayers.Control.PanZoom, {
             div = OpenLayers.Util.createAlphaImageDiv(id, centered,
                                       new OpenLayers.Size(sz.w, 
                                               this.zoomStopHeight),
-                                      imgLocation + "zoombar.png", 
+                                      imgLocation,
                                       "absolute", null, "crop");
             div.style.height = sz.h + "px";
         } else {
@@ -236,7 +236,7 @@ OpenLayers.Control.PanZoomBar = OpenLayers.Class(OpenLayers.Control.PanZoom, {
                         'OpenLayers_Control_PanZoomBar_Zoombar' + this.map.id,
                         centered,
                         sz,
-                        imgLocation+"zoombar.png");
+                        imgLocation);
         }
         div.style.cursor = "pointer";
         this.zoombarDiv = div;

--- a/lib/OpenLayers/Format/Text.js
+++ b/lib/OpenLayers/Format/Text.js
@@ -53,8 +53,7 @@ OpenLayers.Format.Text = OpenLayers.Class(OpenLayers.Format, {
 
         if(options.extractStyles !== false) {
             options.defaultStyle = {
-                'externalGraphic': OpenLayers.Util.getImagesLocation() +
-                                                                "marker.png",
+                'externalGraphic': OpenLayers.Util.getImageLocation("marker.png"),
                 'graphicWidth': 21,
                 'graphicHeight': 25,
                 'graphicXOffset': -10.5,

--- a/lib/OpenLayers/Layer/EventPane.js
+++ b/lib/OpenLayers/Layer/EventPane.js
@@ -104,7 +104,7 @@ OpenLayers.Layer.EventPane = OpenLayers.Class(OpenLayers.Layer, {
         this.pane.style.height="100%";
         if (OpenLayers.BROWSER_NAME == "msie") {
             this.pane.style.background = 
-                "url(" + OpenLayers.Util.getImagesLocation() + "blank.gif)";
+                "url(" + OpenLayers.Util.getImageLocation("blank.gif") + ")";
         }
 
         if (this.isFixed) {

--- a/lib/OpenLayers/Layer/WorldWind.js
+++ b/lib/OpenLayers/Layer/WorldWind.js
@@ -96,7 +96,7 @@ OpenLayers.Layer.WorldWind = OpenLayers.Class(OpenLayers.Layer.Grid, {
                 Y: y
               });
         } else {
-            return OpenLayers.Util.getImagesLocation() + "blank.gif";
+            return OpenLayers.Util.getImageLocation("blank.gif");
         }
 
     },

--- a/lib/OpenLayers/Marker.js
+++ b/lib/OpenLayers/Marker.js
@@ -231,7 +231,7 @@ OpenLayers.Marker = OpenLayers.Class({
  * {<OpenLayers.Icon>} A default OpenLayers.Icon to use for a marker
  */
 OpenLayers.Marker.defaultIcon = function() {
-    var url = OpenLayers.Util.getImagesLocation() + "marker.png";
+    var url = OpenLayers.Util.getImageLocation("marker.png");
     var size = new OpenLayers.Size(21, 25);
     var calculateOffset = function(size) {
                     return new OpenLayers.Pixel(-(size.w/2), -size.h);

--- a/lib/OpenLayers/Popup/FramedCloud.js
+++ b/lib/OpenLayers/Popup/FramedCloud.js
@@ -218,7 +218,7 @@ OpenLayers.Popup.FramedCloud =
     initialize:function(id, lonlat, contentSize, contentHTML, anchor, closeBox, 
                         closeBoxCallback) {
 
-        this.imageSrc = OpenLayers.Util.getImagesLocation() + 'cloud-popup-relative.png';
+        this.imageSrc = OpenLayers.Util.getImageLocation('cloud-popup-relative.png');
         OpenLayers.Popup.Framed.prototype.initialize.apply(this, arguments);
         this.contentDiv.className = this.contentDisplayClass;
     },

--- a/lib/OpenLayers/Util.js
+++ b/lib/OpenLayers/Util.js
@@ -557,6 +557,16 @@ OpenLayers.Util.getImagesLocation = function() {
     return OpenLayers.ImgPath || (OpenLayers._getScriptLocation() + "img/");
 };
 
+/** 
+ * Function: getImageLocation
+ * 
+ * Returns:
+ * {String} The fully formatted location string for a specified image
+ */
+OpenLayers.Util.getImageLocation = function(image) {
+    return OpenLayers.Util.getImagesLocation() + image;
+};
+
 
 /** 
  * Function: Try

--- a/lib/deprecated.js
+++ b/lib/deprecated.js
@@ -1475,8 +1475,8 @@ OpenLayers.Control.MouseToolbar = OpenLayers.Class(
      * Method: _addButton
      */
     _addButton:function(id, img, activeImg, xy, sz, title) {
-        var imgLocation = OpenLayers.Util.getImagesLocation() + img;
-        var activeImgLocation = OpenLayers.Util.getImagesLocation() + activeImg;
+        var imgLocation = OpenLayers.Util.getImageLocation(img);
+        var activeImgLocation = OpenLayers.Util.getImageLocation(activeImg);
         // var btn = new ol.AlphaImage("_"+id, imgLocation, xy, sz);
         var btn = OpenLayers.Util.createAlphaImageDiv(
                                     "OpenLayers_Control_MouseToolbar_" + id, 


### PR DESCRIPTION
Make all attempts to get a URL for an image go through a single
routine, OpenLayers.Util.getImageLocation, which is given the actual
image name.

This allows users to replace that routine with an enhanced version
which can rewrite the full URL, for example to go through the rails
asset pipeline when using OpenLayers with rails.
