### PR TITLE
ReadWithPOST should pass through options.headers

### DIFF
--- a/lib/OpenLayers/Protocol/HTTP.js
+++ b/lib/OpenLayers/Protocol/HTTP.js
@@ -166,7 +166,7 @@ OpenLayers.Protocol.HTTP = OpenLayers.Class(OpenLayers.Protocol, {
      * {<OpenLayers.Protocol.Response>} A response object, whose "priv" property
      *     references the HTTP request, this object is also passed to the
      *     callback function when the request completes, its "features" property
-     *     is then populated with the the features received from the server.
+     *     is then populated with the features received from the server.
      */
     read: function(options) {
         OpenLayers.Protocol.prototype.read.apply(this, arguments);
@@ -183,13 +183,13 @@ OpenLayers.Protocol.HTTP = OpenLayers.Class(OpenLayers.Protocol, {
                            options.readWithPOST : this.readWithPOST;
         var resp = new OpenLayers.Protocol.Response({requestType: "read"});
         if(readWithPOST) {
+            var headers = options.headers || {};
+            headers["Content-Type"] = "application/x-www-form-urlencoded";
             resp.priv = OpenLayers.Request.POST({
                 url: options.url,
                 callback: this.createCallback(this.handleRead, resp, options),
                 data: OpenLayers.Util.getParameterString(options.params),
-                headers: {
-                    "Content-Type": "application/x-www-form-urlencoded"
-                }
+                headers: headers
             });
         } else {
             resp.priv = OpenLayers.Request.GET({


### PR DESCRIPTION
At the moment, it is ignoring headers set in the options.
Tests continue to pass after this change.
While I'm at it, fix a minor typo in the docs
