### PR TITLE
Tile.Image: reset the img.src on clear.

### DIFF
--- a/lib/OpenLayers/Tile/Image.js
+++ b/lib/OpenLayers/Tile/Image.js
@@ -314,7 +314,9 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile, {
         var img = this.imgDiv;
         img.style.visibility = 'hidden';
         img.style.opacity = 0;
-        img.src = url ? url : this.blankImageUrl;
+        if (url) {
+            img.src = url;
+        }
     },
     
     /**
@@ -400,6 +402,7 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile, {
                 this.setImgSrc(this.layer.getURL(this.bounds));
             } else {
                 OpenLayers.Element.addClass(img, "olImageLoadError");
+                img.src = this.blankImageUrl;
                 this.onImageLoad();
             }
         }


### PR DESCRIPTION
I'm using a layer where most of the tiles are empty (no data to display). In this case, instead of returning a transparent png file, the server return an HTTP 204 response. The `olImageLoadError` css class is set to completely hide the element.

Now I have an issue in the following situation:
- A new `Tile.Image` is created, `tile.url` and `img.src` are set and the server returns a 204 response. `onImageError()` is called and adds the `olImageLoadError` class. Works as expected.
- The map is zoomed in and out.
- At this time: `tile.draw()`, `tile.clear()` are called, `tile.url` is set and finally `tile.initImage()` is called. But because `tile.url == img.src`, `onImageError()` is not called and `olImageLoadError` is not set.

This issue can be reproduced in [map.geo.admin.ch](http://map.geo.admin.ch/?selectedNode=node_ch.swisstopo.fixpunkte-agnes1&Y=660000&X=190000&zoom=1&bgLayer=voidLayer&layers=ch.swisstopo.fixpunkte-agnes&layers_opacity=1&layers_visibility=true&lang=fr): using the pan-zoom bar: zoom in, zoom out, zoom out and zoom in: failing tiles are displayed.

Possible solution: `img.src` must be reseted in `tile.clear()` 
