### PR TITLE
alwaysInRange not updated when using addOptions

### DIFF
--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -338,6 +338,11 @@ OpenLayers.Layer = OpenLayers.Class({
 
         this.metadata = {};
         
+        options = OpenLayers.Util.extend({}, options);
+        // make sure we respect alwaysInRange if set on the prototype
+        if (this.alwaysInRange != null) {
+            options.alwaysInRange = this.alwaysInRange;
+        }
         this.addOptions(options);
 
         this.name = name;
@@ -858,7 +863,7 @@ OpenLayers.Layer = OpenLayers.Class({
                 alwaysInRange = false;
             }
         }
-        if(this.alwaysInRange == null) {
+        if(this.options.alwaysInRange == null) {
             this.alwaysInRange = alwaysInRange;
         }
 

--- a/tests/Layer.html
+++ b/tests/Layer.html
@@ -174,6 +174,16 @@
         t.eq(log, 0, "addOptions doesn't call initResolutions when layer is not in map");
     }
     
+    function test_addOptionsScale(t) {
+        t.plan(1);
+        var map = new OpenLayers.Map("map");
+        var layer = new OpenLayers.Layer.WMS();
+        map.addLayer(layer);
+        map.zoomToMaxExtent();
+        layer.addOptions({maxResolution: 0.5, numZoomLevels: 15});
+        t.eq(layer.alwaysInRange, false, "alwaysInRange should not be true anymore");
+    }
+    
     function test_Layer_StandardOptionsAccessors (t) {
 
         t.plan( 4 );


### PR DESCRIPTION
test case which currently fails:

```
var map = new OpenLayers.Map("map");
var layer = new OpenLayers.Layer.WMS();
map.addLayer(layer);
map.zoomToMaxExtent();
layer.addOptions({minScale: 50000});
```

layer.alwaysInRange will still be true, but it should not be.
