### PR TITLE
"snappingOptions" option is not used neither in lib examples and tests.

### DIFF
--- a/lib/OpenLayers/Control/ModifyFeature.js
+++ b/lib/OpenLayers/Control/ModifyFeature.js
@@ -246,7 +246,6 @@ OpenLayers.Control.ModifyFeature = OpenLayers.Class(OpenLayers.Control, {
         // configure the drag control
         var dragOptions = {
             geometryTypes: ["OpenLayers.Geometry.Point"],
-            snappingOptions: this.snappingOptions,
             onStart: function(feature, pixel) {
                 control.dragStart.apply(control, [feature, pixel]);
             },


### PR DESCRIPTION
I did a search on all OpenLayers files (*.js and *.html) . "snappingOptions" only appears in [ModifyFeature.js:L249](https://github.com/openlayers/openlayers/blob/master/lib/OpenLayers/Control/ModifyFeature.js#L249)

Using checkout @dd8d89546062753f47d3091fc179a6be2627daa9 (when "ModifyFeature.js" was created) is not used anywhere, seems to be a code that was left in the initial deployment.
