### PR TITLE
Create the layer's metadata object in the initialize function

### DIFF
--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -329,7 +329,7 @@ OpenLayers.Layer = OpenLayers.Class({
      * {Object} This object can be used to store additional information on a
      *     layer object.
      */
-    metadata: {},
+    metadata: null,
     
     /**
      * Constructor: OpenLayers.Layer
@@ -340,6 +340,8 @@ OpenLayers.Layer = OpenLayers.Class({
      */
     initialize: function(name, options) {
 
+        this.metadata = {};
+        
         this.addOptions(options);
 
         this.name = name;


### PR DESCRIPTION
Create the layer's metadata object in the initialize function, otherwise any assignment to an instance of an OpenLayers.Layer class or subclass add/modifies those properties on the OpenLayers.Layer prototype
