### PR TITLE
backBuffer style left and top need to be rounded

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -663,8 +663,8 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
                 this.backBufferLonLat, resolution);
         var leftOffset = parseInt(this.map.layerContainerDiv.style.left, 10);
         var topOffset = parseInt(this.map.layerContainerDiv.style.top, 10);
-        backBuffer.style.left = (position.x - leftOffset) + '%';
-        backBuffer.style.top = (position.y - topOffset) + '%';
+        backBuffer.style.left = Math.round(position.x - leftOffset) + '%';
+        backBuffer.style.top = Math.round(position.y - topOffset) + '%';
     },
 
     /**

--- a/tests/Layer/Grid.html
+++ b/tests/Layer/Grid.html
@@ -1245,7 +1245,7 @@
         // zoom transition.
         //
 
-        t.plan(2);
+        t.plan(4);
 
         var map = new OpenLayers.Map('map');
         var layer = new OpenLayers.Layer.WMS('', '', {}, {
@@ -1260,7 +1260,8 @@
         map.setCenter(new OpenLayers.LonLat(10, 10));
         t.ok(layer.backBuffer && layer.backBuffer.parentNode === layer.div,
                 'backbuffer inserted after map move');
-
+        t.eq(layer.backBuffer.style.left, '121%');
+        t.eq(layer.backBuffer.style.top, '211%');
         // zoom
         map.zoomTo(1);
         t.eq(layer.backBuffer, null,


### PR DESCRIPTION
otherwise the backbuffer uses a different positioning than the original tile.

Original patch by @ahocevar I only added the test case.

@elemoine Please consider this for 2.12
