### PR TITLE
Map: make options.center compatible with permalink

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -628,9 +628,9 @@ OpenLayers.Map = OpenLayers.Class({
              * be properly set below.
              */
             delete this.center;
-            this.addLayers(options.layers);        
+            this.addLayers(options.layers);
             // set center (and optionally zoom)
-            if (options.center) {
+            if (options.center && !this.getCenter()) {
                 // zoom can be undefined here
                 this.setCenter(options.center, options.zoom);
             }


### PR DESCRIPTION
This little change enables use of permalink and Map.options.center together, as in examples/mapbox.html

If permalink/argparser in use, center will have been set by addLayers, so if that is the case don't use options.center, which is the default to be used when not already set by argparser. 
