### PR TITLE
Making map construction work with permalink.

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -496,12 +496,15 @@ OpenLayers.Map = OpenLayers.Class({
             this.projection.projCode : this.projection;
         OpenLayers.Util.applyDefaults(this, OpenLayers.Projection.defaults[projCode]);
         
-        // allow extents to be arrays
+        // allow extents and center to be arrays
         if (this.maxExtent && !(this.maxExtent instanceof OpenLayers.Bounds)) {
             this.maxExtent = new OpenLayers.Bounds(this.maxExtent);
         }
         if (this.restrictedExtent && !(this.restrictedExtent instanceof OpenLayers.Bounds)) {
             this.restrictedExtent = new OpenLayers.Bounds(this.restrictedExtent);
+        }
+        if (this.center && !(this.center instanceof OpenLayers.LonLat)) {
+            this.center = new OpenLayers.LonLat(this.center);
         }
 
         // initialize layers array

--- a/tests/Control/Permalink.html
+++ b/tests/Control/Permalink.html
@@ -321,6 +321,29 @@
         map.layers[1].setVisibility(false);
         t.ok(OpenLayers.Util.isEquivalentUrl(OpenLayers.Util.getElement('permalink').href, location+"#zoom=2&lat=0&lon=1.75781&layers=BF"), 'setVisibility sets permalink');
     }
+    
+    function test_arrayCenter(t) {
+        t.plan(1);
+        var err;
+        try {
+            var map = new OpenLayers.Map({
+                layers: [new OpenLayers.Layer(null, {isBaseLayer: true})],
+                controls: [
+                    new OpenLayers.Control.Permalink({anchor: true})
+                ],
+                center: [0, 0],
+                zoom: 1
+            });
+        } catch (e) {
+            err = e;
+        }
+        if (err) {
+            t.fail("Map construction failure: " + err.message);
+        } else {
+            t.ok(true, "Map construction works");
+        }
+    }
+    
   </script>
 </head>
 <body>


### PR DESCRIPTION
If a map is configured with a permalink control and a center, the permalink control tries to work with the map center before setCenter is called.  This sequence assumes that the map center will already be a LonLat.  This fails if the map is constructed with a coordinate array.  Safer move is to convert center to LonLat before controls are added.
