### PR TITLE
renaming from olLayerGridTile to olLayerGrid

### DIFF
--- a/examples/style.mobile.css
+++ b/examples/style.mobile.css
@@ -43,7 +43,7 @@ div.olControlZoom a:hover {
         background: rgba(0, 60, 136, 0.5);
     }
 }
-.olLayerGridTile .olTileImage {
+.olLayerGrid .olTileImage {
     -webkit-transition: opacity 0.2s linear;
     -moz-transition: opacity 0.2s linear;
     -o-transition: opacity 0.2s linear;

--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -211,14 +211,14 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
      * {String} Name of the class added to the layer div. If not set in the
      *     options passed to the constructor then className defaults to
      *     "olLayerGridSingleTile" for single tile layers (see <singleTile>),
-     *     and "olLayerGridTile" for non single tile layers.
+     *     and "olLayerGrid" for non single tile layers.
      *
      * Note:
      *
      * The displaying of tiles is not animated by default for single tile
      *     layers - OpenLayers' default theme (style.css) includes this:
      * (code)
-     * .olLayerGridTile .olTileImage {
+     * .olLayerGrid .olTileImage {
      *     -webkit-transition: opacity 0.2s linear;
      *     -moz-transition: opacity 0.2s linear;
      *     -o-transition: opacity 0.2s linear;
@@ -291,7 +291,7 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
         
         if (this.className === null) {
             this.className = this.singleTile ? 'olLayerGridSingleTile' :
-                                               'olLayerGridTile';
+                                               'olLayerGrid';
         }
 
         if (!OpenLayers.Animation.isNative) {

--- a/notes/2.12.md
+++ b/notes/2.12.md
@@ -63,7 +63,7 @@ Corresponding issues/pull requests:
 
 The displaying of tiles can now be animated, using CSS3 transitions. Transitions operate on the `opacity` property. Here's the CSS rule defined in OpenLayers' default theme:
 
-    .olLayerGridTile .olTileImage {
+    .olLayerGrid .olTileImage {
         -webkit-transition: opacity 0.2s linear;
         -moz-transition: opacity 0.2s linear;
         -o-transition: opacity 0.2s linear;

--- a/tests/Layer/Grid.html
+++ b/tests/Layer/Grid.html
@@ -33,7 +33,7 @@
         t.eq( layer.ratio, 1.5, "ratio default is 1.5");
         t.eq( layer.numLoadingTiles, 0, "numLoadingTiles starts at 0");
         t.ok( layer.tileClass === OpenLayers.Tile.Image, "tileClass default is OpenLayers.Tile.Image");
-        t.eq( layer.className, 'olLayerGridTile', "className default is olLayerGridTile");
+        t.eq( layer.className, 'olLayerGrid', "className default is olLayerGrid");
         t.eq( layer.removeBackBufferDelay, 2500, "removeBackBufferDelay default is 2500");
 
         var obj = {};
@@ -55,8 +55,8 @@
         var map = new OpenLayers.Map('map');
         layer = new OpenLayers.Layer.Grid(name, url, params, null);
         map.addLayer(layer);
-        t.ok(OpenLayers.Element.hasClass(layer.div, "olLayerGridTile"),
-             "olLayerGridTile class assigned to layer div");
+        t.ok(OpenLayers.Element.hasClass(layer.div, "olLayerGrid"),
+             "olLayerGrid class assigned to layer div");
         map.destroy();
     }
 

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -476,7 +476,7 @@ a.olControlZoomOut {
  * Animations
  */
 
-.olLayerGridTile .olTileImage {
+.olLayerGrid .olTileImage {
     -webkit-transition: opacity 0.2s linear;
     -moz-transition: opacity 0.2s linear;
     -o-transition: opacity 0.2s linear;


### PR DESCRIPTION
Further to #365. This pull request suggests doing a simple renaming, from `olLayerGridTile` to `olLayerGrid`.
