### PR TITLE
Canvas Renderer: cacheExternalGraphic style for memory caching Images

### DIFF
--- a/examples/canvas-image-cache.html
+++ b/examples/canvas-image-cache.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>OpenLayers Canvas Hit Detection Example</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <link rel="stylesheet" href="../theme/default/style.css" type="text/css">
+        <link rel="stylesheet" href="style.css" type="text/css">
+        <script src="../lib/OpenLayers.js"></script>
+    </head>
+    <body>
+        <h1 id="title">Image Cache with Canvas</h1>
+        <p id="shortdesc">
+            Demonstrates the use of the cacheExternalGraphic style to avoid flickering on the Canvas Renderer.
+			The Left Image is always reloaded on redraw while the Right Image is cached.
+			After redrawing the map (after pan for example), the Left Image will always be above the right one.
+        </p>
+        <div id="map" class="smallmap" style="width:800px;height:600px"></div>
+        <div id="docs">
+            <p>
+                Click on the features above to see them selected.  This example 
+                uses the Canvas renderer so it only works on browsers where 
+                canvas is supported.
+            </p>
+            <p>
+                View the <a href="canvas-image-cache.js" target="_blank">canvas-hit-detection.js</a>
+                source to see how this is done.
+            </p>
+        </div>
+        <script src="canvas-image-cache.js"></script>
+    </body>
+</html>

--- a/examples/canvas-image-cache.js
+++ b/examples/canvas-image-cache.js
@@ -1,0 +1,68 @@
+
+// create some sample features
+var Feature = OpenLayers.Feature.Vector;
+var Geometry = OpenLayers.Geometry;
+var features = [
+    new Feature(
+        new Geometry.Point(-80, 0),
+        {cls: "one"}
+    ),
+    new Feature(
+        new Geometry.Point(80, 0),
+        {cls: "two"}
+    )  
+];
+
+// create rule based styles
+var Rule = OpenLayers.Rule;
+var Filter = OpenLayers.Filter;
+var style = new OpenLayers.Style({
+    pointRadius: 250,
+    strokeWidth: 3,
+    strokeOpacity: 0.7,
+    strokeColor: "navy",
+    fillColor: "#ffcc66",
+    fillOpacity: 1
+}, {
+    rules: [
+        new Rule({
+            filter: new Filter.Comparison({
+                type: "==",
+                property: "cls",
+                value: "one"
+            }),
+            symbolizer: {
+                externalGraphic: "img/widelong.jpg",
+                cacheExternalGraphic: false
+            }
+        }),
+        new Rule({
+            filter: new Filter.Comparison({
+                type: "==",
+                property: "cls",
+                value: "two"
+            }),
+            symbolizer: {
+                externalGraphic: "img/widelong.jpg",
+                cacheExternalGraphic: true
+            }
+        })
+    ]
+});
+
+var layer = new OpenLayers.Layer.Vector(null, {
+    styleMap: new OpenLayers.StyleMap({
+        "default": style
+    }),
+    isBaseLayer: true,
+    renderers: ["Canvas"]
+});
+layer.addFeatures(features);
+
+var map = new OpenLayers.Map({
+    div: "map",
+    layers: [layer],
+    center: new OpenLayers.LonLat(0, 0),
+    zoom: 1
+});
+

--- a/lib/OpenLayers/Renderer/Canvas.js
+++ b/lib/OpenLayers/Renderer/Canvas.js
@@ -8,6 +8,40 @@
  */
 
 /**
+ * Class OpenLayers.ImageCache
+ * Used for caching external Images to avoid flickering when rendered again
+ */
+OpenLayers.ImageCache = {
+    
+    imageHash: {},
+    
+    get: function(url) {
+        return this.imageHash[url];
+    },
+    request: function(url, callback, scope) {
+        scope = scope || this;
+        var cachedImage = this.imageHash[url];
+        
+        if(cachedImage) {
+            callback.call(scope,cachedImage);
+        } else {
+            var onLoad = function(img) {
+                this.imageHash[url] = img;
+                callback.call(scope,img);
+            }
+            this.load(url,onLoad,this);
+        }
+    },
+    load: function(url,callback,scope) {
+        var img = new Image();
+        img.onload = function() {
+            callback.call(scope,img);
+        }
+        img.src = url;
+    }
+};
+
+/**
  * Class: OpenLayers.Renderer.Canvas 
  * A renderer based on the 2D 'canvas' drawing element.
  * 
@@ -239,11 +273,6 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
      * featureId - {String}
      */ 
     drawExternalGraphic: function(geometry, style, featureId) {
-        var img = new Image();
-
-        if (style.graphicTitle) {
-            img.title = style.graphicTitle;           
-        }
 
         var width = style.graphicWidth || style.graphicHeight;
         var height = style.graphicHeight || style.graphicWidth;
@@ -256,9 +285,16 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
 
         var opacity = style.graphicOpacity || style.fillOpacity;
         
-        var onLoad = function() {
+        var title = style.graphicTitle;
+        
+        var cacheGraphic = style.cacheExternalGraphic===true ? true : false;
+        
+        var onLoad = function(img) {
             if(!this.features[featureId]) {
                 return;
+            }
+            if(title) {
+                img.title = title;
             }
             var pt = this.getLocalXY(geometry);
             var p0 = pt[0];
@@ -284,9 +320,11 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
                 }
             }
         };
-
-        img.onload = OpenLayers.Function.bind(onLoad, this);
-        img.src = style.externalGraphic;
+        if(cacheGraphic) {
+            OpenLayers.ImageCache.request(style.externalGraphic,onLoad,this);
+        } else {
+            OpenLayers.ImageCache.load(style.externalGraphic,onLoad,this);
+        }
     },
 
     /**


### PR DESCRIPTION
Hello,

this pull request is for the trac issue #3266 (http://trac.osgeo.org/openlayers/ticket/3266).
It will enable Memory Image Caching for features specifying the cacheExternalGraphic style attribute in the Canvas Renderer.
This is my first patch, so i'm not sure if i met all coding Guidelines.
It would be nice if you review this patch.

kind regards
Martin
