### PR TITLE
Clustered features searchable by .getFeatureBy[...]

### DIFF
--- a/lib/OpenLayers/Layer/Vector.js
+++ b/lib/OpenLayers/Layer/Vector.js
@@ -262,7 +262,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         this.unrenderedFeatures = {};
 
         // Allow for custom layer behavior
-        if (this.strategies){
+        if (this.strategies) {
             for(var i = 0, len = this.strategies.length; i < len; i++) {
                 this.strategies[i].setLayer(this);
             }
@@ -326,7 +326,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         var features = this.features;
         var len = features.length;
         var clonedFeatures = new Array(len);
-        for (var i = 0; i < len; ++i) {
+        for (var i = 0; i < len; i++) {
             clonedFeatures[i] = features[i].clone();
         }
         obj.features = clonedFeatures;
@@ -697,7 +697,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
 
             //in the case that this feature is one of the selected features,
             // remove it from that array as well.
-            if (OpenLayers.Util.indexOf(this.selectedFeatures, feature) !== -1){
+            if (OpenLayers.Util.indexOf(this.selectedFeatures, feature) !== -1) {
                 OpenLayers.Util.removeItem(this.selectedFeatures, feature);
             }
 
@@ -951,8 +951,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * passed named attribute set to the given value.
      */
     getFeaturesByAttribute: function(attrName, attrValue, searchClustered) {
-        var i,
-            feature,
+        var i, feature,
             len = this.features.length,
             foundFeatures = [];
         for (i = 0; i < len; i++) {
@@ -1016,10 +1015,9 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * geometries.
      */
     getDataExtent: function () {
-        var i,
+        var i, geometry,
             len = features.length,
             maxExtent = null,
-            geometry = null,
             features = this.features;
         if (features && len > 0) {
             for (i = 0; i < len; i++) {

--- a/lib/OpenLayers/Layer/Vector.js
+++ b/lib/OpenLayers/Layer/Vector.js
@@ -842,11 +842,13 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      *
      * Parameters:
      * evt - {Event}
+     * searchClustered - {Boolean} Optional Parameter. If true features
+     *     clustered by <OpenLayers.Strategy.Cluster> are searched too.
      *
      * Returns:
      * {<OpenLayers.Feature.Vector>} A feature if one was under the event.
      */
-    getFeatureFromEvent: function(evt) {
+    getFeatureFromEvent: function(evt, searchClustered) {
         if (!this.renderer) {
             throw new Error('getFeatureFromEvent called on layer with no ' +
                             'renderer. This usually means you destroyed a ' +
@@ -856,8 +858,8 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         var feature = null;
         var featureId = this.renderer.getFeatureIdFromEvent(evt);
         if (featureId) {
-            if (typeof featureId === "string") {
-                feature = this.getFeatureById(featureId);
+            if (typeof featureId === 'string') {
+                feature = this.getFeatureById(featureId, searchClustered);
             } else {
                 feature = featureId;
             }
@@ -872,21 +874,32 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * Parameters:
      * property - {String}
      * value - {String}
+     * searchClustered - {Boolean} Optional Parameter. If true features
+     *     clustered by <OpenLayers.Strategy.Cluster> are searched too.
      *
      * Returns:
      * {<OpenLayers.Feature.Vector>} A feature corresponding to the given
      * property value or null if there is no such feature.
      */
-    getFeatureBy: function(property, value) {
+    getFeatureBy: function(property, value, searchClustered) {
         //TBD - would it be more efficient to use a hash for this.features?
-        var feature = null;
-        for(var i=0, len=this.features.length; i<len; ++i) {
-            if(this.features[i][property] == value) {
-                feature = this.features[i];
-                break;
+        var i, j, clusterLen,
+            len = this.features.length;
+
+        for (i = 0; i < len; i++) {
+            if (this.features[i][property] == value) {
+                return this.features[i];
+            }
+            if (searchClustered && this.features[i].cluster) {
+                clusterLen = this.features[i].cluster.length;
+                for (j = 0; j < clusterLen; j++) {
+                    if (this.features[i].cluster[j][property] == value) {
+                        return this.features[i].cluster[j];
+                    }
+                }
             }
         }
-        return feature;
+        return null;
     },
 
     /**
@@ -895,13 +908,15 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      *
      * Parameters:
      * featureId - {String}
+     * searchClustered - {Boolean} Optional Parameter. If true features
+     *     clustered by <OpenLayers.Strategy.Cluster> are searched too.
      *
      * Returns:
      * {<OpenLayers.Feature.Vector>} A feature corresponding to the given
      * featureId or null if there is no such feature.
      */
-    getFeatureById: function(featureId) {
-        return this.getFeatureBy('id', featureId);
+    getFeatureById: function(featureId, searchClustered) {
+        return this.getFeatureBy('id', featureId, searchClustered);
     },
 
     /**
@@ -910,13 +925,15 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      *
      * Parameters:
      * featureFid - {String}
+     * searchClustered - {Boolean} Optional Parameter. If true features
+     *     clustered by <OpenLayers.Strategy.Cluster> are searched too.
      *
      * Returns:
      * {<OpenLayers.Feature.Vector>} A feature corresponding to the given
      * featureFid or null if there is no such feature.
      */
-    getFeatureByFid: function(featureFid) {
-        return this.getFeatureBy('fid', featureFid);
+    getFeatureByFid: function(featureFid, searchClustered) {
+        return this.getFeatureBy('fid', featureFid, searchClustered);
     },
 
     /**
@@ -928,19 +945,21 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * Parameters:
      * attrName - {String}
      * attrValue - {Mixed}
+     * searchClustered - {Boolean} Optional Parameter. If true features
+     *     clustered by <OpenLayers.Strategy.Cluster> are searched too.
      *
      * Returns:
      * Array({<OpenLayers.Feature.Vector>}) An array of features that have the
      * passed named attribute set to the given value.
      */
-    getFeaturesByAttribute: function(attrName, attrValue) {
+    getFeaturesByAttribute: function(attrName, attrValue, searchClustered) {
         var i,
             feature,
             len = this.features.length,
             foundFeatures = [];
-        for(i = 0; i < len; i++) {
+        for (i = 0; i < len; i++) {
             feature = this.features[i];
-            if(feature && feature.attributes) {
+            if (feature && feature.attributes) {
                 if (feature.attributes[attrName] === attrValue) {
                     foundFeatures.push(feature);
                 }

--- a/lib/OpenLayers/Layer/Vector.js
+++ b/lib/OpenLayers/Layer/Vector.js
@@ -881,22 +881,30 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      */
     getFeatureBy: function(property, value, searchClustered) {
         //TBD - would it be more efficient to use a hash for this.features?
-        var i, j, clusterLen,
+        var i, j, feature, clusterFeature, clusterLen,
             len = this.features.length;
 
         for (i = 0; i < len; i++) {
-            if (this.features[i][property] == value) {
-                return this.features[i];
+            feature = this.features[i];
+
+            if (feature && feature[property] == value) {
+                return feature;
             }
-            if (searchClustered && this.features[i].cluster) {
-                clusterLen = this.features[i].cluster.length;
+
+            if (searchClustered && feature && feature.cluster) {
+                clusterLen = feature.cluster.length;
+
                 for (j = 0; j < clusterLen; j++) {
-                    if (this.features[i].cluster[j][property] == value) {
-                        return this.features[i].cluster[j];
+                    clusterFeature = feature.cluster[j];
+
+                    if (clusterFeature && clusterFeature[property] == value) {
+                        return clusterFeature;
                     }
                 }
             }
         }
+
+
         return null;
     },
 
@@ -951,14 +959,30 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * passed named attribute set to the given value.
      */
     getFeaturesByAttribute: function(attrName, attrValue, searchClustered) {
-        var i, feature,
+        var i, j, hasFound, feature, clusterFeature, clusterLen,
             len = this.features.length,
             foundFeatures = [];
-        for (i = 0; i < len; i++) {
+
+        for (i = 0; i < len; i += 1) {
             feature = this.features[i];
-            if (feature && feature.attributes) {
-                if (feature.attributes[attrName] === attrValue) {
-                    foundFeatures.push(feature);
+            hasFound = feature && feature.attributes &&
+                    feature.attributes[attrName] === attrValue;
+
+            if (hasFound) {
+                foundFeatures.push(feature);
+            }
+
+            if (searchClustered && feature && feature.cluster) {
+                clusterLen = feature.cluster.length;
+
+                for (j = 0; j < clusterLen; j++) {
+                    clusterFeature = feature.cluster[j];
+                    hasFound = clusterFeature && clusterFeature.attributes &&
+                            clusterFeature.attributes[attrName] === attrValue;
+
+                    if (hasFound) {
+                        foundFeatures.push(clusterFeature);
+                    }
                 }
             }
         }
@@ -1016,7 +1040,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      */
     getDataExtent: function () {
         var i, geometry,
-            len = features.length,
+            len = this.features.length,
             maxExtent = null,
             features = this.features;
         if (features && len > 0) {

--- a/lib/OpenLayers/Layer/Vector.js
+++ b/lib/OpenLayers/Layer/Vector.js
@@ -1,5 +1,5 @@
-/* Copyright (c) 2006-2012 by OpenLayers Contributors (see authors.txt for 
- * full list of contributors). Published under the Clear BSD license.  
+/* Copyright (c) 2006-2012 by OpenLayers Contributors (see authors.txt for
+ * full list of contributors). Published under the Clear BSD license.
  * See http://svn.openlayers.org/trunk/openlayers/license.txt for the
  * full text of the license. */
 
@@ -57,7 +57,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * beforefeatureremoved - Triggered before a feature is removed. Listeners
      *      will receive an object with a *feature* property referencing the
      *      feature to be removed.
-     * beforefeaturesremoved - Triggered before multiple features are removed. 
+     * beforefeaturesremoved - Triggered before multiple features are removed.
      *      Listeners will receive an object with a *features* property
      *      referencing the features to be removed.
      * featureremoved - Triggerd after a feature is removed. The event
@@ -76,14 +76,14 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * featureunselected - Triggered after a feature is unselected.
      *      Listeners will receive an object with a *feature* property
      *      referencing the unselected feature.
-     * beforefeaturemodified - Triggered when a feature is selected to 
-     *      be modified.  Listeners will receive an object with a *feature* 
+     * beforefeaturemodified - Triggered when a feature is selected to
+     *      be modified.  Listeners will receive an object with a *feature*
      *      property referencing the selected feature.
      * featuremodified - Triggered when a feature has been modified.
-     *      Listeners will receive an object with a *feature* property referencing 
+     *      Listeners will receive an object with a *feature* property referencing
      *      the modified feature.
      * afterfeaturemodified - Triggered when a feature is finished being modified.
-     *      Listeners will receive an object with a *feature* property referencing 
+     *      Listeners will receive an object with a *feature* property referencing
      *      the modified feature.
      * vertexmodified - Triggered when a vertex within any feature geometry
      *      has been modified.  Listeners will receive an object with a
@@ -120,33 +120,33 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      */
     isBaseLayer: false,
 
-    /** 
+    /**
      * APIProperty: isFixed
      * {Boolean} Whether the layer remains in one place while dragging the
      * map.
      */
     isFixed: false,
 
-    /** 
+    /**
      * APIProperty: features
-     * {Array(<OpenLayers.Feature.Vector>)} 
+     * {Array(<OpenLayers.Feature.Vector>)}
      */
     features: null,
-    
-    /** 
+
+    /**
      * Property: filter
      * {<OpenLayers.Filter>} The filter set in this layer,
      *     a strategy launching read requests can combined
      *     this filter with its own filter.
      */
     filter: null,
-    
-    /** 
+
+    /**
      * Property: selectedFeatures
-     * {Array(<OpenLayers.Feature.Vector>)} 
+     * {Array(<OpenLayers.Feature.Vector>)}
      */
     selectedFeatures: null,
-    
+
     /**
      * Property: unrenderedFeatures
      * {Object} hash of features, keyed by feature.id, that the renderer
@@ -159,32 +159,32 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * {Boolean} report friendly error message when loading of renderer
      * fails.
      */
-    reportError: true, 
+    reportError: true,
 
-    /** 
+    /**
      * APIProperty: style
      * {Object} Default style for the layer
      */
     style: null,
-    
+
     /**
      * Property: styleMap
      * {<OpenLayers.StyleMap>}
      */
     styleMap: null,
-    
+
     /**
      * Property: strategies
      * {Array(<OpenLayers.Strategy>})} Optional list of strategies for the layer.
      */
     strategies: null,
-    
+
     /**
      * Property: protocol
      * {<OpenLayers.Protocol>} Optional protocol for the layer.
      */
     protocol: null,
-    
+
     /**
      * Property: renderers
      * {Array(String)} List of supported Renderer classes. Add to this list to
@@ -193,21 +193,21 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * method will be used, if not defined in the 'renderer' option.
      */
     renderers: ['SVG', 'VML', 'Canvas'],
-    
-    /** 
+
+    /**
      * Property: renderer
      * {<OpenLayers.Renderer>}
      */
     renderer: null,
-    
+
     /**
      * APIProperty: rendererOptions
      * {Object} Options for the renderer. See {<OpenLayers.Renderer>} for
      *     supported options.
      */
     rendererOptions: null,
-    
-    /** 
+
+    /**
      * APIProperty: geometryType
      * {String} geometryType allows you to limit the types of geometries this
      * layer supports. This should be set to something like
@@ -215,16 +215,16 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      */
     geometryType: null,
 
-    /** 
+    /**
      * Property: drawn
      * {Boolean} Whether the Vector Layer features have been drawn yet.
      */
     drawn: false,
-    
-    /** 
+
+    /**
      * APIProperty: ratio
      * {Float} This specifies the ratio of the size of the visiblity of the Vector Layer features to the size of the map.
-     */   
+     */
     ratio: 1,
 
     /**
@@ -243,7 +243,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         OpenLayers.Layer.prototype.initialize.apply(this, arguments);
 
         // allow user-set renderer, otherwise assign one
-        if (!this.renderer || !this.renderer.supported()) {  
+        if (!this.renderer || !this.renderer.supported()) {
             this.assignRenderer();
         }
 
@@ -251,7 +251,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         if (!this.renderer || !this.renderer.supported()) {
             this.renderer = null;
             this.displayError();
-        } 
+        }
 
         if (!this.styleMap) {
             this.styleMap = new OpenLayers.StyleMap();
@@ -260,7 +260,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         this.features = [];
         this.selectedFeatures = [];
         this.unrenderedFeatures = {};
-        
+
         // Allow for custom layer behavior
         if(this.strategies){
             for(var i=0, len=this.strategies.length; i<len; i++) {
@@ -301,20 +301,20 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         this.renderer = null;
         this.geometryType = null;
         this.drawn = null;
-        OpenLayers.Layer.prototype.destroy.apply(this, arguments);  
+        OpenLayers.Layer.prototype.destroy.apply(this, arguments);
     },
 
     /**
      * Method: clone
      * Create a clone of this layer.
-     * 
+     *
      * Note: Features of the layer are also cloned.
      *
      * Returns:
      * {<OpenLayers.Layer.Vector>} An exact clone of this layer
      */
     clone: function (obj) {
-        
+
         if (obj == null) {
             obj = new OpenLayers.Layer.Vector(this.name, this.getOptions());
         }
@@ -332,8 +332,8 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         obj.features = clonedFeatures;
 
         return obj;
-    },    
-    
+    },
+
     /**
      * Method: refresh
      * Ask the layer to request features again and redraw them.  Triggers
@@ -349,11 +349,11 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         }
     },
 
-    /** 
+    /**
      * Method: assignRenderer
-     * Iterates through the available renderer implementations and selects 
+     * Iterates through the available renderer implementations and selects
      * and assigns the first one whose "supported()" function returns true.
-     */    
+     */
     assignRenderer: function()  {
         for (var i=0, len=this.renderers.length; i<len; i++) {
             var rendererClass = this.renderers[i];
@@ -363,32 +363,32 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             if (renderer && renderer.prototype.supported()) {
                 this.renderer = new renderer(this.div, this.rendererOptions);
                 break;
-            }  
-        }  
+            }
+        }
     },
 
-    /** 
-     * Method: displayError 
+    /**
+     * Method: displayError
      * Let the user know their browser isn't supported.
      */
     displayError: function() {
         if (this.reportError) {
-            OpenLayers.Console.userError(OpenLayers.i18n("browserNotSupported", 
+            OpenLayers.Console.userError(OpenLayers.i18n("browserNotSupported",
                                      {renderers: this. renderers.join('\n')}));
-        }    
+        }
     },
 
-    /** 
+    /**
      * Method: setMap
-     * The layer has been added to the map. 
-     * 
+     * The layer has been added to the map.
+     *
      * If there is no renderer set, the layer can't be used. Remove it.
      * Otherwise, give the renderer a reference to the map and set its size.
-     * 
+     *
      * Parameters:
-     * map - {<OpenLayers.Map>} 
+     * map - {<OpenLayers.Map>}
      */
-    setMap: function(map) {        
+    setMap: function(map) {
         OpenLayers.Layer.prototype.setMap.apply(this, arguments);
 
         if (!this.renderer) {
@@ -440,15 +440,15 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             }
         }
     },
-    
+
     /**
      * Method: onMapResize
-     * Notify the renderer of the change in size. 
-     * 
+     * Notify the renderer of the change in size.
+     *
      */
     onMapResize: function() {
         OpenLayers.Layer.prototype.onMapResize.apply(this, arguments);
-        
+
         var newSize = this.map.getSize();
         newSize.w = newSize.w * this.ratio;
         newSize.h = newSize.h * this.ratio;
@@ -457,22 +457,22 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
 
     /**
      * Method: moveTo
-     *  Reset the vector layer's div so that it once again is lined up with 
+     *  Reset the vector layer's div so that it once again is lined up with
      *   the map. Notify the renderer of the change of extent, and in the
-     *   case of a change of zoom level (resolution), have the 
+     *   case of a change of zoom level (resolution), have the
      *   renderer redraw features.
-     * 
-     *  If the layer has not yet been drawn, cycle through the layer's 
+     *
+     *  If the layer has not yet been drawn, cycle through the layer's
      *   features and draw each one.
-     * 
+     *
      * Parameters:
-     * bounds - {<OpenLayers.Bounds>} 
-     * zoomChanged - {Boolean} 
-     * dragging - {Boolean} 
+     * bounds - {<OpenLayers.Bounds>}
+     * zoomChanged - {Boolean}
+     * dragging - {Boolean}
      */
     moveTo: function(bounds, zoomChanged, dragging) {
         OpenLayers.Layer.prototype.moveTo.apply(this, arguments);
-        
+
         var coordSysUnchanged = true;
         if (!dragging) {
             this.renderer.root.style.visibility = 'hidden';
@@ -501,7 +501,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             if (OpenLayers.IS_GECKO === true) {
                 this.div.scrollLeft = this.div.scrollLeft;
             }
-            
+
             if (!zoomChanged && coordSysUnchanged) {
                 for (var i in this.unrenderedFeatures) {
                     var feature = this.unrenderedFeatures[i];
@@ -517,9 +517,9 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
                 feature = this.features[i];
                 this.drawFeature(feature);
             }
-        }    
+        }
     },
-    
+
     /**
      * APIMethod: redraw
      * Redraws the layer.  Returns true if the layer was redrawn, false if not.
@@ -528,16 +528,16 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * {Boolean} The layer was redrawn.
      */
     redraw: function() {
-        // this is to force Layer.redraw set zoomChanged 
+        // this is to force Layer.redraw set zoomChanged
         // to true in the moveTo call
         this.resolution = null;
         return OpenLayers.Layer.prototype.redraw.apply(this, arguments);
     },
-    
-    /** 
+
+    /**
      * APIMethod: display
      * Hide or show the Layer
-     * 
+     *
      * Parameters:
      * display - {Boolean}
      */
@@ -556,14 +556,14 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * Add Features to the layer.
      *
      * Parameters:
-     * features - {Array(<OpenLayers.Feature.Vector>)} 
+     * features - {Array(<OpenLayers.Feature.Vector>)}
      * options - {Object}
      */
     addFeatures: function(features, options) {
         if (!(OpenLayers.Util.isArray(features))) {
             features = [features];
         }
-        
+
         var notify = !options || !options.silent;
         if(notify) {
             var event = {features: features};
@@ -573,7 +573,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             }
             features = event.features;
         }
-        
+
         // Track successfully added features for featuresadded event, since
         // beforefeatureadded can veto single features.
         var featuresAdded = [];
@@ -582,9 +582,9 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
                 this.renderer.locked = true;
             } else {
                 this.renderer.locked = false;
-            }    
+            }
             var feature = features[i];
-            
+
             if (this.geometryType &&
               !(feature.geometry instanceof this.geometryType)) {
                 throw new TypeError('addFeatures: component should be an ' +
@@ -609,7 +609,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             featuresAdded.push(feature);
             this.features.push(feature);
             this.drawFeature(feature);
-            
+
             if (notify) {
                 this.events.triggerEvent("featureadded", {
                     feature: feature
@@ -617,7 +617,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
                 this.onFeatureInsert(feature);
             }
         }
-        
+
         if(notify) {
             this.events.triggerEvent("featuresadded", {features: featuresAdded});
         }
@@ -631,7 +631,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      *     and featureremoved events will be triggered for each feature.  The
      *     featuresremoved event will be triggered after all features have
      *     been removed.  To supress event triggering, use the silent option.
-     * 
+     *
      * Parameters:
      * features - {Array(<OpenLayers.Feature.Vector>)} List of features to be
      *     removed.
@@ -656,7 +656,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         }
 
         var notify = !options || !options.silent;
-        
+
         if (notify) {
             this.events.triggerEvent(
                 "beforefeaturesremoved", {features: features}
@@ -669,15 +669,15 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             // because if all the features after the current one are 'null', we
             // won't call eraseGeometry, so we break the 'renderer functions
             // will always be called with locked=false *last*' rule. The end result
-            // is a possible gratiutious unlocking to save a loop through the rest 
+            // is a possible gratiutious unlocking to save a loop through the rest
             // of the list checking the remaining features every time. So long as
-            // null geoms are rare, this is probably okay.    
+            // null geoms are rare, this is probably okay.
             if (i != 0 && features[i-1].geometry) {
                 this.renderer.locked = true;
             } else {
                 this.renderer.locked = false;
             }
-    
+
             var feature = features[i];
             delete this.unrenderedFeatures[feature.id];
 
@@ -694,8 +694,8 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             if (feature.geometry) {
                 this.renderer.eraseFeatures(feature);
             }
-                    
-            //in the case that this feature is one of the selected features, 
+
+            //in the case that this feature is one of the selected features,
             // remove it from that array as well.
             if (OpenLayers.Util.indexOf(this.selectedFeatures, feature) != -1){
                 OpenLayers.Util.removeItem(this.selectedFeatures, feature);
@@ -712,8 +712,8 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             this.events.triggerEvent("featuresremoved", {features: features});
         }
     },
-    
-    /** 
+
+    /**
      * APIMethod: removeAllFeatures
      * Remove all features from the layer.
      *
@@ -786,20 +786,20 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * is included, this style will be used.  If no style is included, the
      * feature's style will be used.  If the feature doesn't have a style,
      * the layer's style will be used.
-     * 
-     * This function is not designed to be used when adding features to 
+     *
+     * This function is not designed to be used when adding features to
      * the layer (use addFeatures instead). It is meant to be used when
-     * the style of a feature has changed, or in some other way needs to 
+     * the style of a feature has changed, or in some other way needs to
      * visually updated *after* it has already been added to a layer. You
-     * must add the feature to the layer for most layer-related events to 
+     * must add the feature to the layer for most layer-related events to
      * happen.
      *
-     * Parameters: 
-     * feature - {<OpenLayers.Feature.Vector>} 
+     * Parameters:
+     * feature - {<OpenLayers.Feature.Vector>}
      * style - {String | Object} Named render intent or full symbolizer object.
      */
     drawFeature: function(feature, style) {
-        // don't try to draw the feature with the renderer if the layer is not 
+        // don't try to draw the feature with the renderer if the layer is not
         // drawn itself
         if (!this.drawn) {
             return;
@@ -814,7 +814,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
                 style = this.styleMap.createSymbolizer(feature, renderIntent);
             }
         }
-        
+
         var drawn = this.renderer.drawFeature(feature, style);
         //TODO remove the check for null when we get rid of Renderer.SVG
         if (drawn === false || drawn === null) {
@@ -823,13 +823,13 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             delete this.unrenderedFeatures[feature.id];
         }
     },
-    
+
     /**
      * Method: eraseFeatures
      * Erase features from the layer.
      *
      * Parameters:
-     * features - {Array(<OpenLayers.Feature.Vector>)} 
+     * features - {Array(<OpenLayers.Feature.Vector>)}
      */
     eraseFeatures: function(features) {
         this.renderer.eraseFeatures(features);
@@ -841,7 +841,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * Otherwise, return null.
      *
      * Parameters:
-     * evt - {Event} 
+     * evt - {Event}
      *
      * Returns:
      * {<OpenLayers.Feature.Vector>} A feature if one was under the event.
@@ -918,7 +918,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
     getFeatureByFid: function(featureFid) {
         return this.getFeatureBy('fid', featureFid);
     },
-    
+
     /**
      * APIMethod: getFeaturesByAttribute
      * Returns an array of features that have the given attribute key set to the
@@ -930,15 +930,15 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * attrValue - {Mixed}
      *
      * Returns:
-     * Array({<OpenLayers.Feature.Vector>}) An array of features that have the 
+     * Array({<OpenLayers.Feature.Vector>}) An array of features that have the
      * passed named attribute set to the given value.
      */
     getFeaturesByAttribute: function(attrName, attrValue) {
         var i,
-            feature,    
+            feature,
             len = this.features.length,
             foundFeatures = [];
-        for(i = 0; i < len; i++) {            
+        for(i = 0; i < len; i++) {
             feature = this.features[i];
             if(feature && feature.attributes) {
                 if (feature.attributes[attrName] === attrValue) {
@@ -971,12 +971,12 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * Does nothing by default. Override this if you
      * need to do something on feature updates.
      *
-     * Parameters: 
-     * feature - {<OpenLayers.Feature.Vector>} 
+     * Parameters:
+     * feature - {<OpenLayers.Feature.Vector>}
      */
     onFeatureInsert: function(feature) {
     },
-    
+
     /**
      * APIMethod: preFeatureInsert
      * method called before a feature is inserted.
@@ -985,15 +985,15 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * layer, but before they are drawn, such as adjust the style.
      *
      * Parameters:
-     * feature - {<OpenLayers.Feature.Vector>} 
+     * feature - {<OpenLayers.Feature.Vector>}
      */
     preFeatureInsert: function(feature) {
     },
 
-    /** 
+    /**
      * APIMethod: getDataExtent
      * Calculates the max extent which includes all of the features.
-     * 
+     *
      * Returns:
      * {<OpenLayers.Bounds>} or null if the layer has no features with
      * geometries.

--- a/lib/OpenLayers/Layer/Vector.js
+++ b/lib/OpenLayers/Layer/Vector.js
@@ -262,8 +262,8 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         this.unrenderedFeatures = {};
 
         // Allow for custom layer behavior
-        if(this.strategies){
-            for(var i=0, len=this.strategies.length; i<len; i++) {
+        if (this.strategies){
+            for(var i = 0, len = this.strategies.length; i < len; i++) {
                 this.strategies[i].setLayer(this);
             }
         }
@@ -277,16 +277,16 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
     destroy: function() {
         if (this.strategies) {
             var strategy, i, len;
-            for(i=0, len=this.strategies.length; i<len; i++) {
+            for (i = 0, len = this.strategies.length; i < len; i++) {
                 strategy = this.strategies[i];
-                if(strategy.autoDestroy) {
+                if (strategy.autoDestroy) {
                     strategy.destroy();
                 }
             }
             this.strategies = null;
         }
         if (this.protocol) {
-            if(this.protocol.autoDestroy) {
+            if (this.protocol.autoDestroy) {
                 this.protocol.destroy();
             }
             this.protocol = null;
@@ -315,7 +315,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      */
     clone: function (obj) {
 
-        if (obj == null) {
+        if (!obj) {
             obj = new OpenLayers.Layer.Vector(this.name, this.getOptions());
         }
 
@@ -326,7 +326,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         var features = this.features;
         var len = features.length;
         var clonedFeatures = new Array(len);
-        for(var i=0; i<len; ++i) {
+        for (var i = 0; i < len; ++i) {
             clonedFeatures[i] = features[i].clone();
         }
         obj.features = clonedFeatures;
@@ -344,8 +344,8 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      *     the refresh event.
      */
     refresh: function(obj) {
-        if(this.calculateInRange() && this.visibility) {
-            this.events.triggerEvent("refresh", obj);
+        if (this.calculateInRange() && this.visibility) {
+            this.events.triggerEvent('refresh', obj);
         }
     },
 
@@ -355,9 +355,9 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * and assigns the first one whose "supported()" function returns true.
      */
     assignRenderer: function()  {
-        for (var i=0, len=this.renderers.length; i<len; i++) {
+        for (var i = 0, len = this.renderers.length; i < len; i++) {
             var rendererClass = this.renderers[i];
-            var renderer = (typeof rendererClass == "function") ?
+            var renderer = (typeof rendererClass === 'function') ?
                 rendererClass :
                 OpenLayers.Renderer[rendererClass];
             if (renderer && renderer.prototype.supported()) {
@@ -373,8 +373,8 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      */
     displayError: function() {
         if (this.reportError) {
-            OpenLayers.Console.userError(OpenLayers.i18n("browserNotSupported",
-                                     {renderers: this. renderers.join('\n')}));
+            OpenLayers.Console.userError(OpenLayers.i18n('browserNotSupported',
+                    {renderers: this.renderers.join('\n')}));
         }
     },
 
@@ -410,11 +410,11 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      *     activated here.
      */
     afterAdd: function() {
-        if(this.strategies) {
+        if (this.strategies) {
             var strategy, i, len;
-            for(i=0, len=this.strategies.length; i<len; i++) {
+            for (i = 0, len = this.strategies.length; i < len; i++) {
                 strategy = this.strategies[i];
-                if(strategy.autoActivate) {
+                if (strategy.autoActivate) {
                     strategy.activate();
                 }
             }
@@ -430,11 +430,11 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      */
     removeMap: function(map) {
         this.drawn = false;
-        if(this.strategies) {
+        if (this.strategies) {
             var strategy, i, len;
-            for(i=0, len=this.strategies.length; i<len; i++) {
+            for (i = 0, len = this.strategies.length; i < len; i++) {
                 strategy = this.strategies[i];
-                if(strategy.autoActivate) {
+                if (strategy.autoActivate) {
                     strategy.deactivate();
                 }
             }
@@ -512,7 +512,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         if (!this.drawn || zoomChanged || !coordSysUnchanged) {
             this.drawn = true;
             var feature;
-            for(var i=0, len=this.features.length; i<len; i++) {
+            for (var i = 0, len = this.features.length; i < len; i++) {
                 this.renderer.locked = (i !== (len - 1));
                 feature = this.features[i];
                 this.drawFeature(feature);
@@ -546,7 +546,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         // we need to set the display style of the root in case it is attached
         // to a foreign layer
         var currentDisplay = this.div.style.display;
-        if(currentDisplay != this.renderer.root.style.display) {
+        if (currentDisplay != this.renderer.root.style.display) {
             this.renderer.root.style.display = currentDisplay;
         }
     },
@@ -565,20 +565,20 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         }
 
         var notify = !options || !options.silent;
-        if(notify) {
-            var event = {features: features};
-            var ret = this.events.triggerEvent("beforefeaturesadded", event);
-            if(ret === false) {
+        if (notify) {
+            var evt = {features: features};
+            var ret = this.events.triggerEvent('beforefeaturesadded', evt);
+            if (ret === false) {
                 return;
             }
-            features = event.features;
+            features = evt.features;
         }
 
         // Track successfully added features for featuresadded event, since
         // beforefeatureadded can veto single features.
         var featuresAdded = [];
-        for (var i=0, len=features.length; i<len; i++) {
-            if (i != (features.length - 1)) {
+        for (var i = 0, len = features.length; i < len; i++) {
+            if (i !== (features.length - 1)) {
                 this.renderer.locked = true;
             } else {
                 this.renderer.locked = false;
@@ -599,8 +599,8 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             }
 
             if (notify) {
-                if(this.events.triggerEvent("beforefeatureadded",
-                                            {feature: feature}) === false) {
+                if (this.events.triggerEvent('beforefeatureadded',
+                        {feature: feature}) === false) {
                     continue;
                 }
                 this.preFeatureInsert(feature);
@@ -611,15 +611,15 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             this.drawFeature(feature);
 
             if (notify) {
-                this.events.triggerEvent("featureadded", {
+                this.events.triggerEvent('featureadded', {
                     feature: feature
                 });
                 this.onFeatureInsert(feature);
             }
         }
 
-        if(notify) {
-            this.events.triggerEvent("featuresadded", {features: featuresAdded});
+        if (notify) {
+            this.events.triggerEvent('featuresadded', {features: featuresAdded});
         }
     },
 
@@ -642,7 +642,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * silent - {Boolean} Supress event triggering.  Default is false.
      */
     removeFeatures: function(features, options) {
-        if(!features || features.length === 0) {
+        if (!features || features.length === 0) {
             return;
         }
         if (features === this.features) {
@@ -659,7 +659,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
 
         if (notify) {
             this.events.triggerEvent(
-                "beforefeaturesremoved", {features: features}
+                'beforefeaturesremoved', {features: features}
             );
         }
 
@@ -672,7 +672,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             // is a possible gratiutious unlocking to save a loop through the rest
             // of the list checking the remaining features every time. So long as
             // null geoms are rare, this is probably okay.
-            if (i != 0 && features[i-1].geometry) {
+            if (i !== 0 && features[i - 1].geometry) {
                 this.renderer.locked = true;
             } else {
                 this.renderer.locked = false;
@@ -682,7 +682,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             delete this.unrenderedFeatures[feature.id];
 
             if (notify) {
-                this.events.triggerEvent("beforefeatureremoved", {
+                this.events.triggerEvent('beforefeatureremoved', {
                     feature: feature
                 });
             }
@@ -697,19 +697,19 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
 
             //in the case that this feature is one of the selected features,
             // remove it from that array as well.
-            if (OpenLayers.Util.indexOf(this.selectedFeatures, feature) != -1){
+            if (OpenLayers.Util.indexOf(this.selectedFeatures, feature) !== -1){
                 OpenLayers.Util.removeItem(this.selectedFeatures, feature);
             }
 
             if (notify) {
-                this.events.triggerEvent("featureremoved", {
+                this.events.triggerEvent('featureremoved', {
                     feature: feature
                 });
             }
         }
 
         if (notify) {
-            this.events.triggerEvent("featuresremoved", {features: features});
+            this.events.triggerEvent('featuresremoved', {features: features});
         }
     },
 
@@ -729,20 +729,20 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         var features = this.features;
         if (notify) {
             this.events.triggerEvent(
-                "beforefeaturesremoved", {features: features}
+                'beforefeaturesremoved', {features: features}
             );
         }
         var feature;
-        for (var i = features.length-1; i >= 0; i--) {
+        for (var i = features.length - 1; i >= 0; i--) {
             feature = features[i];
             if (notify) {
-                this.events.triggerEvent("beforefeatureremoved", {
+                this.events.triggerEvent('beforefeatureremoved', {
                     feature: feature
                 });
             }
             feature.layer = null;
             if (notify) {
-                this.events.triggerEvent("featureremoved", {
+                this.events.triggerEvent('featureremoved', {
                     feature: feature
                 });
             }
@@ -752,7 +752,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         this.unrenderedFeatures = {};
         this.selectedFeatures = [];
         if (notify) {
-            this.events.triggerEvent("featuresremoved", {features: features});
+            this.events.triggerEvent('featuresremoved', {features: features});
         }
     },
 
@@ -767,14 +767,12 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * options - {Object}
      */
     destroyFeatures: function(features, options) {
-        var all = (features == undefined); // evaluates to true if
-                                           // features is null
-        if(all) {
+        if (!features) {
             features = this.features;
         }
-        if(features) {
+        if (features) {
             this.removeFeatures(features, options);
-            for(var i=features.length-1; i>=0; i--) {
+            for (var i = features.length - 1; i >= 0; i--) {
                 features[i].destroy();
             }
         }
@@ -804,9 +802,9 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         if (!this.drawn) {
             return;
         }
-        if (typeof style != "object") {
-            if(!style && feature.state === OpenLayers.State.DELETE) {
-                style = "delete";
+        if (typeof style !== 'object') {
+            if (!style && feature.state === OpenLayers.State.DELETE) {
+                style = 'delete';
             }
             var renderIntent = style || feature.renderIntent;
             style = feature.style || this.style;
@@ -1018,11 +1016,13 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * geometries.
      */
     getDataExtent: function () {
-        var maxExtent = null;
-        var features = this.features;
-        if(features && (features.length > 0)) {
-            var geometry = null;
-            for(var i=0, len=features.length; i<len; i++) {
+        var i,
+            len = features.length,
+            maxExtent = null,
+            geometry = null,
+            features = this.features;
+        if (features && len > 0) {
+            for (i = 0; i < len; i++) {
                 geometry = features[i].geometry;
                 if (geometry) {
                     if (maxExtent === null) {
@@ -1035,5 +1035,5 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
         return maxExtent;
     },
 
-    CLASS_NAME: "OpenLayers.Layer.Vector"
+    CLASS_NAME: 'OpenLayers.Layer.Vector'
 });

--- a/tests/Layer/Vector.html
+++ b/tests/Layer/Vector.html
@@ -1,7 +1,8 @@
+<!doctype html>
 <html>
 <head>
 <script src="../OLLoader.js"></script>
-  <script type="text/javascript">
+<script>
 
     var name = "Vector Layer";
     
@@ -155,51 +156,108 @@
     }
 
     function test_Layer_Vector_getFeature(t) {
-        t.plan(13);
+        t.plan(27);
 
         var layer = new OpenLayers.Layer.Vector(name);
-        var feature = new OpenLayers.Feature.Vector(new OpenLayers.Geometry.Point(-111.04, 45.68));
+        var feature1 = new OpenLayers.Feature.Vector(new OpenLayers.Geometry.Point(-111.04, 45.68));
 
-        t.ok(layer.getFeatureById(feature.id) == null,
+        t.ok(layer.getFeatureById(feature1.id) == null,
              "OpenLayers.Layer.Vector.getFeatureById returns null while the layer is empty");
         t.ok(layer.getFeatureByFid('my_fid') == null,
              "OpenLayers.Layer.Vector.getFeatureByFid returns null while the layer is empty");
 
-        layer.addFeatures([feature]);
+        layer.addFeatures([feature1]);
 
         t.ok(layer.getFeatureByFid('my_fid') == null,
              "OpenLayers.Layer.Vector.getFeatureByFid returns null on unset feature fid");
 
-        feature.fid = 'my_fid';
+        feature1.fid = 'my_fid';
 
-        t.ok(layer.getFeatureById(feature.id) == feature,
+        t.ok(layer.getFeatureById(feature1.id) == feature1,
              "OpenLayers.Layer.Vector.getFeatureById returns the correct feature");
-        t.ok(layer.getFeatureByFid(feature.fid) == feature,
+        t.ok(layer.getFeatureByFid(feature1.fid) == feature1,
              "OpenLayers.Layer.Vector.getFeatureByFid returns the correct feature");
         t.ok(layer.getFeatureById('some_id_that_does_not_exist') == null,
              "OpenLayers.Layer.Vector.getFeatureById returns null on non-existing feature id");
         t.ok(layer.getFeatureByFid('some_fid_that_does_not_exist') == null,
              "OpenLayers.Layer.Vector.getFeatureByFid returns null on non-existing feature fid");
-        t.ok(layer.getFeatureById(feature.fid) == null,
+        t.ok(layer.getFeatureById(feature1.fid) == null,
              "OpenLayers.Layer.Vector.getFeatureById ignores the feature fid");
-        t.ok(layer.getFeatureByFid(feature.id) == null,
+        t.ok(layer.getFeatureByFid(feature1.id) == null,
              "OpenLayers.Layer.Vector.getFeatureByFid ignores the feature id");
 
-        t.ok(layer.getFeatureBy('id', feature.id) == feature,
+        t.ok(layer.getFeatureBy('id', feature1.id) == feature1,
              "OpenLayers.Layer.Vector.getFeatureBy('id', ...) works like getFeatureById on existing feature id");
         t.ok(layer.getFeatureBy('id', 'some_id_that_does_not_exist') == null,
              "OpenLayers.Layer.Vector.getFeatureBy('id', ...) works like getFeatureById on non-existing feature id");
-        t.ok(layer.getFeatureBy('fid', feature.fid) == feature,
+        t.ok(layer.getFeatureBy('fid', feature1.fid) == feature1,
              "OpenLayers.Layer.Vector.getFeatureBy('fid', ...) works like getFeatureByFid on existing feature fid");
         t.ok(layer.getFeatureBy('fid', 'some_fid_that_does_not_exist') == null,
              "OpenLayers.Layer.Vector.getFeatureBy('fid', ...) works like getFeatureByFid on non-existing feature fid");
+
+        // Clustered Features
+        var clusterStrategy = new OpenLayers.Strategy.Cluster();
+        var layer = new OpenLayers.Layer.Vector(name, {
+            strategies: [clusterStrategy],
+            isBaseLayer: true
+        });
+        var map = new OpenLayers.Map('map', {
+            resolutions: [4, 2, 1],
+            maxExtent: new OpenLayers.Bounds(-40, -40, 40, 40)
+        });
+        map.addLayer(layer);
+
+        var feature1 = new OpenLayers.Feature.Vector(new OpenLayers.Geometry.Point(-3, 3));
+        var feature2 = new OpenLayers.Feature.Vector(new OpenLayers.Geometry.Point(4, 4));
+        var feature3 = new OpenLayers.Feature.Vector(new OpenLayers.Geometry.Point(2, 1));
+        var feature4 = new OpenLayers.Feature.Vector(new OpenLayers.Geometry.Point(3, 0));
+        feature1.fid = 'my_fid';
+
+        layer.addFeatures([feature1, feature2, feature3, feature4]);
+        map.setCenter(new OpenLayers.LonLat(0, 0), 0);
+
+        if (layer.features.length !== 1) {
+            t.fail("Cluster Strategy does not work");
+        }
+
+        t.ok(layer.getFeatureById(feature1.id) == null,
+             "OpenLayers.Layer.Vector.getFeatureById returns null when Cluster Strategy is active");
+        t.ok(layer.getFeatureByFid(feature1.fid) == null,
+             "OpenLayers.Layer.Vector.getFeatureByFid returns null when Cluster Strategy is active");
+
+        t.ok(layer.getFeatureById(feature1.id, true) == feature1,
+             "OpenLayers.Layer.Vector.getFeatureById returns the correct feature when Cluster Strategy is active and searchClustered is true");
+        t.ok(layer.getFeatureByFid(feature1.fid, true) == feature1,
+             "OpenLayers.Layer.Vector.getFeatureByFid returns the correct feature when Cluster Strategy is active and searchClustered is true");
+
+        t.ok(layer.getFeatureById(feature1.id, true) == feature1,
+             "OpenLayers.Layer.Vector.getFeatureById returns the correct feature when Cluster Strategy is active and searchClustered is true");
+        t.ok(layer.getFeatureByFid(feature1.fid, true) == feature1,
+             "OpenLayers.Layer.Vector.getFeatureByFid returns the correct feature when Cluster Strategy is active and searchClustered is true");
+        t.ok(layer.getFeatureById('some_id_that_does_not_exist', true) == null,
+             "OpenLayers.Layer.Vector.getFeatureById returns null on non-existing feature id when Cluster Strategy is active and searchClustered is true");
+        t.ok(layer.getFeatureByFid('some_fid_that_does_not_exist', true) == null,
+             "OpenLayers.Layer.Vector.getFeatureByFid returns null on non-existing feature fid when Cluster Strategy is active and searchClustered is true");
+        t.ok(layer.getFeatureById(feature1.fid, true) == null,
+             "OpenLayers.Layer.Vector.getFeatureById ignores the feature fid when Cluster Strategy is active and searchClustered is true");
+        t.ok(layer.getFeatureByFid(feature1.id, true) == null,
+             "OpenLayers.Layer.Vector.getFeatureByFid ignores the feature id when Cluster Strategy is active and searchClustered is true");
+
+        t.ok(layer.getFeatureBy('id', feature1.id, true) == feature1,
+             "OpenLayers.Layer.Vector.getFeatureBy('id', ...) works like getFeatureById on existing feature id when Cluster Strategy is active and searchClustered is true");
+        t.ok(layer.getFeatureBy('id', 'some_id_that_does_not_exist', true) == null,
+             "OpenLayers.Layer.Vector.getFeatureBy('id', ...) works like getFeatureById on non-existing feature id when Cluster Strategy is active and searchClustered is true");
+        t.ok(layer.getFeatureBy('fid', feature1.fid, true) == feature1,
+             "OpenLayers.Layer.Vector.getFeatureBy('fid', ...) works like getFeatureByFid on existing feature fid when Cluster Strategy is active and searchClustered is true");
+        t.ok(layer.getFeatureBy('fid', 'some_fid_that_does_not_exist', true) == null,
+             "OpenLayers.Layer.Vector.getFeatureBy('fid', ...) works like getFeatureByFid on non-existing feature fid when Cluster Strategy is active and searchClustered is true");
     }
-    
+
     function test_Layer_Vector_getFeaturesByAttribute(t) {
-        t.plan( 9 );
+        t.plan(18);
         // setup layer
         var layer = new OpenLayers.Layer.Vector(name);
-        
+
         // feature_1
         var geometry_1 = new OpenLayers.Geometry.Point(-28.63, 153.64);
         var attributes_1 = {
@@ -208,7 +266,7 @@
         };
         var feature_1 = new OpenLayers.Feature.Vector(geometry_1, attributes_1);
         feature_1.fid = 'f_01'; // to identify later
-        
+
         // feature_2
         var geometry_2 = new OpenLayers.Geometry.Point(-27.48, 153.05);
         var attributes_2 = {
@@ -217,7 +275,7 @@
         };
         var feature_2 = new OpenLayers.Feature.Vector(geometry_2, attributes_2);
         feature_2.fid = 'f_02'; // to identify later
-        
+
         // feature_3
         var geometry_3 = new OpenLayers.Geometry.Point(-33.74, 150.3);
         var attributes_3 = {
@@ -226,16 +284,16 @@
         };
         var feature_3 = new OpenLayers.Feature.Vector(geometry_3, attributes_3);
         feature_3.fid = 'f_03'; // to identify later
-        
+
         // Tests
-        
+
         // don't find anything... no features added
         // 1 test
         t.ok(layer.getFeaturesByAttribute('humpty', 'dumpty').length === 0,
              "OpenLayers.Layer.Vector.getFeaturesByAttribute returns an empty array while the layer is empty");
-        
+
         layer.addFeatures([feature_1, feature_2, feature_3]);
-        
+
         // simple use case: find 1 feature with an attribute and matching value
         // 2 tests
         var dumptyResults = layer.getFeaturesByAttribute('humpty', 'dumpty');
@@ -243,7 +301,7 @@
              "OpenLayers.Layer.Vector.getFeaturesByAttribute returns an array with one feature for attribute 'humpty' with value 'dumpty'");
         t.ok(dumptyResults[0].fid === 'f_01',
              "OpenLayers.Layer.Vector.getFeaturesByAttribute returns the correct feature with attribute 'humpty' set to 'dumpty'");
-        
+
         // simple use case: find 1 feature with an attribute and matching value
         //                  and respect data types
         // 2 tests
@@ -252,17 +310,17 @@
              "OpenLayers.Layer.Vector.getFeaturesByAttribute returns an array with one feature for attribute 'clazz' with value '1' (a string)");
         t.ok(strOneResults[0].fid === 'f_02',
              "OpenLayers.Layer.Vector.getFeaturesByAttribute returns the correct feature with attribute 'clazz' set to the string '1'");
-        
+
         // simple use case: find 2 features with an attribute and matching value
         //                  and respect data types
-        // 2 tests    
+        // 2 tests
         var numOneResults = layer.getFeaturesByAttribute('clazz', 1);
         t.ok(numOneResults.length === 2,
              "OpenLayers.Layer.Vector.getFeaturesByAttribute returns an array with two features for attribute 'clazz' with value 1 (a number)");
-        var bothFound = !!((numOneResults[0].fid === 'f_01' && numOneResults[1].fid === 'f_03') || (numOneResults[0].fid === 'f_03' && numOneResults[1].fid === 'f_01')); 
+        var bothFound = !!((numOneResults[0].fid === 'f_01' && numOneResults[1].fid === 'f_03') || (numOneResults[0].fid === 'f_03' && numOneResults[1].fid === 'f_01'));
         t.ok(bothFound,
              "OpenLayers.Layer.Vector.getFeaturesByAttribute returns the correct features with attribute 'clazz' set to the number 1");
-        
+
         // advanced use case: find the 1 feature, that has an attribute not set
         var undefined;
         var humptyNotSet = layer.getFeaturesByAttribute('humpty', undefined);
@@ -270,6 +328,68 @@
              "OpenLayers.Layer.Vector.getFeaturesByAttribute can be used to find features that have certain attributes not set");
         t.ok(humptyNotSet[0].fid === 'f_02',
              "OpenLayers.Layer.Vector.getFeaturesByAttribute found the correct featuren that has a certain attribute not set");
+
+        // Clustered Features
+        var clusterStrategy = new OpenLayers.Strategy.Cluster();
+        var layer = new OpenLayers.Layer.Vector(name, {
+            strategies: [clusterStrategy],
+            isBaseLayer: true
+        });
+        var map = new OpenLayers.Map('map', {
+            resolutions: [4, 2, 1],
+            maxExtent: new OpenLayers.Bounds(-40, -40, 40, 40)
+        });
+        map.addLayer(layer);
+        map.setCenter(new OpenLayers.LonLat(0, 0), 0);
+
+        // Clustered Features Tests
+
+        // don't find anything... no features added
+        // 1 test
+        t.ok(layer.getFeaturesByAttribute('humpty', 'dumpty', true).length === 0,
+             "OpenLayers.Layer.Vector.getFeaturesByAttribute returns an empty array while the layer is empty when Cluster Strategy is active and searchClustered is true");
+
+        layer.addFeatures([feature_1, feature_2, feature_3]);
+
+        if (layer.features.length !== 1) {
+            t.fail("Cluster Strategy does not work");
+        }
+
+        // simple use case: find 1 feature with an attribute and matching value
+        // 2 tests
+        var dumptyResults = layer.getFeaturesByAttribute('humpty', 'dumpty', true);
+        t.ok(dumptyResults.length === 1,
+             "OpenLayers.Layer.Vector.getFeaturesByAttribute returns an array with one feature for attribute 'humpty' with value 'dumpty' when Cluster Strategy is active and searchClustered is true");
+        t.ok(dumptyResults[0].fid === 'f_01',
+             "OpenLayers.Layer.Vector.getFeaturesByAttribute returns the correct feature with attribute 'humpty' set to 'dumpty' when Cluster Strategy is active and searchClustered is true");
+
+        // simple use case: find 1 feature with an attribute and matching value
+        //                  and respect data types
+        // 2 tests
+        var strOneResults = layer.getFeaturesByAttribute('clazz', '1', true);
+        t.ok(strOneResults.length === 1,
+             "OpenLayers.Layer.Vector.getFeaturesByAttribute returns an array with one feature for attribute 'clazz' with value '1' (a string) when Cluster Strategy is active and searchClustered is true");
+        t.ok(strOneResults[0].fid === 'f_02',
+             "OpenLayers.Layer.Vector.getFeaturesByAttribute returns the correct feature with attribute 'clazz' set to the string '1' when Cluster Strategy is active and searchClustered is true");
+
+        // simple use case: find 2 features with an attribute and matching value
+        //                  and respect data types
+        // 2 tests
+        var numOneResults = layer.getFeaturesByAttribute('clazz', 1, true);
+        t.ok(numOneResults.length === 2,
+             "OpenLayers.Layer.Vector.getFeaturesByAttribute returns an array with two features for attribute 'clazz' with value 1 (a number) when Cluster Strategy is active and searchClustered is true");
+        var bothFound = !!((numOneResults[0].fid === 'f_01' && numOneResults[1].fid === 'f_03') || (numOneResults[0].fid === 'f_03' && numOneResults[1].fid === 'f_01'));
+        t.ok(bothFound,
+             "OpenLayers.Layer.Vector.getFeaturesByAttribute returns the correct features with attribute 'clazz' set to the number 1 when Cluster Strategy is active and searchClustered is true");
+
+        // advanced use case: find the 1 feature plus 1 cluster, that has an attribute not set
+        var undefined;
+        var humptyNotSet = layer.getFeaturesByAttribute('humpty', undefined, true);
+        t.ok(humptyNotSet.length === 1 + 1,
+             "OpenLayers.Layer.Vector.getFeaturesByAttribute can be used to find features that have certain attributes not set when Cluster Strategy is active and searchClustered is true");
+        t.ok(humptyNotSet[1].fid === 'f_02',
+             "OpenLayers.Layer.Vector.getFeaturesByAttribute found the correct featuren that has a certain attribute not set when Cluster Strategy is active and searchClustered is true");
+
     }
 
     function test_Layer_Vector_getDataExtent(t) {
@@ -896,7 +1016,7 @@
         map.destroy();
     }
 
-  </script>
+</script>
 </head>
 <body>
 <div id="map" style="width:500px;height:550px"></div>


### PR DESCRIPTION
Added option that clustered features are searched by <code>.getFeatureBy[...]</code> too.  Also always using <code>evt</code> instead of <code>event</code>, some code quality changes and trailing whitespaces deleted.

_Please test and say if it breaks anything._

<del>PS: Isn't <code>; ++i) {</code> in a <code>for</code> statement senseless? It should be <code>; i++) {</code> always!</del> See #308.
