### PR TITLE
Layer/Google/v3.html test fail

### DIFF
--- a/tests/Layer/Google/v3.html
+++ b/tests/Layer/Google/v3.html
@@ -144,7 +144,7 @@
         var satellite = new OpenLayers.Layer.Google( "Google Satellite" , {type: google.maps.MapTypeId.SATELLITE, 'maxZoomLevel':18} );
         var layer = new OpenLayers.Layer.WMS( "OpenLayers WMS", 
                 "http://labs.metacarta.com/wms/vmap0", {layers: 'basic', 'transparent':true}, 
-                  {isBaseLayer: false, singleTile: true} );
+                  {isBaseLayer: false, singleTile: true, displayOutsideMaxExtent: true} );
     
         map.addLayers([satellite, layer]);
         map.setCenter(new OpenLayers.LonLat(10.205188,48.857593), 5);


### PR DESCRIPTION
http://www.openlayers.org/dev/tests/run-tests.html using Google Chrome:

```
Layer/Google/v3.html: fail 1 ok 14 (detailed: fail 1 ok 47)
[...]
test_Layer_Google_overlay fail 1 ok 0
    fail Bottom right pixel is covered by untiled WMS layer
[...]
```
