### PR TITLE
Feature change on drag of features with parent geometry

### DIFF
--- a/lib/OpenLayers/Control/ModifyFeature.js
+++ b/lib/OpenLayers/Control/ModifyFeature.js
@@ -427,7 +427,8 @@ OpenLayers.Control.ModifyFeature = OpenLayers.Class(OpenLayers.Control, {
      */
     dragStart: function(feature, pixel) {
         // only change behavior if the feature is not in the vertices array
-        if(feature != this.feature && !feature.geometry.parent &&
+        if(feature != this.feature && (feature.geometry.parent ?
+		   feature.geometry.parent != this.feature.geometry.parent : true) &&
            feature != this.dragHandle && feature != this.radiusHandle) {
             if(this.standalone === false && this.feature) {
                 // unselect the currently selected feature


### PR DESCRIPTION
There is a line, as feature, and the start point and end point of this line that are also a features, so we can apply externalGraphics to them. "Point features" shares its geometry object with line "points".

There was an bug, when we tried to edit that kind of line with another line active, without explicit clickout or ModifyFeature deactivation. In this case, proper deselection (firing events, for example) of previous line wasn't made, and some strange bugs may occur.

And, sorry for my poor english. :)
