### PR TITLE
Remove Rico from OpenLayers.js

### DIFF
--- a/lib/OpenLayers.js
+++ b/lib/OpenLayers.js
@@ -108,8 +108,6 @@
                 "OpenLayers/Console.js",
                 "OpenLayers/Tween.js",
                 "OpenLayers/Kinetic.js",
-                "Rico/Corner.js",
-                "Rico/Color.js",
                 "OpenLayers/Events.js",
                 "OpenLayers/Request.js",
                 "OpenLayers/Request/XMLHttpRequest.js",


### PR DESCRIPTION
A minor point, but I assume these are still in there by mistake. The other deprecated classes seem to have already been removed.
