### PR TITLE
Control click behaviour of the ZoomBox Control via API Property

### DIFF
--- a/lib/OpenLayers/Control/ZoomBox.js
+++ b/lib/OpenLayers/Control/ZoomBox.js
@@ -29,6 +29,12 @@ OpenLayers.Control.ZoomBox = OpenLayers.Class(OpenLayers.Control, {
      * {Boolean} Should the control be used for zooming out?
      */
     out: false,
+    /**
+     * Property: zoomOnClick
+     * {Boolean} Should the control zoom if the user just clicked and didn't
+     * draw a box?
+     */
+    zoomOnClick: true,
 
     /**
      * APIProperty: keyMask
@@ -93,7 +99,7 @@ OpenLayers.Control.ZoomBox = OpenLayers.Class(OpenLayers.Control, {
             if (lastZoom == this.map.getZoom() && this.alwaysZoom == true){ 
                 this.map.zoomTo(lastZoom + (this.out ? -1 : 1)); 
             }
-        } else { // it's a pixel
+        } else if (this.zoomOnClick){ // it's a pixel
             if (!this.out) {
                 this.map.setCenter(this.map.getLonLatFromPixel(position),
                                this.map.getZoom() + 1);


### PR DESCRIPTION
Currently, a simple click in the map triggers a zoom when the ZoomBox control is active. This can be quite confusing for map users. The newly introduced `zoomOnClick` property lets the developer decide if the map zoom should happen on click or just when an extent rectangle has been drawn. 
