### PR TITLE
make GetRecords request work against pyCSW

### DIFF
--- a/lib/OpenLayers/Format/CSWGetRecords/v2_0_2.js
+++ b/lib/OpenLayers/Format/CSWGetRecords/v2_0_2.js
@@ -30,6 +30,7 @@ OpenLayers.Format.CSWGetRecords.v2_0_2 = OpenLayers.Class(OpenLayers.Format.XML,
         csw: "http://www.opengis.net/cat/csw/2.0.2",
         dc: "http://purl.org/dc/elements/1.1/",
         dct: "http://purl.org/dc/terms/",
+        gmd: "http://www.isotc211.org/2005/gmd",
         geonet: "http://www.fao.org/geonetwork",
         ogc: "http://www.opengis.net/ogc",
         ows: "http://www.opengis.net/ows",
@@ -309,6 +310,7 @@ OpenLayers.Format.CSWGetRecords.v2_0_2 = OpenLayers.Class(OpenLayers.Format.XML,
      */
     write: function(options) {
         var node = this.writeNode("csw:GetRecords", options);
+        node.setAttribute("xmlns:gmd", this.namespaces.gmd);
         return OpenLayers.Format.XML.prototype.write.apply(this, [node]);
     },
 


### PR DESCRIPTION
When using "typeNames": "gmd:MD_Metadata" in the config, pyCSW will complain the the gmd prefix is not bound. The only way to get around this in OpenLayers is currently to set the xmlns:gmd attribute in the write function, just like is done in SOSGetObservation.

```
<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" service="CSW" version="2.0.2" resultType="results" maxRecords="100">
<csw:Query typeNames="gmd:MD_Metadata">
<csw:ElementSetName>full</csw:ElementSetName>
<csw:Constraint version="1.1.0">
<csw:CqlText>AnyText LIKE '**'</csw:CqlText>
</csw:Constraint>
</csw:Query>
</csw:GetRecords>
```

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!-- pycsw 1.1-dev -->
<ows:ExceptionReport xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0" xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:apiso="http://www.opengis.net/cat/csw/apiso/1.0" xmlns:gml="http://www.opengis.net/gml" xmlns:dif="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:ogc="http://www.opengis.net/ogc" xmlns:fgdc="http://www.opengis.net/cat/csw/csdgm" xmlns:inspire_ds="http://inspire.ec.europa.eu/schemas/inspire_ds/1.0" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:wrs="http://www.opengis.net/cat/wrs/1.0" version="1.2.0" language="en-US" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.0.0/owsExceptionReport.xsd">
  <ows:Exception locator="service" exceptionCode="InvalidRequest">
    <ows:ExceptionText>Exception: the document is not valid.
Error: Element '{http://www.opengis.net/cat/csw/2.0.2}Query', attribute 'typeNames': The QName value 'gmd:MD_Metadata' has no corresponding namespace declaration in scope..</ows:ExceptionText>
  </ows:Exception>
</ows:ExceptionReport>
```
