### PR TITLE
Add feature indexer for canvas renderer

### DIFF
--- a/lib/OpenLayers/Renderer/Canvas.js
+++ b/lib/OpenLayers/Renderer/Canvas.js
@@ -8,6 +8,189 @@
  */
 
 /**
+ * Class: OpenLayers.FeaturesIndexer
+ * This class takes care of figuring out which order features should be
+ *     placed in the canvas based on given indexing methods.
+ *
+ */
+OpenLayers.FeaturesIndexer = OpenLayers.Class({
+
+    /**
+     * Implied zIndex if it's not defined
+     */
+    minZIndex: -1000,
+
+    /**
+     * Property: order
+     * {Array<String>} This is an array of features id's stored in the
+     *     order that they should show up on screen. Id's higher up in the
+     *     array (higher array index) represent nodes with higher z-indeces.
+     */
+    order: null,
+
+    /**
+     * Property: features
+     * {Object} This is a hash that maps feature ids to feature and associated data
+     */
+    features: null,
+
+    /**
+     * APIMethod: initialize
+     * Create a new feature indexer
+     */
+    initialize: function() {
+        this.clear();
+    },
+
+    /**
+     * APIMethod: clear
+     */
+    clear: function() {
+        this.order = [];
+        this.features = {};
+    },
+
+    /**
+     * APIMethod: exists
+     *
+     * Parameters:
+     * featureId - {String} The feature id to test for existence.
+     *
+     * Returns:
+     * {Boolean} Whether or not the feature exists in the indexer?
+     */
+    exists: function(featureId) {
+        return !!this.features[featureId];
+    },
+
+    /**
+     * APIMethod: remove
+     *
+     * Parameters:
+     * featureId - {String} The feature id to be removed.
+     */
+    remove: function(featureId) {
+        var index = OpenLayers.Util.indexOf(this.order, featureId);
+        if (index >= 0) {
+            this.order.splice(index, 1);
+            delete this.features[featureId];
+        }
+    },
+
+    /**
+     * APIMethod: insert
+     * Insert a new feature into the indexer. In order to find the correct
+     *     positioning for the node to be inserted, this method uses a binary
+     *     search. This makes inserting O(log(n)).
+     *
+     * Parameters:
+     * newFeature - {<OpenLayers.Feature.Vector>} The new feature to be inserted.
+     * data - {Object} data associated with object
+     */
+    insert: function(newFeature, data) {
+        // If the node is known to the indexer, remove it so we can
+        // recalculate where it should go.
+        if (this.exists(newFeature.id)) {
+            this.remove(newFeature.id);
+        }
+
+        var featureId = newFeature.id;
+
+        var leftIndex = -1;
+        var rightIndex = this.order.length;
+        var middle;
+
+        while (rightIndex - leftIndex > 1) {
+            middle = parseInt((leftIndex + rightIndex) / 2);
+
+            var placement = this.compare(newFeature, this.features[this.order[middle]][0]);
+
+            if (placement > 0) {
+                leftIndex = middle;
+            } else {
+                rightIndex = middle;
+            }
+        }
+
+        this.order.splice(rightIndex, 0, featureId);
+        this.features[featureId] = [newFeature, data];
+    },
+
+    /**
+     * APIMethod: compare
+     */
+    compare: function(f1, f2) {
+        var z1 = this.getZIndex(f1);
+        var result = 0;
+
+        if (f2) {
+            var z2 = this.getZIndex(f2);
+            result = z1 - z2;
+            if (result == 0) {
+                result = 1;
+            }
+        }
+
+        return result;
+    },
+
+    /**
+     * APIMethod: getZIndex
+     * Get the z-index value for the current feature from the feature data itself.
+     *
+     * Parameters:
+     * feature - {<OpenLayers.Feature.Vector>} The feature whose z-index to get.
+     *
+     * Returns:
+     * {Integer} The z-index value for the specified feature (from the feature
+     *     data itself).
+     */
+    getZIndex: function(feature) {
+        var zIndex = feature.style && feature.style.graphicZIndex;
+        if (zIndex == null) zIndex = this.minZIndex;
+        return zIndex;
+    },
+
+    /**
+     * APIMethod: iterate
+     * Iterates over features
+     *
+     * Parameters:
+     * handler - {Function} The function(feature, data) called each iteration in indexer's order.
+     * Iteration will be canceled if handler returns false.
+     * scope - {Object} scope for handler
+     *
+     * Returns:
+     * {Boolean} true if handler iterates over all features, else false
+     */
+    iterate: function(handler, scope) {
+        for (var i = 0, len = this.order.length; i < len; i++) {
+            var data = this.features[this.order[i]];
+            if (handler.apply(scope, data) == false) {
+                return false;
+            }
+        }
+        return true;
+    },
+
+    /**
+     * APIMethod: getFeatureById
+     * Returns feature by id
+     *
+     * Parameters:
+     * id - {Number} feature id
+     *
+     * Returns:
+     * {<OpenLayers.Feature.Vector>} found feature or null
+     */
+    getFeatureById: function(id) {
+        return this.features[id][0];
+    },
+
+    CLASS_NAME: "OpenLayers.FeaturesIndexer"
+});
+
+/**
  * Class: OpenLayers.Renderer.Canvas 
  * A renderer based on the 2D 'canvas' drawing element.
  * 
@@ -39,10 +222,11 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
     canvas: null, 
     
     /**
-     * Property: features
-     * {Object} Internal object of feature/style pairs for use in redrawing the layer.
+     * Property: indexer
+     * {<OpenLayers.FeaturesIndexer>} An instance of OpenLayers.FeaturesIndexer
+     *     created upon initialization
      */
