### PR TITLE
controls.html example broken

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -325,7 +325,11 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
         obj.gridResolution = null;
         // same for backbuffer and tile queue
         obj.backBuffer = null;
+        obj.backBufferTimerId = null;
         obj.tileQueue = [];
+        obj.tileQueueId = null;
+        obj.loading = false;
+        obj.moveTimerId = null;
 
         return obj;
     },    


### PR DESCRIPTION
The following permalink generated link doesn't seem to work correctly.
The problem is that the OpenLayers WMS layer doesn't load. Calling redraw on this layer or navigating seems to fix it. Which is weird is that selecting the Global Imagery layer doesn't cause the same issue.
http://openlayers.org/dev/examples/controls.html?zoom=5&lat=69.63135&lon=13.1836&layers=B0F

Couldn't find any good reason for that.
