### PR TITLE
create APIMethod for obtaining the view port

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -612,6 +612,17 @@ OpenLayers.Map = OpenLayers.Class({
             }
         }
     },
+
+    /** 
+     * APIMethod: getViewport
+     * Get the DOMElement representing the view port.
+     *
+     * Returns:
+     * {DOMElement}
+     */
+    getViewport: function() {
+        return this.viewPortDiv;
+    },
     
     /**
      * APIMethod: render


### PR DESCRIPTION
This is needed by GeoExt to append the map panel items there so that they don't interfere with the zoombox for example

This has been discussed with ahocevar, but it would be good to get someone else's opinion (e.g. @elemoine)

TIA.

See also https://github.com/geoext/geoext/pull/24
