### PR TITLE
Improve docs for bounds/lonlat, Layer and Map

### DIFF
--- a/lib/OpenLayers/BaseTypes/Bounds.js
+++ b/lib/OpenLayers/BaseTypes/Bounds.js
@@ -56,15 +56,19 @@ OpenLayers.Bounds = OpenLayers.Class({
 
     /**
      * Constructor: OpenLayers.Bounds
-     * Construct a new bounds object.
+     * Construct a new bounds object. Coordinates can either be passed as four
+     * arguments, or as a single argument.
      *
-     * Parameters:
+     * Parameters (four arguments):
      * left - {Number} The left bounds of the box.  Note that for width
      *        calculations, this is assumed to be less than the right value.
      * bottom - {Number} The bottom bounds of the box.  Note that for height
      *          calculations, this is assumed to be more than the top value.
      * right - {Number} The right bounds.
      * top - {Number} The top bounds.
+     *
+     * Parameters (single argument):
+     * bounds - {Array(Number)} [left, bottom, right, top]
      */
     initialize: function(left, bottom, right, top) {
         if (OpenLayers.Util.isArray(left)) {

--- a/lib/OpenLayers/BaseTypes/LonLat.js
+++ b/lib/OpenLayers/BaseTypes/LonLat.js
@@ -27,15 +27,19 @@ OpenLayers.LonLat = OpenLayers.Class({
 
     /**
      * Constructor: OpenLayers.LonLat
-     * Create a new map location.
+     * Create a new map location. Coordinates can be passed either as two
+     * arguments, or as a single argument.
      *
-     * Parameters:
+     * Parameters (two arguments):
      * lon - {Number} The x-axis coordinate in map units.  If your map is in
      *     a geographic projection, this will be the Longitude.  Otherwise,
      *     it will be the x coordinate of the map location in your map units.
      * lat - {Number} The y-axis coordinate in map units.  If your map is in
      *     a geographic projection, this will be the Latitude.  Otherwise,
      *     it will be the y coordinate of the map location in your map units.
+     *
+     * Parameters (single argument):
+     * location - {Array(Float)} [lon, lat]
      */
     initialize: function(lon, lat) {
         if (OpenLayers.Util.isArray(lon)) {

--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -229,7 +229,11 @@ OpenLayers.Layer = OpenLayers.Class({
     
     /**
      * APIProperty: maxExtent
-     * {<OpenLayers.Bounds>}  The center of these bounds will not stray outside
+     * {<OpenLayers.Bounds>|Array} If provided as an array, the array
+     *     should consist of four values (left, bottom, right, top).
+     *     The maximum extent for the layer.  Defaults to null.
+     * 
+     *     The center of these bounds will not stray outside
      *     of the viewport extent during panning.  In addition, if
      *     <displayOutsideMaxExtent> is set to false, data will not be
      *     requested that falls completely outside of these bounds.
@@ -238,7 +242,9 @@ OpenLayers.Layer = OpenLayers.Class({
     
     /**
      * APIProperty: minExtent
-     * {<OpenLayers.Bounds>}
+     * {<OpenLayers.Bounds>|Array} If provided as an array, the array
+     *     should consist of four values (left, bottom, right, top).
+     *     The minimum extent for the layer.  Defaults to null.
      */
     minExtent: null,
     

--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -307,7 +307,9 @@ OpenLayers.Map = OpenLayers.Class({
 
     /**
      * APIProperty: maxExtent
-     * {<OpenLayers.Bounds>} The maximum extent for the map.  Defaults to the
+     * {<OpenLayers.Bounds>|Array} If provided as an array, the array
+     *     should consist of four values (left, bottom, right, top).
+     *     The maximum extent for the map.  Defaults to the
      *     whole world in decimal degrees (-180, -90, 180, 90).  Specify a 
      *     different extent in the map options if you are not using a geographic
      *     projection and displaying the whole  world. To restrict user panning
@@ -318,13 +320,17 @@ OpenLayers.Map = OpenLayers.Class({
     
     /**
      * APIProperty: minExtent
-     * {<OpenLayers.Bounds>}
+     * {<OpenLayers.Bounds>|Array} If provided as an array, the array
+     *     should consist of four values (left, bottom, right, top).
+     *     The minimum extent for the map.  Defaults to null.
      */
     minExtent: null,
     
     /**
      * APIProperty: restrictedExtent
-     * {<OpenLayers.Bounds>} Limit map navigation to this extent where possible.
+     * {<OpenLayers.Bounds>|Array} If provided as an array, the array
+     *     should consist of four values (left, bottom, right, top).
+     *     Limit map navigation to this extent where possible.
      *     If a non-null restrictedExtent is set, panning will be restricted
      *     to the given bounds.  In addition, zooming to a resolution that
      *     displays more than the restricted extent will center the map
@@ -436,6 +442,24 @@ OpenLayers.Map = OpenLayers.Class({
      *     provided or if you intend to call the <render> method later.
      * options - {Object} Optional object with properties to tag onto the map.
      *
+     * Valid options (in addition to the listed API properties):
+     * center - {<OpenLayers.LonLat>|Array} The default initial center of the map.
+     *     If provided as array, the first value is the x coordinate,
+     *     and the 2nd value is the y coordinate.
+     *     Only specify if <layers> is provided.
+     *     Note that if an ArgParser/Permalink control is present,
+     *     and the querystring contains coordinates, center will be set
+     *     by that, and this option will be ignored.
+     * zoom - {Number} The initial zoom level for the map. Only specify if
+     *     <layers> is provided.
+     *     Note that if an ArgParser/Permalink control is present,
+     *     and the querystring contains a zoom level, zoom will be set
+     *     by that, and this option will be ignored.
+     * extent - {<OpenLayers.Bounds>|Array} The initial extent of the map.
+     *     If provided as an array, the array should consist of
+     *     four values (left, bottom, right, top).
+     *     Only specify if <center> and <zoom> are not provided.
+     * 
      * Examples:
      * (code)
      * // create a map with default options in an element with the id "map1"
@@ -443,28 +467,26 @@ OpenLayers.Map = OpenLayers.Class({
      *
      * // create a map with non-default options in an element with id "map2"
      * var options = {
+     *     projection: "EPSG:3857",
      *     maxExtent: new OpenLayers.Bounds(-200000, -200000, 200000, 200000),
-     *     maxResolution: 156543,
-     *     units: 'm',
-     *     projection: "EPSG:41001"
+     *     center: new OpenLayers.LonLat(-12356463.476333, 5621521.4854095)
      * };
      * var map = new OpenLayers.Map("map2", options);
      *
-     * // map with non-default options - same as above but with a single argument
+     * // map with non-default options - same as above but with a single argument,
+     * // a restricted extent, and using arrays for bounds and center
      * var map = new OpenLayers.Map({
      *     div: "map_id",
-     *     maxExtent: new OpenLayers.Bounds(-200000, -200000, 200000, 200000),
-     *     maxResolution: 156543,
-     *     units: 'm',
-     *     projection: "EPSG:41001"
+     *     projection: "EPSG:3857",
+     *     maxExtent: [-18924313.432222, -15538711.094146, 18924313.432222, 15538711.094146],
+     *     restrictedExtent: [-13358338.893333, -9608371.5085962, 13358338.893333, 9608371.5085962],
+     *     center: [-12356463.476333, 5621521.4854095]
      * });
      *
      * // create a map without a reference to a container - call render later
      * var map = new OpenLayers.Map({
-     *     maxExtent: new OpenLayers.Bounds(-200000, -200000, 200000, 200000),
-     *     maxResolution: 156543,
-     *     units: 'm',
-     *     projection: "EPSG:41001"
+     *     projection: "EPSG:3857",
+     *     maxExtent: new OpenLayers.Bounds(-200000, -200000, 200000, 200000)
      * });
      * (end)
      */    
@@ -499,6 +521,9 @@ OpenLayers.Map = OpenLayers.Class({
         // allow extents and center to be arrays
         if (this.maxExtent && !(this.maxExtent instanceof OpenLayers.Bounds)) {
             this.maxExtent = new OpenLayers.Bounds(this.maxExtent);
+        }
+        if (this.minExtent && !(this.minExtent instanceof OpenLayers.Bounds)) {
+            this.minExtent = new OpenLayers.Bounds(this.minExtent);
         }
         if (this.restrictedExtent && !(this.restrictedExtent instanceof OpenLayers.Bounds)) {
             this.restrictedExtent = new OpenLayers.Bounds(this.restrictedExtent);
@@ -622,7 +647,7 @@ OpenLayers.Map = OpenLayers.Class({
         if (options && options.layers) {
             /** 
              * If you have set options.center, the map center property will be
-             * set at this point.  However, since setCenter has not been caleld,
+             * set at this point.  However, since setCenter has not been called,
              * addLayers gets confused.  So we delete the map center in this 
              * case.  Because the check below uses options.center, it will
              * be properly set below.
@@ -1659,7 +1684,9 @@ OpenLayers.Map = OpenLayers.Class({
      * Set the map center (and optionally, the zoom level).
      * 
      * Parameters:
-     * lonlat - {<OpenLayers.LonLat>} The new center location.
+     * lonlat - {<OpenLayers.LonLat>|Array} The new center location.
+     *     If provided as array, the first value is the x coordinate,
+     *     and the 2nd value is the y coordinate.
      * zoom - {Integer} Optional zoom level.
      * dragging - {Boolean} Specifies whether or not to trigger 
      *                      movestart/end events
@@ -2279,7 +2306,8 @@ OpenLayers.Map = OpenLayers.Class({
      * Zoom to the passed in bounds, recenter
      * 
      * Parameters:
-     * bounds - {<OpenLayers.Bounds>}
+     * bounds - {<OpenLayers.Bounds>|Array} If provided as an array, the array
+     *     should consist of four values (left, bottom, right, top).
      * closest - {Boolean} Find the zoom level that most closely fits the 
      *     specified bounds. Note that this may result in a zoom that does 
      *     not exactly contain the entire extent.


### PR DESCRIPTION
Docs improvements originally intended for #248, filtered for inclusion in 2.12. Partly by @ahocevar and partly by me.

Includes one small logic change: For compatibility with other extents and with Layer, Map.mixExtent can also be defined as an array.

Tests continue to pass.
