### PR TITLE
Comparason type like with null (property not present)

### DIFF
--- a/lib/OpenLayers/Filter/Comparison.js
+++ b/lib/OpenLayers/Filter/Comparison.js
@@ -151,8 +151,13 @@ OpenLayers.Filter.Comparison = OpenLayers.Class(OpenLayers.Filter, {
                     (got <= this.upperBoundary);
                 break;
             case OpenLayers.Filter.Comparison.LIKE:
-                var regexp = new RegExp(this.value, "gi");
-                result = regexp.test(got);
+                if (got) {
+                    var regexp = new RegExp(this.value, "gi");
+                    result = regexp.test(got);
+                }
+                else {
+                    result = false;
+                }
                 break;
         }
         return result;

--- a/tests/Filter/Comparison.html
+++ b/tests/Filter/Comparison.html
@@ -275,7 +275,130 @@
             context: new OpenLayers.Feature.Vector(null, {prop: "FOO"}),
             expect: false
         }];
+        t.plan(cases.length);
+
+        var c;
+        for(var i=0; i<cases.length; ++i) {
+            c = cases[i];
+            t.eq(c.filter.evaluate(c.context), c.expect, "case " + i + ": " + c.filter.type);
+        }
+    }        
+
+    function test_evaluate_with_null(t) {
         
+        var cases = [{
+            filter: new OpenLayers.Filter.Comparison({
+                type: OpenLayers.Filter.Comparison.EQUAL_TO,
+                property: "prop",
+                value: "foo"
+            }),
+            context: new OpenLayers.Feature.Vector(null, {}),
+            expect: false
+        }, {
+            filter: new OpenLayers.Filter.Comparison({
+                type: OpenLayers.Filter.Comparison.NOT_EQUAL_TO,
+                property: "prop",
+                value: "foo"
+            }),
+            context: new OpenLayers.Feature.Vector(null, {}),
+            expect: true
+        }, {
+            filter: new OpenLayers.Filter.Comparison({
+                type: OpenLayers.Filter.Comparison.LESS_THAN,
+                property: "prop",
+                value: "foo"
+            }),
+            context: new OpenLayers.Feature.Vector(null, {}),
+            expect: false
+        }, {
+            filter: new OpenLayers.Filter.Comparison({
+                type: OpenLayers.Filter.Comparison.GREATER_THAN,
+                property: "prop",
+                value: "foo"
+            }),
+            context: new OpenLayers.Feature.Vector(null, {}),
+            expect: false
+        }, {
+            filter: new OpenLayers.Filter.Comparison({
+                type: OpenLayers.Filter.Comparison.LESS_THAN_OR_EQUAL_TO,
+                property: "prop",
+                value: "foo"
+            }),
+            context: new OpenLayers.Feature.Vector(null, {}),
+            expect: false
+        }, {
+            filter: new OpenLayers.Filter.Comparison({
+                type: OpenLayers.Filter.Comparison.GREATER_THAN_OR_EQUAL_TO,
+                property: "prop",
+                value: "foo"
+            }),
+            context: new OpenLayers.Feature.Vector(null, {}),
+            expect: false
+        }, {
+            filter: new OpenLayers.Filter.Comparison({
+                type: OpenLayers.Filter.Comparison.BETWEEN,
+                property: "prop",
+                value: "foo"
+            }),
+            context: new OpenLayers.Feature.Vector(null, {}),
+            expect: false
+        }, {
+            filter: new OpenLayers.Filter.Comparison({
+                type: OpenLayers.Filter.Comparison.LIKE,
+                property: "prop",
+                value: "foo"
+            }),
+            context: new OpenLayers.Feature.Vector(null, {}),
+            expect: false
+        }, {
+            filter: new OpenLayers.Filter.Comparison({
+                type: OpenLayers.Filter.Comparison.NOT_EQUAL_TO,
+                property: "prop",
+                value: null
+            }),
+            context: new OpenLayers.Feature.Vector(null, {}),
+            expect: false
+        }, {
+            filter: new OpenLayers.Filter.Comparison({
+                type: OpenLayers.Filter.Comparison.EQUAL_TO,
+                property: "prop",
+                value: null
+            }),
+            context: new OpenLayers.Feature.Vector(null, {}),
+            expect: true
+        }, {
+            filter: new OpenLayers.Filter.Comparison({
+                type: OpenLayers.Filter.Comparison.NOT_EQUAL_TO,
+                property: "prop",
+                value: null
+            }),
+            context: new OpenLayers.Feature.Vector(null, {prop: "FOO"}),
+            expect: true
+        }, {
+            filter: new OpenLayers.Filter.Comparison({
+                type: OpenLayers.Filter.Comparison.EQUAL_TO,
+                property: "prop",
+                value: null
+            }),
+            context: new OpenLayers.Feature.Vector(null, {prop: "FOO"}),
+            expect: false
+        }, {
+            filter: new OpenLayers.Filter.Comparison({
+                type: OpenLayers.Filter.Comparison.LIKE,
+                property: "prop",
+                value: '.+'
+            }),
+            context: new OpenLayers.Feature.Vector(null, {prop: "FOO"}),
+            expect: true
+        }, {
+            filter: new OpenLayers.Filter.Comparison({
+                type: OpenLayers.Filter.Comparison.LIKE,
+                property: "prop",
+                value: '.+'
+            }),
+            context: new OpenLayers.Feature.Vector(null, {}),
+            expect: false
+        }];
         t.plan(cases.length);
 
         var c;


### PR DESCRIPTION
This is an application of the patch from sbrunner on trak ticket #2938

"For example with OSM format all the property will not be always present. And if we test an non existing property "LIKE" '.+' (at lease one char) for example it returns true and should be false ..."

Test were applied and passed. The only tests that did not succeed were tests that already failed.
