### PR TITLE
Make sure tiles are loaded for Bing overlays.

### DIFF
--- a/lib/OpenLayers/Layer/Bing.js
+++ b/lib/OpenLayers/Layer/Bing.js
@@ -176,6 +176,18 @@ OpenLayers.Layer.Bing = OpenLayers.Class(OpenLayers.Layer.XYZ, {
                 res.zoomMax + 1 - res.zoomMin, this.numZoomLevels
             )
         }, true);
+        this.updateAttribution();
+    },
+
+    /**
+     * Method: drawTileFromQueue
+     * Draws the first tile from the tileQueue, and unqueues that tile
+     */
+    drawTileFromQueue: function() {
+        // don't start working on the queue before we have a url from initLayer
+        if (this.url) {
+            OpenLayers.Layer.XYZ.prototype.drawTileFromQueue.apply(this, arguments);
+        }
     },
 
     /**
@@ -185,9 +197,6 @@ OpenLayers.Layer.Bing = OpenLayers.Class(OpenLayers.Layer.XYZ, {
      * bounds - {<OpenLayers.Bounds>}
      */
     getURL: function(bounds) {
-        if (!this.url) {
-            return;
-        }
         var xyz = this.getXYZ(bounds), x = xyz.x, y = xyz.y, z = xyz.z;
         var quadDigits = [];
         for (var i = z; i > 0; --i) {
@@ -253,7 +262,6 @@ OpenLayers.Layer.Bing = OpenLayers.Class(OpenLayers.Layer.XYZ, {
      */
     setMap: function() {
         OpenLayers.Layer.XYZ.prototype.setMap.apply(this, arguments);
-        this.updateAttribution();
         this.map.events.register("moveend", this, this.updateAttribution);
     },
     

--- a/tests/Layer/Bing.html
+++ b/tests/Layer/Bing.html
@@ -1,5 +1,19 @@
 <html>
 <head>
+  <script>
+    /**
+    * Because browsers that implement requestAnimationFrame may not execute
+    * animation functions while a window is not displayed (e.g. in a hidden
+    * iframe as in these tests), we mask the native implementations here.  The
+    * native requestAnimationFrame functionality is tested in Util.html and
+    * in PanZoom.html (where a popup is opened before panning).
+    */
+    window.requestAnimationFrame = 
+        window.webkitRequestAnimationFrame =
+        window.mozRequestAnimationFrame =
+        window.oRequestAnimationFrame =
+        window.msRequestAnimationFrame = null;
+  </script>
   <script src="../OLLoader.js"></script>
   <script type="text/javascript">
     var map, layer; 
@@ -79,6 +93,26 @@
             t.eq(extent2.toBBOX(), map2.getExtent().toBBOX(), "layer extent correct for base layer with zoomMin == 2.");
             map2.destroy();
             OpenLayers.Layer.Bing.processMetadata = origProcessMetadata;
+        });
+    }
+    
+    function test_initLayer_notempty(t) {
+        t.plan(1);
+        
+        map = new OpenLayers.Map("map", {
+            projection: "EPSG:3857",
+            layers: [new OpenLayers.Layer("dummy", {isBaseLayer: true})]
+        });
+        map.zoomToExtent([-14768652, 4492113, -12263964, 5744457]);
+        var layer = new OpenLayers.Layer.Bing(OpenLayers.Util.extend({
+            isBaseLayer: false
+        }, options));
+        map.addLayer(layer);
+        var tile = layer.tileQueue[0];
+        
+        t.delay_call(5, function() {
+            t.ok(tile.url, "Tile not empty");
+            map.destroy();
         });
     }
     


### PR DESCRIPTION
Previously, Bing overlays that were added to an existing map had empty tiles, because tiles are added before the layer url is set in initLayer. This change makes sure tiles are only rendered when the layer url is available, by not processing the tile queue before the layer url is set.
