### PR TITLE
unselectFeature should be API

### DIFF
--- a/lib/OpenLayers/Control/ModifyFeature.js
+++ b/lib/OpenLayers/Control/ModifyFeature.js
@@ -376,7 +376,7 @@ OpenLayers.Control.ModifyFeature = OpenLayers.Class(OpenLayers.Control, {
     },
 
     /**
-     * Method: unselectFeature
+     * APIMethod: unselectFeature
      * Called when the select feature control unselects a feature.
      *
      * Parameters:


### PR DESCRIPTION
When using the modifyFeature control in standalone mode, it is proposed to call 'unselectFeature' to finish feature modification. However, the method is not exposed as API. 'selectFeature is. Let's get consistent.
