### PR TITLE
Map: default controls should include TouchNavigation if present

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -193,8 +193,8 @@ OpenLayers.Map = OpenLayers.Class({
      * {Array(<OpenLayers.Control>)} List of controls associated with the map.
      *
      * If not provided in the map options at construction, the map will
-     *     be given the following controls by default:
-     *  - <OpenLayers.Control.Navigation>
+     *     by default be given the following controls if present in the build:
+     *  - <OpenLayers.Control.Navigation> or <OpenLayers.Control.TouchNavigation>
      *  - <OpenLayers.Control.PanZoom>
      *  - <OpenLayers.Control.ArgParser>
      *  - <OpenLayers.Control.Attribution>
@@ -588,20 +588,23 @@ OpenLayers.Map = OpenLayers.Class({
             }
         }
         
-        if (this.controls == null) {
+        if (this.controls == null) { // default controls
             this.controls = [];
             if (OpenLayers.Control != null) { // running full or lite?
+                // Navigation or TouchNavigation depending on what is in build
                 if (OpenLayers.Control.Navigation) {
-                    this.controls.push(new OpenLayers.Control.Navigation())
+                    this.controls.push(new OpenLayers.Control.Navigation());
+                } else if (OpenLayers.Control.TouchNavigation) {
+                    this.controls.push(new OpenLayers.Control.TouchNavigation());
                 }
                 if (OpenLayers.Control.PanZoom) {
-                    this.controls.push(new OpenLayers.Control.PanZoom())
+                    this.controls.push(new OpenLayers.Control.PanZoom());
                 }
                 if (OpenLayers.Control.ArgParser) {
-                    this.controls.push(new OpenLayers.Control.ArgParser())
+                    this.controls.push(new OpenLayers.Control.ArgParser());
                 }
                 if (OpenLayers.Control.Attribution) {
-                    this.controls.push(new OpenLayers.Control.Attribution())
+                    this.controls.push(new OpenLayers.Control.Attribution());
                 }
             }
         }


### PR DESCRIPTION
As a follow-up to #245, at the moment, there will by default be no navigation if TouchNavigation is in the build instead of Navigation, as with mobile.cfg. This fixes that.

Both possibilities tested and tests continue to pass.

I think this should go in 2.12, as it's quite a serious hole in the logic.
