### PR TITLE
Added support for named graphics for the canvas renderer

### DIFF
--- a/lib/OpenLayers/Renderer/Canvas.js
+++ b/lib/OpenLayers/Renderer/Canvas.js
@@ -799,7 +799,7 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
                     if (id) {
                         featureId = "OpenLayers.Feature.Vector_" + (id - 1 + this.hitOverflow);
                         try {
-                            feature = this.features["OpenLayers.Feature.Vector_" + (id - 1 + this.hitOverflow)][0];
+                            feature = this.features[featureId][0];
                         } catch(err) {
                             // Because of antialiasing on the canvas, when the hit location is at a point where the edge of
                             // one symbol intersects the interior of another symbol, a wrong hit color (and therefore id) results.


### PR DESCRIPTION
It's now possible to use named graphics for point symbols within layers using the canvas renderer. To see this: use examples/graphic-name.html?renderer=Canvas . This should now look and behave the same way as ?renderer=SVG .
