### PR TITLE
Don't draw singleTile WMS layers outside of the layer's maxExtent

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -817,34 +817,40 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
             tileWidth = tileBounds.getWidth();
             tileHeight = tileBounds.getHeight();
         }
-        var resolution = this.map.getResolution(),
-            size = this.tileSize;
-        size.w = (tileWidth / resolution) | 0;
-        size.h = (tileHeight / resolution) | 0;
         
-        var px = this.map.getLayerPxFromLonLat({
-            lon: tileBounds.left,
-            lat: tileBounds.top
-        });
-
-        if (!this.grid.length) {
-            this.grid[0] = [];
-        }
-
-        var tile = this.grid[0][0];
-        if (!tile) {
-            tile = this.addTile(tileBounds, px);
-            
-            this.addTileMonitoringHooks(tile);
-            tile.draw();
-            this.grid[0][0] = tile;
+        if(tileWidth < 0 || tileHeight < 0){
+            //Requested bounds were fully outside of the layer extent
+            //empty the grid and don't add or move any tile
+            this.removeExcessTiles(0,0);
         } else {
-            tile.moveTo(tileBounds, px);
-        }           
-        
-        //remove all but our single tile
-        this.removeExcessTiles(1,1);
-
+            var resolution = this.map.getResolution(),
+                size = this.tileSize;
+            size.w = (tileWidth / resolution) | 0;
+            size.h = (tileHeight / resolution) | 0;
+            
+            var px = this.map.getLayerPxFromLonLat({
+                lon: tileBounds.left,
+                lat: tileBounds.top
+            });
+    
+            if (!this.grid.length) {
+                this.grid[0] = [];
+            }
+    
+            var tile = this.grid[0][0];
+            if (!tile) {
+                tile = this.addTile(tileBounds, px);
+                
+                this.addTileMonitoringHooks(tile);
+                tile.draw();
+                this.grid[0][0] = tile;
+            } else {
+                tile.moveTo(tileBounds, px);
+            }           
+            
+            //remove all but our single tile
+            this.removeExcessTiles(1,1);
+        }
         // store the resolution of the grid
         this.gridResolution = this.getServerResolution();
     },

--- a/tests/Layer/Grid.html
+++ b/tests/Layer/Grid.html
@@ -452,7 +452,7 @@
     }
     
     function test_Layer_Grid_initSingleTile(t) {
-      t.plan( 24 );
+      t.plan( 28 )
       
         layer = new OpenLayers.Layer.Grid(name, url, params, {
             singleTile: true,
@@ -540,7 +540,8 @@
     	layer.maxExtent = new OpenLayers.Bounds(0,20,40,90);
     	desiredTileBounds = new OpenLayers.Bounds(0,20,40,90);
         translatedPX = {x:0,y:90};
-    	layer.initSingleTile(bounds);       
+    	layer.initSingleTile(bounds);
+    	t.ok(layer.tileSize.equals(new OpenLayers.Size(40,70)), "tileSize correct");       
         
         //test bound overlaps the maxExtent
         bounds = new OpenLayers.Bounds(-10,10,50,100);
@@ -556,7 +557,21 @@
     	layer.displayOutsideMaxExtent = true;
         desiredTileBounds = new OpenLayers.Bounds(-40,-35,80,145);
     	layer.initSingleTile(bounds);
-    	t.ok(layer.tileSize.equals(new OpenLayers.Size(120, 180)), "tileSize correct.")
+    	t.ok(layer.tileSize.equals(new OpenLayers.Size(120, 180)), "tileSize correct.");
+    	
+    	//test bounds outside of the maxExtent
+    	bounds = new OpenLayers.Bounds(-10,10,50,100);
+    	layer.ratio = 1;
+    	layer.displayOutsideMaxExtent = false;
+    	layer.maxExtent = new OpenLayers.Bounds(-180,-80,-100,0);
+        layer.removeExcessTiles = function(x,y) {
+            t.ok(x == 0 && y == 0, "removeExcessTiles called with 0,0");
+            layer.grid = [];  
+        };
+    	desiredTileBounds = new OpenLayers.Bounds(-10,10,-100,0); //BAD BOUNDS, This should not draw
+    	layer.initSingleTile(bounds);
+    	t.ok(layer.grid.length === 0, "layer grid is empty");
+    	t.ok(layer.tileSize.equals(new OpenLayers.Size(120, 180)), "retained previous tileSize, without modification");
     }  
      
     function test_Layer_Grid_addTileMonitoringHooks(t) {


### PR DESCRIPTION
Don't attempt to draw an adjusted singleTile wms request when it falls fully outside of the layer's maxExtent.

Adds to issue addressed by #304, which didn't account for bounds fully outside of the layer's maxExtent and attempts to request a tile with bad bounds and negative tile widths or heights in that case.
