### PR TITLE
Build: Allow import directories.

### DIFF
--- a/tools/mergejs.py
+++ b/tools/mergejs.py
@@ -175,12 +175,12 @@ def run (sourceDirectory, outputFilename = None, configFile = None,
     files = {}
 
     ## Import file source code
-    cfg.forceFirst = importFiles("[first]", cfg.forceFirst, cfg, files) 
-    cfg.forceLast = importFiles("[last]", cfg.forceLast, cfg, files) 
+    cfg.forceFirst = importFiles("[first]", cfg.forceFirst, False, cfg, files) 
+    cfg.forceLast = importFiles("[last]", cfg.forceLast, False, cfg, files) 
     if len(cfg.include) == 0:
-        importFiles("[include]", ["."], cfg, files)
+        importFiles("[include]", ["."], True, cfg, files)
     else:
-        importFiles("[include]", cfg.include, cfg, files) 
+        importFiles("[include]", cfg.include, True, cfg, files) 
 
     print "\nImport required files:"
     complete = False
@@ -195,7 +195,7 @@ def run (sourceDirectory, outputFilename = None, configFile = None,
                 if not files.has_key(path):
                     complete = False
                     try:
-                        importFile("", path, cfg, files)
+                        importFile("", path, True, cfg, files)
                     except MissingImport:
                         raise MissingImport("File '%s' not found (required by '%s')." % (path, filepath))
         
@@ -249,17 +249,17 @@ def run (sourceDirectory, outputFilename = None, configFile = None,
         open(outputFilename, "w").write("".join(result))
     return "".join(result)
 
-def importFiles(sectionName, inputFiles, cfg, files): 
+def importFiles(sectionName, inputFiles, excludeFiles, cfg, files): 
     print "\nImport \"%s\" files:" % sectionName
     outputFiles = [] 
     for filepath in inputFiles: 
         if filepath.endswith(SUFFIX_JAVASCRIPT):
-            outputFiles += importFile(sectionName, filepath, cfg, files)
+            outputFiles += importFile(sectionName, filepath, excludeFiles, cfg, files)
         else:
-            outputFiles += importDirectory(sectionName, filepath, cfg, files)
+            outputFiles += importDirectory(sectionName, filepath, excludeFiles, cfg, files)
     return outputFiles
     
-def importDirectory(sectionName, directoryName, cfg, files):
+def importDirectory(sectionName, directoryName, excludeFiles, cfg, files):
     # Normalize directory name
     directoryName = directoryName.replace("\\", "/")
     if directoryName.startswith("./"):
@@ -278,14 +278,14 @@ def importDirectory(sectionName, directoryName, cfg, files):
         for filename in directoryFiles:
             if filename.endswith(SUFFIX_JAVASCRIPT) and not filename.startswith("."):
                 filepath = os.path.join(root, filename)[len(cfg.sourceDirectory)+1:]
-                outputFiles += importFile(sectionName, filepath, cfg, files)
+                outputFiles += importFile(sectionName, filepath, excludeFiles, cfg, files)
     print "End of directory"
     return outputFiles
 
-def importFile(sectionName, filepath, cfg, files):
+def importFile(sectionName, filepath, excludeFiles, cfg, files):
     # Normalize file name
     filepath = filepath.replace("\\", "/")
-    if filepath in files or undesired(filepath, cfg.exclude):
+    if excludeFiles and (filepath in files or undesired(filepath, cfg.exclude)):
         return []
     else:
         fullpath = os.path.join(cfg.sourceDirectory, filepath).strip().replace("\\","/")


### PR DESCRIPTION
After 8047afd909c45b199665412518d08bc9487b93f4 can be used a directory name in `[exclude]` section in a configuration file.

This Pull Request proposes to extend the use of directory names to all other sections.
## Implementation:

Has been developed the method `importFiles` to import files from any section. This method imports the files if they have not previously been imported and are not excluded. If a directory name found walking through the directory and imports its files (when the `[include]` section is empty is equivalent to `./`)

The new code uses the `cfg` object on many points, so to avoid checks as `if cfg:`, always creates a `cfg` object still not reporting configuration file.

Care has been taken to the execution log is clearer separating the phases using a blank line.
## Some changes in behavior:
- If a file is reported in the `[last]` section not it's necessary to ensure that previously reported on `[first]` or `[include]`
- Allows importing files outside the library, eg using `../my_directory/my_source.js`
- It is not possible to repeat a file (now is possible if reported in `[first]` and `[last]` simultaneously)
