### PR TITLE
More precise documentation for OpenLayers.Format.GeoJSON.read

### DIFF
--- a/lib/OpenLayers/Format/GeoJSON.js
+++ b/lib/OpenLayers/Format/GeoJSON.js
@@ -63,8 +63,9 @@ OpenLayers.Format.GeoJSON = OpenLayers.Class(OpenLayers.Format.JSON, {
      *     of <OpenLayers.Feature.Vector>. If type is "Geometry", the input json
      *     must represent a single geometry, and the return will be an
      *     <OpenLayers.Geometry>.  If type is "Feature", the input json must
-     *     represent a single feature, and the return will be an
+     *     represent a single feature (using the GeoJSON type Feature), and the returned object will be an
      *     <OpenLayers.Feature.Vector>.
+     *     If types mismatch null will be returned.
      */
     read: function(json, type, filter) {
         type = (type) ? type : "FeatureCollection";


### PR DESCRIPTION
The changes contain a slightly more precise comment.

Please check the added line on returning null. It describes a current behaviour that is not documented yet and should not be documented if you intend to throw exceptions instead in future.
