### PR TITLE
gutter and maxGetUrlLength broken

### DIFF
--- a/examples/gutter.html
+++ b/examples/gutter.html
@@ -42,12 +42,12 @@
   <script type="text/javascript">
       var map = new OpenLayers.Map('map');
       var states15 = new OpenLayers.Layer.WMS( "States (15px gutter)",
-          "http://demo.opengeo.org/geoserver/wms",
-          {layers: 'topp:states'},
-          {gutter: 15});
+          "http://suite.opengeo.org/geoserver/wms",
+          {layers: 'usa:states'},
+          {gutter: 15, transitionEffect: "resize"});
       var states = new OpenLayers.Layer.WMS( "States (no gutter)",
-          "http://demo.opengeo.org/geoserver/wms",
-          {layers: 'topp:states'});
+          "http://suite.opengeo.org/geoserver/wms",
+          {layers: 'usa:states'});
       map.addLayers([states, states15]);
       map.addControl(new OpenLayers.Control.LayerSwitcher());
       map.setCenter(new OpenLayers.LonLat(-71.848, 42.2), 5);

--- a/lib/OpenLayers/Tile/Image.js
+++ b/lib/OpenLayers/Tile/Image.js
@@ -275,6 +275,8 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile, {
                 style.width = "100%";
             }
             if (this.frame) {
+                style.width = "100%";
+                style.height = "100%";
                 this.frame.appendChild(this.imgDiv);
             }
         }


### PR DESCRIPTION
The wms-long-url.html and gutter.html examples show that Image tiles that use a frame are broken: When zooming in, the backbuffer will appear unscaled.

This is a regression and a blocker for 2.12.
