### PR TITLE
Control/Split should work w/o MultiLineString

### DIFF
--- a/lib/OpenLayers/Control/Split.js
+++ b/lib/OpenLayers/Control/Split.js
@@ -312,16 +312,20 @@ OpenLayers.Control.Split = OpenLayers.Class(OpenLayers.Control, {
      * {Boolean} The target is eligible for splitting.
      */
     isEligible: function(target) {
-        return (
-            target.state !== OpenLayers.State.DELETE
-        ) && (
-            typeof target.geometry.split === "function"
-        ) && (
-            this.feature !== target
-        ) && (
-            !this.targetFilter ||
-            this.targetFilter.evaluate(target.attributes)
-        );
+        if (!target.geometry) {
+            return false;
+        } else {
+            return (
+                target.state !== OpenLayers.State.DELETE
+            ) && (
+                typeof target.geometry.split === "function"
+            ) && (
+                this.feature !== target
+            ) && (
+                !this.targetFilter ||
+                this.targetFilter.evaluate(target.attributes)
+            );
+        }
     },
 
     /**


### PR DESCRIPTION
Change so that control will work when Geometry/MultiLineString is not in the build.

Tests continue to pass
