### PR TITLE
Layer/Grid.html tests fail

### DIFF
--- a/tests/Layer/Grid.html
+++ b/tests/Layer/Grid.html
@@ -1203,17 +1203,17 @@
         var layer = new OpenLayers.Layer.WMS('', '', {}, {
             isBaseLayer: true,
             singleTile: true,
-            ratio: 1
+            ratio: 1.1
         });
         map.addLayer(layer);
         map.setCenter(new OpenLayers.LonLat(0, 0), 0);
 
         // move
-        map.setCenter(new OpenLayers.LonLat(10, 10));
+        map.setCenter(new OpenLayers.LonLat(50, 50));
         t.ok(layer.backBuffer && layer.backBuffer.parentNode === layer.div,
                 'backbuffer inserted after map move');
-        t.eq(layer.backBuffer.style.left, '121%');
-        t.eq(layer.backBuffer.style.top, '211%');
+        t.eq(layer.backBuffer.style.left, '-25%');
+        t.eq(layer.backBuffer.style.top, '-28%');
         // zoom
         map.zoomTo(1);
         t.eq(layer.backBuffer, null,


### PR DESCRIPTION
In master and 2.12.

```
test_singleTile_move_and_zoom fail 2 ok 2
ok backbuffer inserted after map move
fail undefined. eq: values differ: got 0%, but expected 121%
fail undefined. eq: values differ: got 0%, but expected 211%
ok back buffer removed when zooming
```

`git bisect` reports that 5e9104a2a291929bc47b72aa9b72e58f867df7e0 is the first bad commit.
