### PR TITLE
The `loadcancel` event doesn't really exist

### DIFF
--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -88,7 +88,6 @@ OpenLayers.Layer = OpenLayers.Class({
      * Supported map event types:
      * loadstart - Triggered when layer loading starts.
      * loadend - Triggered when layer loading ends.
-     * loadcancel - Triggered when layer loading is canceled.
      * visibilitychanged - Triggered when layer visibility is changed.
      * move - Triggered when layer moves (triggered with every mousemove
      *     during a drag).


### PR DESCRIPTION
Thie `loadcancel` event was introduced with [changeset 2200](http://trac.osgeo.org/openlayers/changeset/2200) and removed again with [changeset 3725](http://trac.osgeo.org/openlayers/changeset/3725). If you search the current code base for `loadcancel`, you won't find any reference.
