### PR TITLE
An alternate way to test for out of extent bounds in Grid.js

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -389,7 +389,16 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
                         this.applyBackBuffer(serverResolution);
                     }
 
-                    this.initSingleTile(bounds);
+                    //test to see if the requested bounds are within the area
+                    //the layer can use. If not, don't bother going further
+                    //and the layer's grid to destroy the previous tile
+                    var extent = (this.map.baseLayer.wrapDateLine) ? this.map.baseLayer.getMaxExent() : this.maxExtent;
+                    var testBounds = bounds.clone().scale(this.ratio);
+                    //using partial:true, since we want whatever portion of the
+                    //layer that can be drawn to be drawn.
+                    if(extent.containsBounds(testBounds,true)){
+                        this.initSingleTile(bounds);
+                    }
                 }
             } else {
 
@@ -817,40 +826,35 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
             tileWidth = tileBounds.getWidth();
             tileHeight = tileBounds.getHeight();
         }
+
+        var resolution = this.map.getResolution(),
+            size = this.tileSize;
+        size.w = (tileWidth / resolution) | 0;
+        size.h = (tileHeight / resolution) | 0;
         
-        if(tileWidth < 0 || tileHeight < 0){
-            //Requested bounds were fully outside of the layer extent
-            //empty the grid and don't add or move any tile
-            this.removeExcessTiles(0,0);
-        } else {
-            var resolution = this.map.getResolution(),
-                size = this.tileSize;
-            size.w = (tileWidth / resolution) | 0;
-            size.h = (tileHeight / resolution) | 0;
-            
-            var px = this.map.getLayerPxFromLonLat({
-                lon: tileBounds.left,
-                lat: tileBounds.top
-            });
-    
-            if (!this.grid.length) {
-                this.grid[0] = [];
-            }
-    
-            var tile = this.grid[0][0];
-            if (!tile) {
-                tile = this.addTile(tileBounds, px);
-                
-                this.addTileMonitoringHooks(tile);
-                tile.draw();
-                this.grid[0][0] = tile;
-            } else {
-                tile.moveTo(tileBounds, px);
-            }           
-            
-            //remove all but our single tile
-            this.removeExcessTiles(1,1);
+        var px = this.map.getLayerPxFromLonLat({
+            lon: tileBounds.left,
+            lat: tileBounds.top
+        });
+
+        if (!this.grid.length) {
+            this.grid[0] = [];
         }
+
+        var tile = this.grid[0][0];
+        if (!tile) {
+            tile = this.addTile(tileBounds, px);
+            
+            this.addTileMonitoringHooks(tile);
+            tile.draw();
+            this.grid[0][0] = tile;
+        } else {
+            tile.moveTo(tileBounds, px);
+        }           
+        
+        //remove all but our single tile
+        this.removeExcessTiles(1,1);
+
         // store the resolution of the grid
         this.gridResolution = this.getServerResolution();
     },

--- a/tests/Layer/Grid.html
+++ b/tests/Layer/Grid.html
@@ -558,20 +558,6 @@
         desiredTileBounds = new OpenLayers.Bounds(-40,-35,80,145);
     	layer.initSingleTile(bounds);
     	t.ok(layer.tileSize.equals(new OpenLayers.Size(120, 180)), "tileSize correct.");
-    	
-    	//test bounds outside of the maxExtent
-    	bounds = new OpenLayers.Bounds(-10,10,50,100);
-    	layer.ratio = 1;
-    	layer.displayOutsideMaxExtent = false;
-    	layer.maxExtent = new OpenLayers.Bounds(-180,-80,-100,0);
-        layer.removeExcessTiles = function(x,y) {
-            t.ok(x == 0 && y == 0, "removeExcessTiles called with 0,0");
-            layer.grid = [];  
-        };
-    	desiredTileBounds = new OpenLayers.Bounds(-10,10,-100,0); //BAD BOUNDS, This should not draw
-    	layer.initSingleTile(bounds);
-    	t.ok(layer.grid.length === 0, "layer grid is empty");
-    	t.ok(layer.tileSize.equals(new OpenLayers.Size(120, 180)), "retained previous tileSize, without modification");
     }  
      
     function test_Layer_Grid_addTileMonitoringHooks(t) {


### PR DESCRIPTION
As suggested in #338 this represents an alternative to the logic used in #339 as a way to avoid requesting a single tile when the requested bounds are outside of the layer's maxExtent (or the baseLayer maxExtent when the baseLayer has 'wrapDateLine:true').

Personally, I feel this logic is better inside of initSingleTile since, as the tests and code for moveTo show, moveTo defers most of that logic to the functions it calls. Additionally, the functions to adjust the bounds and then test / modify them is repeated in initSingleTile, therefore causing the essentially same logic (accessed differently, but the same calculations end up occurring) to be executed twice.
