### PR TITLE
Bbox Strategy should allow for externalProjection

### DIFF
--- a/lib/OpenLayers/Strategy/BBOX.js
+++ b/lib/OpenLayers/Strategy/BBOX.js
@@ -241,9 +241,13 @@ OpenLayers.Strategy.BBOX = OpenLayers.Class(OpenLayers.Strategy, {
      * {<OpenLayers.Filter>} The filter object.
      */
     createFilter: function() {
+        var bounds = this.bounds.clone();
+        if (this.layer.protocol && this.layer.protocol.format && this.layer.protocol.format.externalProjection) {
+            bounds.transform(this.layer.projection, this.layer.protocol.format.externalProjection);
+        }
         var filter = new OpenLayers.Filter.Spatial({
             type: OpenLayers.Filter.Spatial.BBOX,
-            value: this.bounds,
+            value: bounds,
             projection: this.layer.projection
         });
         if (this.layer.filter) {

--- a/tests/Strategy/BBOX.html
+++ b/tests/Strategy/BBOX.html
@@ -206,6 +206,8 @@
 
         var s = new OpenLayers.Strategy.BBOX();
 
+        s.bounds = new OpenLayers.Bounds(0,0,2,2);
+
         var f;
 
         // 2 test


### PR DESCRIPTION
Strategy/BBOX is not currently allowing for the fact that the projection of the data source may differ from that of the layer. This commit checks for externalProjection on the protocol's format.

The checks that protocol/format exist are probably not necessary, but several tests fail if these checks are not in there. I added a dummy bounds in test_createFilter() to stop it complaining it didn't know what 'this.bounds' was.

There is not currently any test that the bounds are correctly set, so I've not added one to check that the externalProjection case works. However, it works on my own tests.
