### PR TITLE
Fix failing VML test on IE9

### DIFF
--- a/tests/Renderer/VML.html
+++ b/tests/Renderer/VML.html
@@ -189,19 +189,20 @@
         r.resolution = 1;
         
         var node = document.createElement('div');
-        node.id = "test"
+        node.id = "test";
         node._geometryClass = "OpenLayers.Geometry.Point";
         
         var geometry = {
             x: 1,
-            y: 2
-        }
+            y: 2,
+            CLASS_NAME: node._geometryClass
+        };
         
         var style = {
             externalGraphic: "foo.png",
             graphicWidth: 7,
             graphicHeight: 10
-        }
+        };
         
         r.drawGeometryNode(node, geometry, style);
 


### PR DESCRIPTION
drawGeometryNode method is keyed off of the passed geometry's CLASS_NAME. This must be included for the renderer to do anything useful in this particular test
