### PR TITLE
If maxResolution is not set, we want the serverResolution.

### DIFF
--- a/lib/OpenLayers/Layer/Bing.js
+++ b/lib/OpenLayers/Layer/Bing.js
@@ -169,7 +169,8 @@ OpenLayers.Layer.Bing = OpenLayers.Class(OpenLayers.Layer.XYZ, {
         }
         this.addOptions({
             maxResolution: Math.min(
-                this.serverResolutions[res.zoomMin], this.maxResolution
+                this.serverResolutions[res.zoomMin],
+                this.maxResolution || Number.POSITIVE_INFINITY
             ),
             numZoomLevels: Math.min(
                 res.zoomMax + 1 - res.zoomMin, this.numZoomLevels


### PR DESCRIPTION
After 2fe882f4d83728814c8ec387b13c0f89e8e74986, no default maxResolution is set. To make the Math.min not return 0, we need a fallback if no maxResolution was configured.
