### PR TITLE
Fix github issue 267, GPX: handling of desc attribute.

### DIFF
--- a/lib/OpenLayers/Format/GPX.js
+++ b/lib/OpenLayers/Format/GPX.js
@@ -376,7 +376,7 @@ OpenLayers.Format.GPX = OpenLayers.Class(OpenLayers.Format.XML, {
         node.appendChild(name);
         var desc = this.createElementNSPlus('gpx:desc');
         desc.appendChild(this.createTextNode(
-            feature.attributes.description || this.defaultDesc));
+            feature.attributes.description || feature.attributes.desc || this.defaultDesc));
         node.appendChild(desc);
         // TBD - deal with remaining (non name/description) attributes.
     },

--- a/tests/Format/GPX.html
+++ b/tests/Format/GPX.html
@@ -3,7 +3,7 @@
     <script src="../OLLoader.js"></script>
     <script type="text/javascript">
     
-    var gpx_data = '<?xml version="1.0" encoding="ISO-8859-1"?><gpx version="1.1" creator="Memory-Map 5.1.3.715 http://www.memory-map.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"><wpt lat="51.3697845627" lon="-0.1853562259"><name>Mark</name><sym><![CDATA[Flag]]></sym><type><![CDATA[Marks]]></type></wpt><rte><name><![CDATA[Route8]]></name><type><![CDATA[Route]]></type><rtept lat="51.3761803674" lon="-0.1829991904"><name><![CDATA[WP0801]]></name><sym><![CDATA[Dot]]></sym><type><![CDATA[Waypoints]]></type></rtept><rtept lat="51.3697894659" lon="-0.1758887005"><name><![CDATA[WP0802]]></name><sym><![CDATA[Dot]]></sym><type><![CDATA[Waypoints]]></type></rtept><rtept lat="51.3639790884" lon="-0.1833202965"><name><![CDATA[WP0803]]></name><sym><![CDATA[Dot]]></sym><type><![CDATA[Waypoints]]></type></rtept><rtept lat="51.3567607069" lon="-0.1751119509"><name><![CDATA[WP0804]]></name><sym><![CDATA[Dot]]></sym><type><![CDATA[Waypoints]]></type></rtept></rte><trk><name><![CDATA[Track]]></name><type><![CDATA[Track]]></type><trkseg><trkpt lat="51.3768216433" lon="-0.1721292044"></trkpt><trkpt lat="51.3708337670" lon="-0.1649230916"></trkpt><trkpt lat="51.3644368725" lon="-0.1736741378"></trkpt><trkpt lat="51.3576354272" lon="-0.1662595250"></trkpt></trkseg></trk></gpx>';
+    var gpx_data = '<?xml version="1.0" encoding="ISO-8859-1"?><gpx version="1.1" creator="Memory-Map 5.1.3.715 http://www.memory-map.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"><wpt lat="51.3697845627" lon="-0.1853562259"><name>Mark</name><desc>A waypoint</desc><sym><![CDATA[Flag]]></sym><type><![CDATA[Marks]]></type></wpt><rte><name><![CDATA[Route8]]></name><desc>A route</desc><type><![CDATA[Route]]></type><rtept lat="51.3761803674" lon="-0.1829991904"><name><![CDATA[WP0801]]></name><desc>Some waypoints</desc><sym><![CDATA[Dot]]></sym><type><![CDATA[Waypoints]]></type></rtept><rtept lat="51.3697894659" lon="-0.1758887005"><name><![CDATA[WP0802]]></name><desc>More waypoints</desc><sym><![CDATA[Dot]]></sym><type><![CDATA[Waypoints]]></type></rtept><rtept lat="51.3639790884" lon="-0.1833202965"><name><![CDATA[WP0803]]></name><desc>Even more waypoints</desc><sym><![CDATA[Dot]]></sym><type><![CDATA[Waypoints]]></type></rtept><rtept lat="51.3567607069" lon="-0.1751119509"><name><![CDATA[WP0804]]></name><desc>The final run of waypoints</desc><sym><![CDATA[Dot]]></sym><type><![CDATA[Waypoints]]></type></rtept></rte><trk><name><![CDATA[Track]]></name><desc>A track</desc><type><![CDATA[Track]]></type><trkseg><trkpt lat="51.3768216433" lon="-0.1721292044"></trkpt><trkpt lat="51.3708337670" lon="-0.1649230916"></trkpt><trkpt lat="51.3644368725" lon="-0.1736741378"></trkpt><trkpt lat="51.3576354272" lon="-0.1662595250"></trkpt></trkseg></trk></gpx>';
     
     function test_Format_GPX_constructor(t) { 
         t.plan(5); 
@@ -113,6 +113,24 @@
         var data = parser.write([], {name: 'foo', desc: 'bar'});
         t.xml_eq(data, '<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OpenLayers" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><metadata><name>foo</name><desc>bar</desc></metadata></gpx>', 'GPX serializes metadata correctly');
     }
+    function test_Format_GPX_description_roundtrip(t) {
+        // especifically written to test for mismatch between <desc> element and .description attribute
+        // as seen in github issue https://github.com/openlayers/openlayers/issues/267
+        t.plan(2);
+
+        var parser = new OpenLayers.Format.GPX();
+        var features = parser.read(gpx_data);
+
+        features[2].attributes['description'] = "A waypoint, but different"
+        var re_gpx_data = parser.write(features);
+        var re_features = parser.read(re_gpx_data);
+
+        // this tests the fix for issue 267
+        t.eq(re_features[1].attributes['desc'], features[1].attributes['desc'], "GPX <desc> xml element roundtrip to .desc js attribute, back to xml, and back to js successful");
+        // this tests for regressions against previous behaviour
+        t.eq(re_features[2].attributes['desc'], features[2].attributes['description'], "GPX exports the .description attribute to a <desc> xml node, and it gets correctly imported into a .desc attribute");
+    }
+
     </script> 
 </head> 
 <body> 


### PR DESCRIPTION
Fixes: https://github.com/openlayers/openlayers/issues/267

Original description of the issue:

> In a GPX file, the description element is called 'desc', and the Format read creates a feature attribute 'desc'. However, write() looks for feature.attributes.description, which of course doesn't exist. The tests are also converting feature.attributes.description to desc, so it seems this is deliberate. Is this to make it compatible with KML? If so, it would surely be better to look for feature.attributes.desc and feature.attributes.description.

This fix includes a roundtrip test: an xml <desc> is properly read into an attribute .desc, and then properly written into a <desc> node, and then read into an attribute .desc again.

A second test checks that an explicity written .description attribute will be properly written to a <desc> node, as was the previous behaviour, in order to avoid breaking existing code.

I am the author/copyright holder of this code and am dedicating it to the public domain under the terms at http://creativecommons.org/publicdomain/zero/1.0/.
