### PR TITLE
Use map's getter methods to set map defaults on layer.

### DIFF
--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -623,18 +623,20 @@ OpenLayers.Layer = OpenLayers.Class({
             
             // grab some essential layer data from the map if it hasn't already
             //  been set
-            this.maxExtent = this.maxExtent || this.map.maxExtent;
+            this.maxExtent = this.maxExtent || this.map.getMaxExtent() ||
+                this.map.maxExtent;
             this.minExtent = this.minExtent || this.map.minExtent;
 
-            this.projection = this.projection || this.map.projection;
+            this.projection = this.projection || this.map.getProjection() ||
+                this.map.projection;
             if (typeof this.projection == "string") {
                 this.projection = new OpenLayers.Projection(this.projection);
             }
 
             // Check the projection to see if we can get units -- if not, refer
             // to properties.
-            this.units = this.projection.getUnits() ||
-                         this.units || this.map.units;
+            this.units = this.projection.getUnits() || this.units ||
+                this.map.getUnits() || this.map.units;
             
             this.initResolutions();
             

--- a/tests/Control/WMSGetFeatureInfo.html
+++ b/tests/Control/WMSGetFeatureInfo.html
@@ -529,14 +529,15 @@
         
         var map = new OpenLayers.Map("map", {
             getExtent: function() {return(new OpenLayers.Bounds(-180,-90,180,90));},
-            projection: "EPSG:900913"
+            projection: "EPSG:900913",
+            allOverlays: true
         });
         var a = new OpenLayers.Layer.WMS("dummy", "http://localhost/wms", {
             layers: "a"
-        }, {projection: "EPSG:3857"});
+        });
         var b = new OpenLayers.Layer.WMS("dummy", "http://localhost/wms", {
             layers: "b"
-        });
+        }, {projection: "EPSG:3857"});
         var c = new OpenLayers.Layer.WMS("dummy", "http://localhost/wms", {
             layers: "c"
         }, {projection: "EPSG:4326"});
@@ -546,12 +547,12 @@
         gfi.activate();
 
         var options = gfi.buildWMSOptions("http://localhost/wms", [a], {xy: {x: 50, y: 50}}, "text/html");
-        t.eq(options.params.SRS, "EPSG:3857", "layer projection used if provided and equal map projection");
-
-        options = gfi.buildWMSOptions("http://localhost/wms", [b], {xy: {x: 50, y: 50}}, "text/html");
         t.eq(options.params.SRS, "EPSG:900913", "map projection used if layer has no projection configured");
 
         options = gfi.buildWMSOptions("http://localhost/wms", [b], {xy: {x: 50, y: 50}}, "text/html");
+        t.eq(options.params.SRS, "EPSG:3857", "layer projection used if provided and equal map projection");
+
+        options = gfi.buildWMSOptions("http://localhost/wms", [c], {xy: {x: 50, y: 50}}, "text/html");
         t.eq(options.params.SRS, "EPSG:900913", "map projection used if layer configured with an incompatible projection");
     }
 

--- a/tests/Layer.html
+++ b/tests/Layer.html
@@ -76,8 +76,26 @@
         layer = new OpenLayers.Layer('Test Layer');
         layer.setName("chicken");
         
-        t.eq(layer.name, "chicken", "setName() works")
+        t.eq(layer.name, "chicken", "setName() works");
         
+    }
+    
+    function test_Layer_setMap(t) {
+        t.plan(3);
+        var map = new OpenLayers.Map({
+            layers: [new OpenLayers.Layer("base", {
+                maxExtent: [-1,-1,1,1],
+                projection: "EPSG:3857",
+                units: "m",
+                isBaseLayer: true
+            })],
+            center: [0,0]
+        });
+        var layer = new OpenLayers.Layer("overlay");
+        map.addLayer(layer);
+        t.eq(layer.maxExtent.toString(), map.getMaxExtent().toString(), "maxExtent defaults to map's maxExtent");
+        t.eq(layer.projection.getCode(), map.getProjectionObject().getCode(), "projection defaults to map's projection");
+        t.eq(layer.units, map.getUnits(), "units defaults to map's units");
     }
 
     function test_Layer_addOptions (t) {


### PR DESCRIPTION
Layer.setMap takes maxExtent, resolution and units from the map if the layer doesn't provide its own. This causes strange results when the correct properties are set on the baseLayer, but not on the map. This change fixes that by using the map's getter methods instead of accessing the map properties directly. (Note: the map properties are still used as fallback after using the getters, to keep satisfying tests with mocked map objects).
