### PR TITLE
Mark context property as part of API

### DIFF
--- a/lib/OpenLayers/Style.js
+++ b/lib/OpenLayers/Style.js
@@ -61,7 +61,7 @@ OpenLayers.Style = OpenLayers.Class({
     rules: null,
     
     /**
-     * Property: context
+     * APIProperty: context
      * {Object} An optional object with properties that symbolizers' property
      * values should be evaluated against. If no context is specified,
      * feature.attributes will be used


### PR DESCRIPTION
It's very useful and is used in examples (at least strategy-cluster-threshold)
