### PR TITLE
Template for the Attribution control

### DIFF
--- a/lib/OpenLayers/Control/Attribution.js
+++ b/lib/OpenLayers/Control/Attribution.js
@@ -25,6 +25,14 @@ OpenLayers.Control.Attribution =
     separator: ", ",
     
     /**
+     * APIProperty: template
+     * {String} Template for the attribution. This has to include the substring
+     *     "${layers}", which will be replaced by the layer specific
+     *     attributions, separated by <separator>. The default is "${layers}".
+     */
+    template: "${layers}",
+    
+    /**
      * Constructor: OpenLayers.Control.Attribution 
      * 
      * Parameters:
@@ -86,7 +94,9 @@ OpenLayers.Control.Attribution =
                     }
                 }
             } 
-            this.div.innerHTML = attributions.join(this.separator);
+            this.div.innerHTML = OpenLayers.String.format(this.template, {
+                layers: attributions.join(this.separator)
+            });
         }
     },
 

--- a/tests/Control/Attribution.html
+++ b/tests/Control/Attribution.html
@@ -30,8 +30,9 @@
         map.addLayer(new OpenLayers.Layer("name", {'attribution':'My layer 2!'}));
         t.eq(control.div.innerHTML, 'My layer!, My layer 2!', "Attribution correct with two layers.");
         control.separator = '|';
+        control.template = "Map Copyright (c) 2012 by Foo Bar; ${layers}";
         map.addLayer(new OpenLayers.Layer("name",{'attribution':'My layer 3!'}));
-        t.eq(control.div.innerHTML, 'My layer!|My layer 2!|My layer 3!', "Attribution correct with three layers and diff seperator.");
+        t.eq(control.div.innerHTML, 'Map Copyright (c) 2012 by Foo Bar; My layer!|My layer 2!|My layer 3!', "Attribution correct with three layers and diff seperator.");
 
 
     }    


### PR DESCRIPTION
This allows to add map specific copyright, or copyright required for tools like geocoders that are used in the context of the map.
