### PR TITLE
Let points and lines take precedence (priority) over polygons when selec...

### DIFF
--- a/lib/OpenLayers/Control/GetFeature.js
+++ b/lib/OpenLayers/Control/GetFeature.js
@@ -415,7 +415,8 @@ OpenLayers.Control.GetFeature = OpenLayers.Class(OpenLayers.Control, {
     /**
      * Method: selectBestFeature
      * Selects the feature from an array of features that is the best match
-     *     for the click position.
+     *     for the click position. Points and Lines take precedence over the
+     *     Polygons.
      * 
      * Parameters:
      * features - {Array(<OpenLayers.Feature.Vector>)}
@@ -432,17 +433,36 @@ OpenLayers.Control.GetFeature = OpenLayers.Class(OpenLayers.Control, {
                 clickPosition.lat);
             var feature, resultFeature, dist;
             var minDist = Number.MAX_VALUE;
-            for(var i=0; i<features.length; ++i) {
+            var i;
+            var areas = [];
+            // treat (multi)polygons separately
+            for(i=features.length-1; i>=0; i--) {
                 feature = features[i];
+                if(feature.geometry instanceof OpenLayers.Geometry.Polygon ||
+                   feature.geometry instanceof OpenLayers.Geometry.MultiPolygon) {
+                    areas.push(features.pop());
+                }
+            }
+            var compare = function(feature) {
                 if(feature.geometry) {
                     dist = point.distanceTo(feature.geometry, {edge: false});
                     if(dist < minDist) {
                         minDist = dist;
                         resultFeature = feature;
-                        if(minDist == 0) {
-                            break;
-                        }
                     }
+                }
+            };
+            if (features.length) {
+                // points or linestring take precedence to any polygon
+                for(i=0; i<features.length; ++i) {
+                    feature = features[i];
+                    compare(feature);
+                }
+            } else {
+                areas.reverse();
+                for(i=0; i<areas.length; ++i) {
+                    feature = areas[i];
+                    compare(feature);
                 }
             }
             

--- a/tests/Control/GetFeature.html
+++ b/tests/Control/GetFeature.html
@@ -169,6 +169,28 @@
         control.events.unregister("outfeature", this, outTest);
     }
     
+    function test_Control_GetFeature_selectBestFeature(t) {
+        t.plan(1);
+
+        var point = new OpenLayers.Feature.Vector(
+            new OpenLayers.Geometry.Point(10, 10)
+        );
+        var polygon = new OpenLayers.Feature.Vector(
+            new OpenLayers.Geometry.Polygon(new OpenLayers.Geometry.LinearRing([
+                new OpenLayers.Geometry.Point(0, 0),
+                new OpenLayers.Geometry.Point(20, 0),
+                new OpenLayers.Geometry.Point(20, 20),
+                new OpenLayers.Geometry.Point(0, 20),
+                new OpenLayers.Geometry.Point(0, 0)
+            ]))
+        );
+        var control = new OpenLayers.Control.GetFeature({
+            select: function(feature) {
+                t.ok(feature == point, "point correctly takes precedence");
+            }
+        });
+        control.selectBestFeature([point, polygon], new OpenLayers.LonLat(9, 9));
+    }
     </script>
 </head>
 <body>


### PR DESCRIPTION
...ting the best matching feature

Let's imagine a user querying a server to get features at a given location. If there is a point as well as a polygon there, we can consider that the user is actually requesting info about the point. With the previous code, it was almost impossible to get info for the point because of the distance comparison.
With this patch, if a point or a linestring is found in the response, it is considered to match better than any polygone.

Please review.
