### PR TITLE
Tiles@Home has been discontinued so it should be removed from the doc as well

### DIFF
--- a/lib/OpenLayers/Layer/OSM.js
+++ b/lib/OpenLayers/Layer/OSM.js
@@ -11,12 +11,14 @@
  * Class: OpenLayers.Layer.OSM
  * This layer allows accessing OpenStreetMap tiles. By default the OpenStreetMap
  *    hosted tile.openstreetmap.org Mapnik tileset is used. If you wish to use
- *    tiles@home / osmarender layer instead, you need to provide a different
- *    URL to the constructor. Here's an example for tiles@home:
+ *    a different layer instead, you need to provide a different
+ *    URL to the constructor. Here's an example for using OpenCycleMap:
  * 
  * (code)
- *     new OpenLayers.Layer.OSM("t@h", 
- *       "http://tah.openstreetmap.org/Tiles/tile/${z}/${x}/${y}.png"); 
+ *     new OpenLayers.Layer.OSM("OpenCycleMap", 
+ *       ["http://a.tile.opencyclemap.org/cycle/${z}/${x}/${y}.png",
+ *        "http://b.tile.opencyclemap.org/cycle/${z}/${x}/${y}.png",
+ *        "http://c.tile.opencyclemap.org/cycle/${z}/${x}/${y}.png"]); 
  * (end)
  *
  * Inherits from:
@@ -38,9 +40,11 @@ OpenLayers.Layer.OSM = OpenLayers.Class(OpenLayers.Layer.XYZ, {
      * (the official OSM tileset) if the second argument to the constructor
      * is null or undefined. To use another tileset you can have something
      * like this:
-     * (start code)
-     *     new OpenLayers.Layer.OSM("t@h", 
-     *       "http://tah.openstreetmap.org/Tiles/tile/${z}/${x}/${y}.png"); 
+     * (code)
+     *     new OpenLayers.Layer.OSM("OpenCycleMap", 
+     *       ["http://a.tile.opencyclemap.org/cycle/${z}/${x}/${y}.png",
+     *        "http://b.tile.opencyclemap.org/cycle/${z}/${x}/${y}.png",
+     *        "http://c.tile.opencyclemap.org/cycle/${z}/${x}/${y}.png"]); 
      * (end)
      */
     url: [


### PR DESCRIPTION
Tiles@Home has been discontinued so it should be removed from the example as well. My choice for OpenCycleMap is arbitrary, but since it is currently up on the main OSM slippy map, imo a valid choice.

See also: #330
