### PR TITLE
Fix Map so zoomChanged when zoom is constructor option

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -662,6 +662,7 @@ OpenLayers.Map = OpenLayers.Class({
              * be properly set below.
              */
             delete this.center;
+            delete this.zoom;
             this.addLayers(options.layers);
             // set center (and optionally zoom)
             if (options.center && !this.getCenter()) {


### PR DESCRIPTION
I access servers where the parameters depend on the zoomlevel/resolution. I use zoomChanged in moveTo to control this, which works fine when initial zoom is set by setCenter(), but doesn't work when zoom is passed as a constructor option. This is because of a similar problem to that with center: the options are set on the map object, so when the logic checks if the zoom has changed it compares two identical properties. You could fix this by passing forceZoomChange, but I delete this.zoom to make it consistent with center.
