### PR TITLE
cosmetic changes on zoom control

### DIFF
--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -436,8 +436,8 @@ div.olControlZoom {
 }
 div.olControlZoom a {
     display: block;
-    margin: 2px;
-    padding: 0 4px;
+    margin: 1px;
+    padding: 0;
     color: white;
     font-size: 18px;
     font-family: 'Lucida Grande', Verdana, Geneva, Lucida, Arial, Helvetica, sans-serif;    
@@ -445,13 +445,10 @@ div.olControlZoom a {
     text-decoration: none;
     text-align: center;
     height: 22px;
-    width: 15px;
-    line-height: 22px;
+    width:22px;
+    line-height: 19px;
     background: #666666; /* fallback for IE - IE6 requires background shorthand*/
     background: rgba(0, 0, 0, 0.3);
-    border: 1px solid;
-    border-color: #ffffff; /* fallback for IE */
-    border-color: rgba(255, 255, 255, 0.6);
     filter: alpha(opacity=60);
 }
 div.olControlZoom a:hover {
@@ -460,10 +457,10 @@ div.olControlZoom a:hover {
     filter: alpha(opacity=80);
 }
 a.olControlZoomIn {
-    border-radius: 5px 5px 0 0;
+    border-radius: 4px 4px 0 0;
 }
 a.olControlZoomOut {
-    border-radius: 0 0 5px 5px;
+    border-radius: 0 0 4px 4px;
 }
 
 


### PR DESCRIPTION
Following  #291, I suggest minor changes:

![before](http://tonio.biz/pulls/before.png)
![after](http://tonio.biz/pulls/after.png)

As suggested by @tschaub, I'm in favor of having this being the default. 
