### PR TITLE
WMS loadend event does not always fire

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -139,6 +139,12 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
     tileQueue: null,
     
     /**
+     * Property: loading
+     * {Boolean} Indicates if tiles are being loaded.
+     */
+    loading: false,
+    
+    /**
      * Property: backBuffer
      * {DOMElement} The back buffer.
      */
@@ -1050,7 +1056,8 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
         
         tile.onLoadStart = function() {
             //if that was first tile then trigger a 'loadstart' on the layer
-            if (this.numLoadingTiles == 0) {
+            if (this.loading === false) {
+                this.loading = true;
                 this.events.triggerEvent("loadstart");
             }
             this.events.triggerEvent("tileloadstart", {tile: tile});
@@ -1061,7 +1068,8 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
             this.numLoadingTiles--;
             this.events.triggerEvent("tileloaded", {tile: tile});
             //if that was the last tile, then trigger a 'loadend' on the layer
-            if (this.numLoadingTiles === 0) {
+            if (this.tileQueue.length === 0 && this.numLoadingTiles === 0) {
+                this.loading = false;
                 this.events.triggerEvent("loadend");
                 if(this.backBuffer) {
                     // the removal of the back buffer is delayed to prevent flash


### PR DESCRIPTION
In the current 2.12 branch, WMS layers don't always fire loadend events. In addition, sometimes the following error shows up in firebug:

```
Image corrupt or truncated: http://vmap0.tiles.osgeo.org/wms/vmap0?LAYERS=basic&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&FORMAT=image%2Fjpeg&SRS=EPSG%3A4326&BBOX=11.25,39.375,16.875,45&WIDTH=256&HEIGHT=256
```

You can reproduce the behaviour by placing the following file in your OL examples directory:

http://pastebin.com/qKtiJEVE

The last loadend should give zero loading layers. If it does, try using the scrollwheel (not too fast, not too slow) a few times and see what happens.
