### PR TITLE
Undefined property in PinchZoom Control

### DIFF
--- a/lib/OpenLayers/Control/PinchZoom.js
+++ b/lib/OpenLayers/Control/PinchZoom.js
@@ -45,7 +45,13 @@ OpenLayers.Control.PinchZoom = OpenLayers.Class(OpenLayers.Control, {
      *     true.
      */
     autoActivate: true,
-    
+
+    /**
+     * APIProperty: handlerOptions
+     * {Object} Used to set non-default properties on the control's handler
+     */
+    handlerOptions: null,
+
     /**
      * Constructor: OpenLayers.Control.PinchZoom
      * Create a control for zooming with pinch gestures.  This works on devices

--- a/tests/Control/PinchZoom.html
+++ b/tests/Control/PinchZoom.html
@@ -4,10 +4,15 @@
   <script type="text/javascript">
 
     function test_constructor(t) {
-        t.plan(2);
-        var control = new OpenLayers.Control.PinchZoom();
+        t.plan(3);
+        var control = new OpenLayers.Control.PinchZoom({
+            handlerOptions: {
+                foo: "bar"
+            }
+        });
         t.ok(control instanceof OpenLayers.Control.PinchZoom, "got an instance");
         t.ok(control.handler instanceof OpenLayers.Handler.Pinch, "control has pinch handler");
+        t.eq(control.handler.foo, "bar",  "handlerOptions works");
         control.destroy();
     }
 


### PR DESCRIPTION
_this.handlerOptions_ is undefined in method _initialize_ of _OpenLayers.Control.PinchZoom_:

``` javascript
   initialize: function(options) {
        // ...
        this.handler = new OpenLayers.Handler.Pinch(this, {
            // ...
        }, this.handlerOptions);
    },
```
