### PR TITLE
HTTP protocol: enable POST for update/delete

### DIFF
--- a/lib/OpenLayers/Protocol/HTTP.js
+++ b/lib/OpenLayers/Protocol/HTTP.js
@@ -62,11 +62,26 @@ OpenLayers.Protocol.HTTP = OpenLayers.Class(OpenLayers.Protocol, {
     scope: null,
 
     /**
-     * Property: readWithPOST
+     * APIProperty: readWithPOST
      * {Boolean} true if read operations are done with POST requests
      *     instead of GET, defaults to false.
      */
     readWithPOST: false,
+
+    /**
+     * APIProperty: updateWithPOST
+     * {Boolean} true if update operations are done with POST requests
+     *     defaults to false.
+     */
+    updateWithPOST: false,
+    
+    /**
+     * APIProperty: deleteWithPOST
+     * {Boolean} true if delete operations are done with POST requests
+     *     defaults to false.
+     *     if true, POST data is set to output of format.write().
+     */
+    deleteWithPOST: false,
 
     /**
      * Property: wildcarded.
@@ -293,7 +308,8 @@ OpenLayers.Protocol.HTTP = OpenLayers.Class(OpenLayers.Protocol, {
             requestType: "update"
         });
 
-        resp.priv = OpenLayers.Request.PUT({
+        var method = this.updateWithPOST ? "POST" : "PUT";
+        resp.priv = OpenLayers.Request[method]({
             url: url,
             callback: this.createCallback(this.handleUpdate, resp, options),
             headers: options.headers,
@@ -344,11 +360,16 @@ OpenLayers.Protocol.HTTP = OpenLayers.Class(OpenLayers.Protocol, {
             requestType: "delete"
         });
 
-        resp.priv = OpenLayers.Request.DELETE({
+        var method = this.deleteWithPOST ? "POST" : "DELETE";
+        var requestOptions = {
             url: url,
             callback: this.createCallback(this.handleDelete, resp, options),
             headers: options.headers
-        });
+        };
+        if (this.deleteWithPOST) {
+            requestOptions.data = this.format.write(feature);
+        }
+        resp.priv = OpenLayers.Request[method](requestOptions);
 
         return resp;
     },


### PR DESCRIPTION
Not all servers use PUT/DELETE. Fusion Tables, for one, uses POST for all transactions.
It's comparatively simple to add this ability by adding new properties updateWithPost and deleteWithPost similar to readWithPOST, and changing update() and delete() to use them. With Fusion Tables, the data with the delete POST is the SQL delete statement.

These new properties should both be APIPropertys and, as it seems to me that readWithPost should also be an APIProperty which developers can set in the options, I've changed this too.

All tests continue to pass after this change.
