### PR TITLE
GPX read should allow for blank attribute nodes

### DIFF
--- a/lib/OpenLayers/Format/GPX.js
+++ b/lib/OpenLayers/Format/GPX.js
@@ -197,7 +197,7 @@ OpenLayers.Format.GPX = OpenLayers.Class(OpenLayers.Format.XML, {
         var attributes = {};
         var attrNode = node.firstChild, value, name;
         while(attrNode) {
-            if(attrNode.nodeType == 1) {
+            if(attrNode.nodeType == 1 && attrNode.firstChild) {
                 value = attrNode.firstChild;
                 if(value.nodeType == 3 || value.nodeType == 4) {
                     name = (attrNode.prefix) ?


### PR DESCRIPTION
Just been loading some test files, and of course the first one I tried had <pre>&lt;desc>&lt;/desc></pre>. This fix allows for this sort of thing by ignoring such attributes.

Tests continue to pass
