### PR TITLE
Removing imageOffset and using getImageSize

### DIFF
--- a/examples/gutter.html
+++ b/examples/gutter.html
@@ -45,7 +45,7 @@
           "http://demo.opengeo.org/geoserver/wms",
           {layers: 'topp:states'},
           {gutter: 15});
-      var states = new OpenLayers.Layer.WMS( "Roads (no gutter)",
+      var states = new OpenLayers.Layer.WMS( "States (no gutter)",
           "http://demo.opengeo.org/geoserver/wms",
           {layers: 'topp:states'});
       map.addLayers([states, states15]);

--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -159,13 +159,6 @@ OpenLayers.Layer = OpenLayers.Class({
      */
     imageSize: null,
     
-    /**
-     * Property: imageOffset
-     * {<OpenLayers.Pixel>} For layers with a gutter, the image offset 
-     *     represents displacement due to the gutter.
-     */
-    imageOffset: null,
-
   // OPTIONS
 
     /** 
@@ -693,7 +686,7 @@ OpenLayers.Layer = OpenLayers.Class({
     /**
      * APIMethod: setTileSize
      * Set the tile size based on the map size.  This also sets layer.imageSize
-     *     and layer.imageOffset for use by Tile.Image.
+     *     or use by Tile.Image.
      * 
      * Parameters:
      * size - {<OpenLayers.Size>}
@@ -710,8 +703,6 @@ OpenLayers.Layer = OpenLayers.Class({
           //                              this.name + ": layers with " +
           //                              "gutters need non-null tile sizes");
           //}
-            this.imageOffset = new OpenLayers.Pixel(-this.gutter, 
-                                                    -this.gutter); 
             this.imageSize = new OpenLayers.Size(tileSize.w + (2*this.gutter), 
                                                  tileSize.h + (2*this.gutter)); 
         }

--- a/lib/OpenLayers/Tile/Image.js
+++ b/lib/OpenLayers/Tile/Image.js
@@ -208,11 +208,12 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile, {
      * code.
      */
     positionTile: function() {
-        var style = this.getTile().style;
+        var style = this.getTile().style,
+            size = this.layer.getImageSize(this.bounds);
         style.left = this.position.x + "%";
         style.top = this.position.y + "%";
-        style.width = this.size.w + "%";
-        style.height = this.size.h + "%";
+        style.width = size.w + "%";
+        style.height = size.h + "%";
     },
 
     /** 
@@ -256,11 +257,6 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile, {
                 var top = this.layer.gutter / this.layer.tileSize.h * 100;
                 style.left = -left + "%";
                 style.top = -top + "%";
-                style.width = (2 * left + 100) + "%";
-                style.height = (2 * top + 100) + "%";
-            } else {
-                style.width = "100%";
-                style.height = "100%";
             }
             style.visibility = "hidden";
             style.opacity = 0;

--- a/tests/Layer.html
+++ b/tests/Layer.html
@@ -764,7 +764,7 @@
     }
       
     function test_layer_setTileSize(t) {
-        t.plan(6);
+        t.plan(4);
 
         layer = new OpenLayers.Layer();
         
@@ -784,7 +784,6 @@
         var size = new OpenLayers.Size(2,2);
         layer.setTileSize(size);
         t.ok(layer.tileSize.equals(size), "size paramater set correctly to layer's tile size");
-        t.ok(layer.imageOffset == null, "imageOffset and imageSize null when no gutters")
       
       //set on layer
         layer.tileSize = layerTileSize;
@@ -803,10 +802,8 @@
         size = new OpenLayers.Size(10,100);
         layer.setTileSize(size);
 
-        var desiredImageOffset = new OpenLayers.Pixel(-15, -15); 
         var desiredImageSize = new OpenLayers.Size(40, 130); 
 
-        t.ok(layer.imageOffset.equals(desiredImageOffset), "image offset correctly calculated");
         t.ok(layer.imageSize.equals(desiredImageSize), "image size correctly calculated");
     }
     

--- a/tests/Tile/Image.html
+++ b/tests/Tile/Image.html
@@ -295,9 +295,6 @@
         t.ok(tile.layer.imageSize == null,
              "zero size gutter doesn't set image size"); 
 
-        t.ok(tile.layer.imageOffset == null,
-             "zero size gutter doesn't set image offset");
-        
         var zero_gutter_bounds = tile.bounds;
         
         map.destroy();
@@ -312,8 +309,12 @@
                                                              tile.size.h + (2 * gutter))),
              "gutter properly changes image size"); 
 
-        t.ok(tile.layer.imageOffset.equals(new OpenLayers.Pixel(-gutter, -gutter)),
-             "gutter properly sets image offset");
+        var offsetLeft = -(gutter / layer.tileSize.w * 100) | 0;
+        var offsetTop = -(gutter / layer.tileSize.h * 100) | 0;
+        t.eq(parseInt(tile.imgDiv.style.left, 10), offsetLeft,
+             "gutter properly sets image left style");
+        t.eq(parseInt(tile.imgDiv.style.top, 10), offsetTop,
+             "gutter properly sets image top style");
         t.ok(tile.bounds.equals(zero_gutter_bounds),
              "gutter doesn't affect tile bounds");
 


### PR DESCRIPTION
This fixes a regression that was introduced with the Tile.Image overhaul. See http://trac.osgeo.org/openlayers/ticket/3625.
