### PR TITLE
set GMaps API version to 3.6 in allOverlays Layer Example

### DIFF
--- a/examples/google-v3-alloverlays.html
+++ b/examples/google-v3-alloverlays.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" href="../theme/default/style.css" type="text/css">
         <link rel="stylesheet" href="../theme/default/google.css" type="text/css">
         <link rel="stylesheet" href="style.css" type="text/css">
-        <script src="http://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="http://maps.google.com/maps/api/js?v=3.6&amp;sensor=false"></script>
         <script src="../lib/OpenLayers.js"></script>
         <script src="google-v3-alloverlays.js"></script>
     </head>


### PR DESCRIPTION
3.6 - highest supported API version
http://trac.osgeo.org/openlayers/ticket/2984 describes why people shouldn't use versions > 3.6
