### PR TITLE
Making the delay for removing the backbuffer configurable.

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -173,7 +173,15 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
      *     flash effects caused by tile animation.
      */
     backBufferTimerId: null,
-    
+
+    /**
+     * APIProperty: removeBackBufferDelay
+     * {Number} Delay for removing the backbuffer when all tiles have finished
+     *     loading. Can be set to 0 when no css opacity transitions for the
+     *     olTileImage class are used. Default is 2500.
+     */
+    removeBackBufferDelay: 2500,
+
     /**
      * Register a listener for a particular event with the following syntax:
      * (code)
@@ -972,7 +980,7 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
                     // effects due to the animation of tile displaying
                     this.backBufferTimerId = window.setTimeout(
                         OpenLayers.Function.bind(this.removeBackBuffer, this),
-                        2500
+                        this.removeBackBufferDelay
                     );
                 }
             }


### PR DESCRIPTION
This helps users who want to avoid having old and new tiles on the screen for transparent single tile layers.
