### PR TITLE
OpenLayers.ImgPath should be API property

### DIFF
--- a/lib/OpenLayers/Util.js
+++ b/lib/OpenLayers/Util.js
@@ -560,8 +560,10 @@ OpenLayers.Util.urlAppend = function(url, paramStr) {
 };
 
 /**
- * Property: ImgPath
- * {String} Default is ''.
+ * APIProperty: ImgPath
+ * {String} Set this to the path where control images are stored.
+ *          If set to '' OpenLayers will use script location + "img/"
+ *          Default is ''.
  */
 OpenLayers.ImgPath = '';
 


### PR DESCRIPTION
if we're recommending people set it, as in docs.openlayers.org/library/deploying.html
