### PR TITLE
If using `OpenLayers` namespace must have at least one @requires

### DIFF
--- a/build/mobile.cfg
+++ b/build/mobile.cfg
@@ -1,5 +1,4 @@
 [first]
-OpenLayers/SingleFile.js
 
 [last]
 

--- a/lib/OpenLayers/BaseTypes.js
+++ b/lib/OpenLayers/BaseTypes.js
@@ -3,6 +3,10 @@
  * See http://svn.openlayers.org/trunk/openlayers/license.txt for the
  * full text of the license. */
 
+/**
+ * @requires OpenLayers/SingleFile.js
+ */
+
 /** 
  * Header: OpenLayers Base Types
  * OpenLayers custom string, number and function functions are described here.

--- a/lib/OpenLayers/BaseTypes/Date.js
+++ b/lib/OpenLayers/BaseTypes/Date.js
@@ -4,6 +4,10 @@
  * full text of the license. */
 
 /**
+ * @requires OpenLayers/SingleFile.js
+ */
+
+/**
  * Namespace: OpenLayers.Date
  * Contains implementations of Date.parse and date.toISOString that match the
  *     ECMAScript 5 specification for parsing RFC 3339 dates.

--- a/lib/OpenLayers/Spherical.js
+++ b/lib/OpenLayers/Spherical.js
@@ -4,6 +4,10 @@
  * full text of the license. */
 
 /**
+ * @requires OpenLayers/SingleFile.js
+ */
+
+/**
  * Namespace: Spherical
  * The OpenLayers.Spherical namespace includes utility functions for
  * calculations on the basis of a spherical earth (ignoring ellipsoidal


### PR DESCRIPTION
With this change the configuration files can be cleaner as `lite.cfg`.

and `mobile.cfg` works without using `[first] OpenLayers/SingleFile.js`.

---

NOTE: I have no authority to change the milestone, my intention was to put in 2.12

Please review
