### PR TITLE
pinch zooming broken

### DIFF
--- a/lib/OpenLayers/Control/PinchZoom.js
+++ b/lib/OpenLayers/Control/PinchZoom.js
@@ -184,6 +184,20 @@ OpenLayers.Control.PinchZoom = OpenLayers.Class(OpenLayers.Control, {
             location.lon += resolution * ((size.w / 2) - zoomPixel.x);
             location.lat -= resolution * ((size.h / 2) - zoomPixel.y);
 
+            // Force a reflow before calling setCenter. This is to work
+            // around an issue occuring in iOS.
+            //
+            // See https://github.com/openlayers/openlayers/pull/351.
+            //
+            // Without a reflow setting the layer container div's top left
+            // style properties to "0px" - as done in Map.moveTo when zoom
+            // is changed - won't actually correctly reposition the layer
+            // container div.
+            //
+            // Also, we need to use a statement that the Google Closure
+            // compiler won't optimize away.
+            this.map.div.clientWidth = this.map.div.clientWidth;
+
             this.map.setCenter(location, zoom);
         }
     },


### PR DESCRIPTION
We've got a regression in the behavior of pinch zooming on multi-touch devices.

To reproduce the issue, open the following two examples:
- http://openlayers.org/dev/examples/mobile.html (bad)
- http://dev.openlayers.org/releases/OpenLayers-2.11/examples/mobile.html (good)

For each example, after the map loads, drag India to the center and pinch over Indonesia to zoom out.  In the good examples, India stays where it should be after zooming out.  In the bad examples, India jumps far to the northwest on the first zoom out.

Git bisect reports that 9cfa5f562ec9a15039dcd942ea22a3ca14032017 is the first bad commit.  I'll try to come up with a more reliable way to test to confirm this.
