### PR TITLE
Stay on the world when transforming coords.

### DIFF
--- a/lib/OpenLayers/Projection.js
+++ b/lib/OpenLayers/Projection.js
@@ -287,7 +287,8 @@ OpenLayers.Projection.nullTransform = function(point) {
 
     function forwardMercator(xy) {
         xy.x = xy.x * pole / 180;
-        xy.y = Math.log(Math.tan((90 + xy.y) * Math.PI / 360)) / Math.PI * pole;
+        var y = Math.log(Math.tan((90 + xy.y) * Math.PI / 360)) / Math.PI * pole;
+        xy.y = Math.max(-20037508.34, Math.min(y, 20037508.34));
         return xy;
     }
 

--- a/tests/Layer/SphericalMercator.html
+++ b/tests/Layer/SphericalMercator.html
@@ -23,11 +23,11 @@
         t.eq(Math.round(phillipines.lat), 0, "Phillipines lat is correct");
         t.eq(phillipines.lon, 20037508.340, "Phillipines lon is correct");
        
-        // Rounding errors make this not infinity 
-        t.ok(ne.lat > 50000000, "NE lat is correct");
+        // be kind and stay within the world instead of having +/- infinity lat
+        t.ok(ne.lat, 20037508.34, "NE lat is correct");
         t.eq(ne.lon, 20037508.34, "NE lon is correct");
         
-        t.eq(sw.lat, -Infinity, "SW lat is correct");
+        t.eq(sw.lat, -20037508.34, "SW lat is correct");
         t.eq(sw.lon, -20037508.34, "SW lon is correct");
     } 
     


### PR DESCRIPTION
Instead of a transform that results in +/- Infinity northing, we can constrain the results to be within the world bounds.
