### PR TITLE
KML: no placemark description output if no description

### DIFF
--- a/lib/OpenLayers/Format/KML.js
+++ b/lib/OpenLayers/Format/KML.js
@@ -42,9 +42,11 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
     
     /** 
      * APIProperty: placemarksDesc
-     * {String} Name of the placemarks.  Default is "No description available".
+     * {String} Default description text for placemarks.
+     *          Null means no node will be written if the feature has
+     *          no description attribute.  Default is null.
      */
-    placemarksDesc: "No description available",
+    placemarksDesc: null,
     
     /** 
      * APIProperty: foldersName
@@ -1192,18 +1194,20 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
                    feature.attributes.name || feature.id;
         placemarkName.appendChild(this.createTextNode(name));
 
-        // Placemark description
-        var placemarkDesc = this.createElementNS(this.kmlns, "description");
-        var desc = feature.attributes.description || this.placemarksDesc;
-        placemarkDesc.appendChild(this.createTextNode(desc));
-        
         // Placemark
         var placemarkNode = this.createElementNS(this.kmlns, "Placemark");
         if(feature.fid != null) {
             placemarkNode.setAttribute("id", feature.fid);
         }
         placemarkNode.appendChild(placemarkName);
-        placemarkNode.appendChild(placemarkDesc);
+
+        // Placemark description
+        var desc = feature.attributes.description || this.placemarksDesc;
+        if (desc) {
+            placemarkDesc = this.createElementNS(this.kmlns, "description");
+            placemarkDesc.appendChild(this.createTextNode(desc));
+            placemarkNode.appendChild(placemarkDesc);
+        }
 
         // Geometry node (Point, LineString, etc. nodes)
         var geometryNode = this.buildGeometryNode(feature.geometry);

--- a/tests/Format/KML.html
+++ b/tests/Format/KML.html
@@ -101,7 +101,7 @@
         var feature = new OpenLayers.Feature.Vector(geom);
         feature.id = 42;
         var kmlOut = format.write(feature);
-        var expected = '<kml xmlns="http://earth.google.com/kml/2.0"><Folder><Placemark><name>42</name><description>No description available</description><Point><coordinates>0,0</coordinates></Point></Placemark></Folder></kml>'
+        var expected = '<kml xmlns="http://earth.google.com/kml/2.0"><Folder><Placemark><name>42</name><Point><coordinates>0,0</coordinates></Point></Placemark></Folder></kml>'
         t.eq(kmlOut, expected, "null foldersName or foldersDesc don't create elements");
     }
     
@@ -126,7 +126,7 @@
         ]);
         feature = new OpenLayers.Feature.Vector(multi, {name: "test name"});
         output = format.write(feature);
-        expected = '<kml xmlns="http://earth.google.com/kml/2.0"><Folder><name>OpenLayers export</name><description>test output</description><Placemark><name>test name</name><description>No description available</description><MultiGeometry><Point><coordinates>0,1</coordinates></Point></MultiGeometry></Placemark></Folder></kml>';
+        expected = '<kml xmlns="http://earth.google.com/kml/2.0"><Folder><name>OpenLayers export</name><description>test output</description><Placemark><name>test name</name><MultiGeometry><Point><coordinates>0,1</coordinates></Point></MultiGeometry></Placemark></Folder></kml>';
         var output = output.replace(/<\?[^>]*\?>/, ''); // Remove XML Prolog
         t.eq(output, expected, "multipoint correctly written");
         
@@ -139,7 +139,7 @@
         ]);
         feature = new OpenLayers.Feature.Vector(multi, {name: "test name"});
         output = format.write(feature);
-        expected = '<kml xmlns="http://earth.google.com/kml/2.0"><Folder><name>OpenLayers export</name><description>test output</description><Placemark><name>test name</name><description>No description available</description><MultiGeometry><LineString><coordinates>1,0 0,1</coordinates></LineString></MultiGeometry></Placemark></Folder></kml>';
+        expected = '<kml xmlns="http://earth.google.com/kml/2.0"><Folder><name>OpenLayers export</name><description>test output</description><Placemark><name>test name</name><MultiGeometry><LineString><coordinates>1,0 0,1</coordinates></LineString></MultiGeometry></Placemark></Folder></kml>';
         var output = output.replace(/<\?[^>]*\?>/, ''); // Remove XML Prolog
         t.eq(output, expected, "multilinestring correctly written");
 
@@ -155,7 +155,7 @@
         ]);
         feature = new OpenLayers.Feature.Vector(multi, {name: "test name"});
         output = format.write(feature);
-        expected = '<kml xmlns="http://earth.google.com/kml/2.0"><Folder><name>OpenLayers export</name><description>test output</description><Placemark><name>test name</name><description>No description available</description><MultiGeometry><Polygon><outerBoundaryIs><LinearRing><coordinates>0,0 1,0 0,1 0,0</coordinates></LinearRing></outerBoundaryIs></Polygon></MultiGeometry></Placemark></Folder></kml>';
+        expected = '<kml xmlns="http://earth.google.com/kml/2.0"><Folder><name>OpenLayers export</name><description>test output</description><Placemark><name>test name</name><MultiGeometry><Polygon><outerBoundaryIs><LinearRing><coordinates>0,0 1,0 0,1 0,0</coordinates></LinearRing></outerBoundaryIs></Polygon></MultiGeometry></Placemark></Folder></kml>';
         var output = output.replace(/<\?[^>]*\?>/, ''); // Remove XML Prolog
         t.eq(output, expected, "multilinestring correctly written");
 


### PR DESCRIPTION
A follow-up to http://trac.osgeo.org/openlayers/ticket/2417 which claimed to stop output of null placemarksDesc, but didn't actually do so. :-)

Have also changed the default to null; the description element is not required, so why bloat the file with useless text?

Changed tests to match this new configuration.