### PR TITLE
Map: replace PanZoom in default controls by PanPanel + ZoomPanel

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -195,7 +195,8 @@ OpenLayers.Map = OpenLayers.Class({
      * If not provided in the map options at construction, the map will
      *     by default be given the following controls if present in the build:
      *  - <OpenLayers.Control.Navigation> or <OpenLayers.Control.TouchNavigation>
-     *  - <OpenLayers.Control.PanZoom>
+     *  - <OpenLayers.Control.PanPanel>
+     *  - <OpenLayers.Control.ZoomPanel>
      *  - <OpenLayers.Control.ArgParser>
      *  - <OpenLayers.Control.Attribution>
      */
@@ -597,8 +598,11 @@ OpenLayers.Map = OpenLayers.Class({
                 } else if (OpenLayers.Control.TouchNavigation) {
                     this.controls.push(new OpenLayers.Control.TouchNavigation());
                 }
-                if (OpenLayers.Control.PanZoom) {
-                    this.controls.push(new OpenLayers.Control.PanZoom());
+                if (OpenLayers.Control.PanPanel) {
+                    this.controls.push(new OpenLayers.Control.PanPanel());
+                }
+                if (OpenLayers.Control.ZoomPanel) {
+                    this.controls.push(new OpenLayers.Control.ZoomPanel());
                 }
                 if (OpenLayers.Control.ArgParser) {
                     this.controls.push(new OpenLayers.Control.ArgParser());

--- a/tests/Map.html
+++ b/tests/Map.html
@@ -44,7 +44,7 @@
         }
         t.ok( map.layers instanceof Array, "map.layers is an Array" );
         t.ok( map.controls instanceof Array, "map.controls is an Array" );
-        t.eq( map.controls.length, 4, "Default map has 4 controls." );
+        t.eq( map.controls.length, 12, "Default map has 12 controls." );
         t.ok( map.events instanceof OpenLayers.Events, "map.events is an OpenLayers.Events" );
         t.ok( map.getMaxExtent() instanceof OpenLayers.Bounds, "map.maxExtent is an OpenLayers.Bounds" );
         t.ok( map.getNumZoomLevels() > 0, "map has a default numZoomLevels" );


### PR DESCRIPTION
As a follow-up to #293, there is a similar problem with zoom controls. mobile and light builds do not include PanZoom, so there will by default be no zoom control. Fix adds ZoomPanel if present.

Both options tested and tests continue to pass.

Again, I think this should go in 2.12 to support mobile and light builds.
