### PR TITLE
Fix Layer.Bing tests, they were broken after removing metadata from the Layer prototype

### DIFF
--- a/lib/OpenLayers/Layer/Bing.js
+++ b/lib/OpenLayers/Layer/Bing.js
@@ -193,7 +193,7 @@ OpenLayers.Layer.Bing = OpenLayers.Class(OpenLayers.Layer.XYZ, {
      */
     updateAttribution: function() {
         var metadata = this.metadata;
-        if (!metadata || !this.map || !this.map.center) {
+        if (!metadata.resourceSets || !this.map || !this.map.center) {
             return;
         }
         var res = metadata.resourceSets[0].resources[0];


### PR DESCRIPTION
eda8eb8dbe2d83f6e6a66b14b39d23d876f94769 broke them
