### PR TITLE
Add required OpenLayers.Filter deps to OpenLayers.Format.CQL

### DIFF
--- a/lib/OpenLayers/Format/CQL.js
+++ b/lib/OpenLayers/Format/CQL.js
@@ -5,6 +5,9 @@
 
 /**
  * @requires OpenLayers/Format/WKT.js
+ * @requires OpenLayers/Filter/Comparison.js
+ * @requires OpenLayers/Filter/Logical.js
+ * @requires OpenLayers/Filter/Spatial.js
  */
 
 /**


### PR DESCRIPTION
The CQL format depends on the Logical, Comparison, and Spatial filters. However, they are not included as dependencies and CQL format throws errors when these filters have not already been included by another component
