### PR TITLE
Error in Layer.Zoomify when width or height is evenly divisible by 256

### DIFF
--- a/lib/OpenLayers/Layer/Zoomify.js
+++ b/lib/OpenLayers/Layer/Zoomify.js
@@ -231,10 +231,10 @@ OpenLayers.Layer.Zoomify = OpenLayers.Class(OpenLayers.Layer.Grid, {
             var w = this.standardTileSize;
             var h = this.standardTileSize;
             if (x == this.tierSizeInTiles[z].w - 1) {
-                w = this.tierImageSize[z].w % this.standardTileSize;
+                w = (this.tierImageSize[z].w % this.standardTileSize) || this.standardTileSize;
             };
             if (y == this.tierSizeInTiles[z].h - 1) {
-                h = this.tierImageSize[z].h % this.standardTileSize;
+                h = (this.tierImageSize[z].h % this.standardTileSize) || this.standardTileSize;
             };
             return new OpenLayers.Size(w, h);
         } else {


### PR DESCRIPTION
See http://trac.osgeo.org/openlayers/ticket/2964
