### PR TITLE
Fix typo

### DIFF
--- a/examples/stylemap.html
+++ b/examples/stylemap.html
@@ -78,7 +78,7 @@
 
     <p id="shortdesc">
         Shows how to use a StyleMap to style features with rule based styling.
-        A style map references on or more OpenLayers.Style objects.  These
+        A style map references one or more OpenLayers.Style objects.  These
         OpenLayers.Style objects are collections of OpenLayers.Rule objects
         that determine how features are styled.  An OpenLayers.Rule object
         combines an OpenLayers.Filter object with a symbolizer.  A filter is used


### PR DESCRIPTION
There's a small typo in the text for this example - "on or more" should be "one or more".
