### PR TITLE
Fixing typo which causes CacheRead to fail when CacheWrite is active

### DIFF
--- a/lib/OpenLayers/Control/CacheRead.js
+++ b/lib/OpenLayers/Control/CacheRead.js
@@ -119,7 +119,7 @@ OpenLayers.Control.CacheRead = OpenLayers.Class(OpenLayers.Control, {
                     url.indexOf(OpenLayers.ProxyHost) === 0) {
                 url = OpenLayers.Control.CacheWrite.urlMap[url];        
             }
-            var dataURI = window.localStorage.getItem("olCache_" + tile.url);
+            var dataURI = window.localStorage.getItem("olCache_" + url);
             if (dataURI) {
                 tile.url = dataURI;
                 if (evt.type === "tileerror") {

--- a/tests/Control/CacheRead.html
+++ b/tests/Control/CacheRead.html
@@ -55,8 +55,8 @@
             return;
         }
         
-        t.plan(4);
-
+        t.plan(5);
+        
         var data = "data:image/gif;base64,R0lGODlhAQABAIAAAP7//wAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==";
         window.localStorage.setItem("olCache_foo/1/1/1", data);
         window.localStorage.setItem("olCache_bar/1/1/1", data);
@@ -70,6 +70,7 @@
             layers: [layer2],
             fetchEvent: "tileerror"
         });
+
         var map = new OpenLayers.Map({
             div: "map",
             projection: "EPSG:900913",
@@ -78,6 +79,15 @@
             zoom: 1,
             center: [0, 0]
         });
+
+        OpenLayers.ProxyHost = "proxy?url=";
+        var tile = new OpenLayers.Tile.Image(layer1, new OpenLayers.LonLat(0, 0), new OpenLayers.Bounds(0, 0, 1, 1), "proxy?url=foo/1/1/1");
+        OpenLayers.Control.CacheWrite.urlMap[tile.url] = "foo/1/1/1";
+        
+        control1.fetch({tile: tile});
+        t.eq(tile.url, data, "proxied url replaced with data uri for original url");
+        delete OpenLayers.Control.CacheWrite.urlMap[tile.url];
+
         t.delay_call(1, function() {
             t.eq(layer1.grid[1][1].imgDiv.src, data, "[tileloadstart] tile content from cache");
             t.ok(layer1.grid[0][0].imgDiv.src !== data, "[tileloadstart] tile content from remote resource");


### PR DESCRIPTION
Not a blocker for 2.12, but just a small fix that would make this new feature work reliably. The problem is that `url` is assigned but never used.

Thanks @gislars for spotting this.
