### PR TITLE
Make cache writing work when cross-origin.

### DIFF
--- a/lib/OpenLayers/Control/CacheWrite.js
+++ b/lib/OpenLayers/Control/CacheWrite.js
@@ -173,11 +173,13 @@ OpenLayers.Control.CacheWrite = OpenLayers.Class(OpenLayers.Control, {
                 try {
                     var canvasContext = tile.getCanvasContext();
                     if (canvasContext) {
+                        var urlMap = OpenLayers.Control.CacheWrite.urlMap;
+                        var url = urlMap[tile.url] || tile.url;
                         window.localStorage.setItem(
-                            "olCache_" + OpenLayers.Control.CacheWrite.urlMap[tile.url],
+                            "olCache_" + url,
                             canvasContext.canvas.toDataURL(this.imageFormat)
                         );
-                        delete OpenLayers.Control.CacheWrite.urlMap[tile.url];
+                        delete urlMap[tile.url];
                     }
                 } catch(e) {
                     // local storage full or CORS violation


### PR DESCRIPTION
The `makeSameOrigin` method is called with every `tileloadstart`, however it only adds an entry to `Control.CacheWrite.urlMap` if `!tile.crossOriginKeyword`.  Later (on `tileloaded`) the `cache` method always tries to get a url from the `urlMap`.  This results in an `olCache_undefined` entry being written in the cache whenever `tile.crossOriginKeyword` is truthy.  This can be seen (on Chrome) using the [offline-storage.html](http://openlayers.org/dev/examples/offline-storage.html) example.  Click "write to cache" and see that there is never more than one entry in `localStorage`.

I'm not sure I totally understand the logic of `makeSameOrigin`, but cache writing works for me if I use the tile URL when there is not an entry in the URL map.
