### PR TITLE
Make the getScriptLocation function work with mobile & light builds

### DIFF
--- a/lib/OpenLayers/SingleFile.js
+++ b/lib/OpenLayers/SingleFile.js
@@ -25,7 +25,7 @@ var OpenLayers = {
      * {String} Path to this script
      */
     _getScriptLocation: (function() {
-        var r = new RegExp("(^|(.*?\\/))(OpenLayers.*?\.js)(\\?|$)"),
+        var r = new RegExp("(^|(.*?\\/))(OpenLayers.*?\\.js)(\\?|$)"),
             s = document.getElementsByTagName('script'),
             src, m, l = "";
         for(var i=0, len=s.length; i<len; i++) {

--- a/tests/SingleFile1.html
+++ b/tests/SingleFile1.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+    <script src="some/path/OpenLayers.js"></script>
+    <script src="../lib/OpenLayers/SingleFile.js"></script>
+    <script type="text/javascript">
+        function test_OpenLayers(t) {
+            t.plan(1);
+            t.eq(OpenLayers._getScriptLocation(), "some/path/",
+                 "Script location correctly detected (OpenLayers.js).");
+        }
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/tests/SingleFile2.html
+++ b/tests/SingleFile2.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+    <script src="some/path/OpenLayers.light.js"></script>
+    <script src="../lib/OpenLayers/SingleFile.js"></script>
+    <script type="text/javascript">
+        function test_OpenLayers(t) {
+            t.plan(1);
+            t.eq(OpenLayers._getScriptLocation(), "some/path/",
+                 "Script location correctly detected (OpenLayers.light.js) .");
+        }
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/tests/SingleFile3.html
+++ b/tests/SingleFile3.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+    <script src="some/path/OpenLayers.light.debug.js"></script>
+    <script src="../lib/OpenLayers/SingleFile.js"></script>
+    <script type="text/javascript">
+        function test_OpenLayers(t) {
+            t.plan(1);
+            t.eq(OpenLayers._getScriptLocation(), "some/path/",
+                 "Script location correctly detected (OpenLayers.light.debug.js).");
+        }
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/tests/list-tests.html
+++ b/tests/list-tests.html
@@ -182,6 +182,9 @@
     <li>OpenLayers3.html</li>
     <li>OpenLayers4.html</li>
     <li>OpenLayersJsFiles.html</li>
+    <li>SingleFile1.html</html>
+    <li>SingleFile2.html</html>
+    <li>SingleFile3.html</html>
     <li>Popup.html</li>
     <li>Popup/Anchored.html</li>
     <li>Popup/AnchoredBubble.html</li>


### PR DESCRIPTION
The current _getScriptLocation function is very strict and will only correctly find the script location when the OpenLayers script is named "OpenLayers.js". This seems highly limiting, especially given that with https://github.com/openlayers/openlayers/commit/c8f0dfd728c6277b52060071338711927b1182e8 :
OpenLayers.debug.js
OpenLayers.light.js
OpenLayers.mobile.js
OpenLayers.light.debug.js  and
OpenLayers.mobile.debug.js

will be built and packaged during the release process and the post commit dev directory update builds.

When _getScriptLocation returns the correct script location, then the default CSS required for OpenLayers UI controls is also included, as is seen in the examples. Without it the CSS file must be specifically included.
