### PR TITLE
Added missing dependency

### DIFF
--- a/lib/OpenLayers/Control/Graticule.js
+++ b/lib/OpenLayers/Control/Graticule.js
@@ -7,6 +7,8 @@
  * @requires OpenLayers/Control.js
  * @requires OpenLayers/Lang.js
  * @requires OpenLayers/Rule.js
+ * @requires OpenLayers/StyleMap.js
+ * @requires OpenLayers/Layer/Vector.js
  */
 
 /**


### PR DESCRIPTION
I'm writing my custom build configuration file and when adding Graticule that wouldn't work. So I digged in and found out that an additional dependency on  OpenLayers/Rule.js was missing, see:

```
        var gratStyle = new OpenLayers.Style({},{
            rules: [new OpenLayers.Rule({'symbolizer':
                {"Point":this.labelSymbolizer,
                 "Line":this.lineSymbolizer}
            })]
```
