### PR TITLE
Remove OpenLayers.Protocol.CSW.v2_0_2.createCallback

### DIFF
--- a/lib/OpenLayers/Protocol/CSW/v2_0_2.js
+++ b/lib/OpenLayers/Protocol/CSW/v2_0_2.js
@@ -53,23 +53,6 @@ OpenLayers.Protocol.CSW.v2_0_2 = OpenLayers.Class(OpenLayers.Protocol, {
     },
 
     /**
-     * Method: createCallback
-     * Returns a function that applies the given public method with resp and
-     *     options arguments.
-     *
-     * Parameters:
-     * method - {Function} The method to be applied by the callback.
-     * response - {<OpenLayers.Protocol.Response>} The protocol response object.
-     * options - {Object} Options sent to the protocol method (read, create,
-     *     update, or delete).
-     */
-    createCallback: function(method, response, options) {
-        return OpenLayers.Function.bind(function() {
-            method.apply(this, [response, options]);
-        }, this);
-    },
-
-    /**
      * Method: read
      * Construct a request for reading new records from the Catalogue.
      */


### PR DESCRIPTION
Same function already defined in `OpenLayers.Protocol`.
Tests continue to pass
