### PR TITLE
ignore empty subject tags in CSWGetRecords parser

### DIFF
--- a/lib/OpenLayers/Format/CSWGetRecords/v2_0_2.js
+++ b/lib/OpenLayers/Format/CSWGetRecords/v2_0_2.js
@@ -262,7 +262,9 @@ OpenLayers.Format.CSWGetRecords.v2_0_2 = OpenLayers.Class(OpenLayers.Format.XML,
                     dc_element[attrs[i].name] = attrs[i].nodeValue;
                 }
                 dc_element.value = this.getChildValue(node);
-                obj[name].push(dc_element);
+                if (dc_element.value != "") {
+                    obj[name].push(dc_element);
+                }
             }
         },
         "dct": {

--- a/tests/Format/CSWGetRecords/v2_0_2.html
+++ b/tests/Format/CSWGetRecords/v2_0_2.html
@@ -41,7 +41,7 @@
     
     function test_read(t) {
         
-        t.plan(16);
+        t.plan(17);
         
         var obj = format.read(csw_response);
                 
@@ -64,6 +64,9 @@
         var testRecord = records[0];
         t.eq(testRecord.type, "BriefRecord", "check value for record.type");
         t.eq(testRecord.title, [{value:"Sample title"}], "check value for record.title");
+
+        // test empty subject
+        t.eq(testRecord.subject, [], "Empty subject tags are ignored");
 
         //test bbox
         t.eq(testRecord.BoundingBox.length, 2, "object contains 2 BoundingBoxes");

--- a/tests/Format/CSWGetRecords/v2_0_2.js
+++ b/tests/Format/CSWGetRecords/v2_0_2.js
@@ -21,6 +21,8 @@ var csw_response =
     '<csw:BriefRecord xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/">' +
       '<dc:identifier>895ac38b-7aef-4a21-b593-b35a6fc7bba9</dc:identifier>' +
       '<dc:title>Sample title</dc:title>' +
+      '<dc:subject />' +
+      '<dc:subject />' +
       '<ows:BoundingBox crs="::Lambert Azimuthal Projection">' +
         '<ows:LowerCorner>156 -3</ows:LowerCorner>' +
         '<ows:UpperCorner>37 83</ows:UpperCorner>' +


### PR DESCRIPTION
When having empty dc:subject tags in the response, the parser currently creates an Array with objects which have a value of an empty string, so [{value: ""}, {value: ""}]. When rendered in an Ext grid, this will yield "," in the cell. I think it's better to ignore empty tags in the OpenLayers Format already, and that's what this patch does. TIA for any review.
