### PR TITLE
Initialize variables in the code to keep the prototype clean.

### DIFF
--- a/lib/OpenLayers/Layer/Zoomify.js
+++ b/lib/OpenLayers/Layer/Zoomify.js
@@ -63,21 +63,21 @@ OpenLayers.Layer.Zoomify = OpenLayers.Class(OpenLayers.Layer.Grid, {
      * {Array(Integer)} Number of tiles up to the given tier of pyramid.
      *                          - filled during Zoomify pyramid initialization.
      */
-    tileCountUpToTier: new Array(),
+    tileCountUpToTier: null,
 
     /**
      * Property: tierSizeInTiles
      * {Array(<OpenLayers.Size>)} Size (in tiles) for each tier of pyramid.
      *                          - filled during Zoomify pyramid initialization.
      */
-    tierSizeInTiles: new Array(),
+    tierSizeInTiles: null,
 
     /**
      * Property: tierImageSize
      * {Array(<OpenLayers.Size>)} Image size in pixels for each pyramid tier.
      *                          - filled during Zoomify pyramid initialization.
      */
-    tierImageSize: new Array(),
+    tierImageSize: null,
 
     /**
      * Constructor: OpenLayers.Layer.Zoomify
@@ -117,8 +117,8 @@ OpenLayers.Layer.Zoomify = OpenLayers.Class(OpenLayers.Layer.Grid, {
             Math.ceil( imageSize.h / this.standardTileSize )
             );
 
-        this.tierSizeInTiles.push( tiles );
-        this.tierImageSize.push( imageSize );
+        this.tierSizeInTiles = [tiles];
+        this.tierImageSize = [imageSize];
 
         while (imageSize.w > this.standardTileSize ||
                imageSize.h > this.standardTileSize ) {
@@ -140,7 +140,7 @@ OpenLayers.Layer.Zoomify = OpenLayers.Class(OpenLayers.Layer.Grid, {
 
         this.numberOfTiers = this.tierSizeInTiles.length;
 
-        this.tileCountUpToTier[0] = 0;
+        this.tileCountUpToTier = [0];
         for (var i = 1; i < this.numberOfTiers; i++) {
             this.tileCountUpToTier.push(
                 this.tierSizeInTiles[i-1].w * this.tierSizeInTiles[i-1].h +


### PR DESCRIPTION
See #157, `tileCountUpToTier`, `tierSizeInTiles` and `tierImageSize` are initialized at the prototype level: all the instances are sharing the same arrays.