-    features: null,
+    indexer: null,
     
     /**
      * Property: pendingRedraw
@@ -69,7 +253,7 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
         this.root = document.createElement("canvas");
         this.container.appendChild(this.root);
         this.canvas = this.root.getContext("2d");
-        this.features = {};
+        this.indexer = new OpenLayers.FeaturesIndexer();
         if (this.hitDetection) {
             this.hitCanvas = document.createElement("canvas");
             this.hitContext = this.hitCanvas.getContext("2d");
@@ -106,7 +290,7 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
      * featureId - {String}
      */
     eraseGeometry: function(geometry, featureId) {
-        this.eraseFeatures(this.features[featureId][0]);
+        this.eraseFeatures(this.indexer.getFeatureById(featureId));
     },
 
     /**
@@ -176,11 +360,11 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
             rendered = (style.display !== "none") && !!bounds && intersects;
             if (rendered) {
                 // keep track of what we have rendered for redraw
-                this.features[feature.id] = [feature, style];
+                this.indexer.insert(feature, style);
             }
             else {
                 // remove from features tracked for redraw
-                delete(this.features[feature.id]);
+                this.indexer.remove(feature.id);
             }
             this.pendingRedraw = true;
         }
@@ -257,7 +441,7 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
         var opacity = style.graphicOpacity || style.fillOpacity;
         
         var onLoad = function() {
-            if(!this.features[featureId]) {
+            if(!this.indexer.exists(featureId)) {
                 return;
             }
             var pt = this.getLocalXY(geometry);
@@ -768,7 +952,7 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
         var height = this.root.height;
         var width = this.root.width;
         this.canvas.clearRect(0, 0, width, height);
-        this.features = {};
+        this.indexer.clear();
         if (this.hitDetection) {
             this.hitContext.clearRect(0, 0, width, height);
         }
@@ -801,7 +985,7 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
                     if (id) {
                         featureId = "OpenLayers.Feature.Vector_" + (id - 1 + this.hitOverflow);
                         try {
-                            feature = this.features[featureId][0];
+                            feature = this.indexer.getFeatureById(featureId);
                         } catch(err) {
                             // Because of antialiasing on the canvas, when the hit location is at a point where the edge of
                             // one symbol intersects the interior of another symbol, a wrong hit color (and therefore id) results.
@@ -827,7 +1011,7 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
             features = [features];
         }
         for(var i=0; i<features.length; ++i) {
-            delete this.features[features[i].id];
+            this.indexer.remove(features[i].id);
         }
         this.redraw();
     },
@@ -851,17 +1035,14 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
             var labelMap = [];
             var feature, geometry, style;
             var worldBounds = (this.map.baseLayer && this.map.baseLayer.wrapDateLine) && this.map.getMaxExtent();
-            for (var id in this.features) {
-                if (!this.features.hasOwnProperty(id)) { continue; }
-                feature = this.features[id][0];
+            this.indexer.iterate(function(feature, style) {
                 geometry = feature.geometry;
                 this.calculateFeatureDx(geometry.getBounds(), worldBounds);
-                style = this.features[id][1];
                 this.drawGeometry(geometry, style, feature.id);
                 if(style.label) {
                     labelMap.push([feature, style]);
                 }
-            }
+            }, this);
             var item;
             for (var i=0, len=labelMap.length; i<len; ++i) {
                 item = labelMap[i];

--- a/tests/Renderer/Canvas.html
+++ b/tests/Renderer/Canvas.html
@@ -493,6 +493,51 @@
         });
     }
 
+    function test_drawOrder(t) {
+        if (!supported) { t.plan(0); return; }
+        t.plan(8);
+
+        setUp();
+        var renderer = layer.renderer;
+
+        var f1 = new OpenLayers.Feature.Vector(new OpenLayers.Geometry.Point(0, 0));
+        var f2 = new OpenLayers.Feature.Vector(new OpenLayers.Geometry.Point(0, 1));
+        exp = renderer.drawFeature(f1, {});
+        t.eq(exp, true, 'drawFeature f1 returns true');
+
+        exp = renderer.drawFeature(f2, {});
+        t.eq(exp, true, 'drawFeature f2 returns true');
+
+        renderer.eraseFeatures(f1);
+
+        var orderList = [];
+        var drawGeometry = renderer.drawGeometry;
+        renderer.drawGeometry = function(geometry, style, featureId) {
+            orderList.push(featureId);
+            return drawGeometry.apply(this, arguments);
+        }
+
+        exp = renderer.drawFeature(f1, {});
+        t.eq(exp, true, 'drawFeature f1 returns again true');
+
+        t.eq(f2.id, orderList[0], 'feature f2 drawn first');
+        t.eq(f1.id, orderList[1], 'feature f1 drawn second');
+
+        orderList = [];
+        var f3 = new OpenLayers.Feature.Vector(new OpenLayers.Geometry.Point(0, 2));
+        f1.style = {graphicZIndex: 1};
+        f3.style = {graphicZIndex: 3};
+        renderer.locked = true;
+        renderer.drawFeature(f1, {});
+        renderer.locked = false;
+        renderer.drawFeature(f3, {});
+        t.eq(f2.id, orderList[0], 'feature f2 drawn first');
+        t.eq(f1.id, orderList[1], 'feature f1(zIndex=1) drawn second');
+        t.eq(f3.id, orderList[2], 'feature f3(zIndex=3) drawn third');
+
+        tearDown();
+    }
+
   </script>
 </head>
 <body>


### PR DESCRIPTION
In Canvas renderer only one way to control order of rendering features - add and remove features to/from renderer, actually to it's hash-map. And iteration order for hash-map is new id - latest in a iteration. But not in IE9.
In IE9 deleted keys are preserves order if insert same key again.

I'm added test for this, and also add graphicZIndex support for canvas renderer.

P.S. Sorry for english, i'm not native english speaker 
