### PR TITLE
Remove "firebug" on the tests.cfg

### DIFF
--- a/build/tests.cfg
+++ b/build/tests.cfg
@@ -7,4 +7,5 @@
 [include]
 
 [exclude]
+Firebug
 OpenLayers.js


### PR DESCRIPTION
As discussed in [dev](http://osgeo-org.1560.n6.nabble.com/Why-quot-firebugx-js-quot-is-in-quot-OpenLayers-js-quot-compressed-code-td4694879.html), it is proposed to remove "firebug" on the "tests.cfg" because it is used to generate the compressed code "OpenLayers.js" (see [tools/update_dev_dir.sh](https://github.com/openlayers/openlayers/blob/master/tools/update_dev_dir.sh))
