### PR TITLE
Map: check default controls are in build

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -577,14 +577,20 @@ OpenLayers.Map = OpenLayers.Class({
         }
         
         if (this.controls == null) {
+            this.controls = [];
             if (OpenLayers.Control != null) { // running full or lite?
-                this.controls = [ new OpenLayers.Control.Navigation(),
-                                  new OpenLayers.Control.PanZoom(),
-                                  new OpenLayers.Control.ArgParser(),
-                                  new OpenLayers.Control.Attribution()
-                                ];
-            } else {
-                this.controls = [];
+                if (OpenLayers.Control.Navigation) {
+                    this.controls.push(new OpenLayers.Control.Navigation())
+                }
+                if (OpenLayers.Control.PanZoom) {
+                    this.controls.push(new OpenLayers.Control.PanZoom())
+                }
+                if (OpenLayers.Control.ArgParser) {
+                    this.controls.push(new OpenLayers.Control.ArgParser())
+                }
+                if (OpenLayers.Control.Attribution) {
+                    this.controls.push(new OpenLayers.Control.Attribution())
+                }
             }
         }
 


### PR DESCRIPTION
At the moment, Map.initialize() adds 4 controls by default, but does not check they are actually in the build. If you follow the instructions for creating a custom build in docs.openlayers.org/library/deploying.html and add each class you use, this will work for the examples/lite.html build/lite.cfg case where there are no controls at all (does anybody actually use this?), but will fail for most of the other examples because the 4 controls are not explicitly mentioned in the script and so will not be in the build. examples/example.js for example, which adds a layerSwitcher to lite.html/cfg

A simple way around this is to add a check in initialize() that the Controls are actually available.

Tests pass after this change, and I have tested with both types of build.
