### PR TITLE
Fix proj4js script.src

### DIFF
--- a/examples/graticule.html
+++ b/examples/graticule.html
@@ -23,7 +23,7 @@
             }
         </style>
         <script src="../lib/OpenLayers.js"></script>
-        <script src="http://proj4js.org/lib/proj4js-compressed.js"></script>
+        <script src="http://svn.osgeo.org/metacrs/proj4js/trunk/lib/proj4js-compressed.js"></script>
         <script type="text/javascript">
             Proj4js.defs["EPSG:42304"]="+title=Atlas of Canada, LCC +proj=lcc +lat_1=49 +lat_2=77 +lat_0=49 +lon_0=-95 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs";
             

--- a/examples/using-proj4js.html
+++ b/examples/using-proj4js.html
@@ -7,7 +7,7 @@
         <title>Using Proj4JS for vector reprojection</title>
         <link rel="stylesheet" href="../theme/default/style.css" type="text/css">
         <link rel="stylesheet" href="style.css" type="text/css">
-        <script type="text/javascript" src="http://trac.osgeo.org/proj4js/export/2080/trunk/lib/proj4js-compressed.js"></script>
+        <script type="text/javascript" src="http://svn.osgeo.org/metacrs/proj4js/trunk/lib/proj4js-compressed.js"></script>
         <script type="text/javascript" src="http://spatialreference.org/ref/epsg/31467/proj4js/"></script>
         <script type="text/javascript" src="../lib/OpenLayers.js"></script>
         <script type="text/javascript" src="./using-proj4js.js"></script>

--- a/tests/Control/Graticule.html
+++ b/tests/Control/Graticule.html
@@ -1,7 +1,7 @@
 <html>
 <head>
     <script src="../OLLoader.js"></script>
-    <script src="http://proj4js.org/lib/proj4js-compressed.js"></script>
+    <script src="http://svn.osgeo.org/metacrs/proj4js/trunk/lib/proj4js-compressed.js"></script>
     <script type="text/javascript">
 
     function test_initialize(t) {


### PR DESCRIPTION
examples/graticule.html and tests/Control/Graticule.html do not work because http://proj4js.org/lib/proj4js-compressed.js do not respond.
