### PR TITLE
prevent double click from firing click callback in IE

### DIFF
--- a/lib/OpenLayers/Handler/Click.js
+++ b/lib/OpenLayers/Handler/Click.js
@@ -331,10 +331,13 @@ OpenLayers.Handler.Click = OpenLayers.Class(OpenLayers.Handler, {
      * Handle double-click sequence.
      */
     handleDouble: function(evt) {
-        if (this["double"] && this.passesDblclickTolerance(evt)) {
-            this.callback("dblclick", [evt]);
+        if (this.passesDblclickTolerance(evt)) {
+            if (this["double"]) {
+                this.callback("dblclick", [evt]);
+            }
+            // to prevent a dblclick from firing the click callback in IE
+            this.clearTimer();
         }
-        this.clearTimer();
     },
     
     /** 


### PR DESCRIPTION
Handler.Click tests still pass AFAICT
