### PR TITLE
Modify Grid.js to respect layer's maxExtent in singleTile mode

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -782,28 +782,32 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
 
         var tileWidth = bounds.getWidth() * this.ratio;
         var tileHeight = bounds.getHeight() * this.ratio;
+        
         var tileBounds = 
-                new OpenLayers.Bounds(
-                    center.lon - (tileWidth / 2), 
-                    center.lat - (tileHeight / 2), 
-                    center.lon + (tileWidth / 2), 
-                    center.lat + (tileHeight / 2)
-                );
-        //adjust tile bounds to fit in maxExtent restriction
-        //if there is a maxExtent restriction
-        if(this.maxExtent) {
+            new OpenLayers.Bounds(center.lon - (tileWidth/2),
+                                  center.lat - (tileHeight/2),
+                                  center.lon + (tileWidth/2),
+                                  center.lat + (tileHeight/2));
+
+        // adjust tile bounds so they do not exceed maxExtent, except when the
+        // layer's maxExtent equals the world bounds or displayOutsideMaxExtent
+        // is set to true
+        var ignoreMaxExtent =
+            (this.map.baseLayer.wrapDateLine &&
+            this.maxExtent.equals(this.map.getMaxExtent())) ||
+            this.displayOutsideMaxExtent;
+        if(!ignoreMaxExtent) {
             tileBounds.bottom = Math.max(this.maxExtent.bottom, tileBounds.bottom);
             tileBounds.top = Math.min(this.maxExtent.top, tileBounds.top);
             tileBounds.left = Math.max(this.maxExtent.left, tileBounds.left);
             tileBounds.right = Math.min(this.maxExtent.right, tileBounds.right);
             tileWidth = tileBounds.getWidth();
             tileHeight = tileBounds.getHeight();
-            var resolution = this.map.getResolution();
-            this.tileSize = new OpenLayers.Size(
-                tileWidth / resolution,
-                tileHeight / resolution
-            );
         }
+        var resolution = this.map.getResolution(),
+            size = this.tileSize;
+        size.w = (tileWidth / resolution) | 0;
+        size.h = (tileHeight / resolution) | 0;
         
         var px = this.map.getLayerPxFromLonLat({
             lon: tileBounds.left,

--- a/tests/Layer/Grid.html
+++ b/tests/Layer/Grid.html
@@ -449,7 +449,7 @@
     }
     
     function test_Layer_Grid_initSingleTile(t) {
-      t.plan( 19 );
+      t.plan( 24 );
       
         layer = new OpenLayers.Layer.Grid(name, url, params, {
             singleTile: true,
@@ -462,13 +462,17 @@
         var desiredUL = new OpenLayers.LonLat(-40,145);
         
         translatedPX = {};
+        layer.tileSize = new OpenLayers.Size();
         layer.map = {
+            baseLayer: {wrapDateLine: true},
+            getMaxExtent: function() { return new OpenLayers.Bounds(-180,-90,180,90); },
             getLayerPxFromLonLat: function(ul) {
                 t.ok(ul.lon === desiredUL.lon && ul.lat === desiredUL.lat, "correct ul passed to translation");
                 return translatedPX;        
             },
             getResolution:function(){return 1;}
         };
+        layer.maxExtent = layer.map.getMaxExtent();
 
         var newTile = {
             draw: function() {
@@ -498,7 +502,7 @@
                 t.ok(tileBounds.equals(desiredTileBounds), "correct tile bounds passed to tile.moveTo()");
                 t.ok(px == translatedPX, "correct tile px passed to tile.moveTo()");
             }
-        }; 
+        };
         layer.grid = [[ tile ]];
         layer.initSingleTile(bounds);
         
@@ -507,13 +511,15 @@
         layer.grid = [];
         //more useful mocks
         layer.map = {
+            baseLayer: {wrapDateLine: false},
+            getMaxExtent: function() { return new OpenLayers.Bounds(-180,-90,180,90); },
             getLayerPxFromLonLat: function(ul) {
             	return {
             		x:ul.lon, 
             		y:ul.lat
         		};
         	},
-        	getResolution:function(){return 1;}
+        	getResolution: function(){return 1;}
     	};
     	layer.addTile = function(tileBounds, px) {
             t.ok(tileBounds.equals(desiredTileBounds), "correct tile bounds passed to addTile to create new tile");
@@ -541,6 +547,13 @@
         translatedPX = {x:-40,y:145};
         layer.grid = [[ tile ]];
     	layer.initSingleTile(bounds);
+    	t.ok(layer.tileSize.equals(new OpenLayers.Size(80, 125)), "tileSize correct.");
+    	
+    	//test bounds where ratio will be applied on all edges
+    	layer.displayOutsideMaxExtent = true;
+        desiredTileBounds = new OpenLayers.Bounds(-40,-35,80,145);
+    	layer.initSingleTile(bounds);
+    	t.ok(layer.tileSize.equals(new OpenLayers.Size(120, 180)), "tileSize correct.")
     }  
      
     function test_Layer_Grid_addTileMonitoringHooks(t) {


### PR DESCRIPTION
A wms layer with `singleTile:true` would always use the full visible map extent \* `layer.ratio` regardless of any `maxExtent` set property set on the layer. This corrects that issue.

Tests passed in IE8, IE9, FF & Chrome.
