### PR TITLE
Vector.Redraw should set zoomChanged to true in moveTo

### DIFF
--- a/lib/OpenLayers/Layer/Vector.js
+++ b/lib/OpenLayers/Layer/Vector.js
@@ -537,6 +537,9 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         if (OpenLayers.Renderer.NG && this.renderer instanceof OpenLayers.Renderer.NG) {
             this.drawn = false;
         }
+        this.resolution = null; // this is to force Layer.redraw set
+                                // zoomChanged to true in the moveTo
+                                // call
         return OpenLayers.Layer.prototype.redraw.apply(this, arguments);
     },
     

--- a/tests/Layer/Vector.html
+++ b/tests/Layer/Vector.html
@@ -917,7 +917,32 @@
             "featuresadded event received expected number of features");
     }
 
+    function test_redraw(t) {
+        t.plan(2);
 
+        // test that when redraw is called on a vector layer then
+        // moveTo gets called on the layer and receives zoomChanged
+        // true
+
+        var log = [];
+
+        var map = new OpenLayers.Map("map");
+        var layer = new OpenLayers.Layer.Vector("vector", {isBaseLayer: true});
+        map.addLayer(layer);
+        map.setCenter([0, 0], 5);
+
+        layer.moveTo = function(extent, zoomChanged) {
+            log.push(zoomChanged);
+        };
+
+        layer.redraw();
+        t.eq(log.length, 1, "redraw makes moveTo be called once");
+        if (log.length == 1) {
+            t.eq(log[0], true, "redraw makes moveTo be called with zoomChanged true");
+        }
+
+        map.destroy();
+    }
 
   </script>
 </head>


### PR DESCRIPTION
See #305

Except for Tile/Image (#311) all tests pass in FireFox 10, Chrome 17, Safari 5.1, IE8 and IE9.
