### PR TITLE
fix for trac ticket # 3554 single-arg Map constructor does not work if you pass a DOM element ref

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -496,7 +496,10 @@ OpenLayers.Map = OpenLayers.Class({
     initialize: function (div, options) {
         
         // If only one argument is provided, check if it is an object.
-        if(arguments.length === 1 && typeof div === "object") {
+        var isDOMElement = window.HTMLElement ?
+            div instanceof HTMLElement :
+            div.hasOwnProperty("nodeType");
+        if(arguments.length === 1 && typeof div === "object" && !isDOMElement) {
             options = div;
             div = options && options.div;
         }

--- a/tests/Map.html
+++ b/tests/Map.html
@@ -130,6 +130,22 @@
         map.destroy();
     }
 
+    function test_Map_constructor_renderTo_DOM_element_ref(t) {
+        t.plan( 1 );
+
+        var map_div = document.getElementById('map');
+        map = new OpenLayers.Map(map_div); 
+        var baseLayer = new OpenLayers.Layer.WMS("Test Layer", 
+            "http://octo.metacarta.com/cgi-bin/mapserv?",
+            {map: "/mapdata/vmap_wms.map", layers: "basic"});
+        map.addLayer(baseLayer);
+        
+        var mapDiv = document.getElementById("map");
+        t.ok(map.div == mapDiv, "Map is rendered to the 'map' div.")
+        
+        map.destroy();
+    }
+
     function test_Map_setOptions(t) {
         t.plan(2);
         map = new OpenLayers.Map('map', {maxExtent: new OpenLayers.Bounds(100, 200, 300, 400)});


### PR DESCRIPTION
(Sorry, I messed up the original pull request. This is a copy with the amendment suggested by elemoine)

Here is the text of the original ticket at http://trac.osgeo.org/openlayers/ticket/3554

The docs for OpenLayers.Map indicate that you can pass a DOM element into the single-arg constructor. You can verify that it doesn't work with:

``` html
<html>
    <body>
    <div id="mapdiv"></div>

    <script src="http://www.openlayers.org/api/OpenLayers.js"></script>

    <script type="text/javascript">
        function Map(element) {
            var map = new OpenLayers.Map(element);
            map.addLayer(new OpenLayers.Layer.OSM());
            map.zoomToMaxExtent();
        }

        var mapContainer = document.getElementById('mapdiv');
        var map = new Map(mapContainer);
    </script>
    </body>
</html>
```

You can workaround this problem, by replacing the last line above with:

```
var map = new Map({div: mapContainer});
```

I have written a test that replicates the bug and applied the patch at:

http://trac.osgeo.org/openlayers/attachment/ticket/3554/openlayers-3554.patch

For any original code that I have added, I am the author/copyright holder of this code and am dedicating it to the public domain under the terms at http://creativecommons.org/publicdomain/zero/1.0/.
