### PR TITLE
A popup can be destroyed before obtaining the images of `contentDiv`.

### DIFF
--- a/lib/OpenLayers/Popup.js
+++ b/lib/OpenLayers/Popup.js
@@ -685,7 +685,9 @@ OpenLayers.Popup = OpenLayers.Class({
         // 'img' properties in the context.
         //
         var onImgLoad = function() {
-            
+            if (this.popup.id === null) { // this.popup has been destroyed!
+                return;
+            }
             this.popup.updateSize();
      
             if ( this.popup.visible() && this.popup.panMapIfOutOfView ) {


### PR DESCRIPTION
currently it produces an error in `Popup.js` with call stack:

 `getSafeContentSize:747 <- updateSize:526 <- updateSize:689`

It is easy to happen if popups with images are displayed using:

 `Control.SelectFeature (..., {hover: true, highlightOnly: true})`
