### PR TITLE
Util.html test fail with Chrome and Chromium

### DIFF
--- a/tests/Util.html
+++ b/tests/Util.html
@@ -507,9 +507,8 @@
 
         t.eq(element.style.opacity, '', 
              "element.style.opacity is removed when opacity = " + opacity);
-        //Safari 3 returns null for this value, which is okay
-        var filterString = (OpenLayers.BROWSER_NAME == 'safari') ? null : '';
-        t.eq(element.style.filter, filterString, 
+        // Some browser returns null instead of '', which is okay
+        t.ok(element.style.filter == '' || element.style.filter == null,
              "element.style.filter is removed when opacity = " + opacity);
     }
 


### PR DESCRIPTION
Using Google Chrome version 20.0.1096.1 dev or Chromium 18.0.1025.15, test_Util_modifyDOMElement_opacity fail.

We have:

``` javascript
//Safari 3 returns null for this value, which is okay
var filterString = (OpenLayers.BROWSER_NAME == 'safari') ? null : '';
t.eq(element.style.filter, filterString, 
     "element.style.filter is removed when opacity = " + opacity);
```

But the browser returns '' instead of null.
