### PR TITLE
Incorrect Bing attribution when custom maxResolution is set

### DIFF
--- a/lib/OpenLayers/Layer/Bing.js
+++ b/lib/OpenLayers/Layer/Bing.js
@@ -223,7 +223,8 @@ OpenLayers.Layer.Bing = OpenLayers.Class(OpenLayers.Layer.XYZ, {
             this.map.getProjectionObject(),
             new OpenLayers.Projection("EPSG:4326")
         );
-        var providers = res.imageryProviders, zoom = this.map.getZoom() + 1,
+        var providers = res.imageryProviders,
+            zoom = this.serverResolutions.indexOf(this.getServerResolution()),
             copyrights = "", provider, i, ii, j, jj, bbox, coverage;
         for (i=0,ii=providers.length; i<ii; ++i) {
             provider = providers[i];


### PR DESCRIPTION
The previous way of hard-coding an offset of 1 causes an incorrect attribution for layers with a custom maxResolution. This is related to #418.

The issue can easily be seen when comparing the attribution of http://openlayers.org/dev/examples/bing-tiles-restrictedzoom.html with http://openlayers.org/dev/examples/bing-tiles.html.
