### PR TITLE
Issues with window resize in IE9 for OL 2.12RC2

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -580,8 +580,8 @@ OpenLayers.Map = OpenLayers.Class({
  
         // Because Mozilla does not support the "resize" event for elements 
         // other than "window", we need to put a hack here. 
-        if (OpenLayers.String.contains(navigator.appName, "Microsoft")) {
-            // If IE, register the resize on the div
+        if (parseFloat(navigator.appVersion.split("MSIE")[1]) < 9) {
+            // If IE < 9, register the resize on the div
             this.events.register("resize", this, this.updateSize);
         } else {
             // Else updateSize on catching the window's resize


### PR DESCRIPTION
We are having issues in IE9 with window resize.  Specifically, in all other browsers we have been testing (earlier IE, FF, etc) when the window is being resized the map dynamically moves and updates, keeping the original center point in the center of the new larger/smaller window.  In IE9 the map does not dynamically update (i.e. the center of the map is not maintained) in either 2.11 or 2.12RC2.  Even worse, in IE9 and OL 2.12RC2 when the user starts to pan after a window resize, the google base layer "hops" and presents a shift in relation to the overlays (vector layers, wms layers etc).

I have 2 simple full screen test cases (one for 2.11 and one with 2.12RC2) up and web accessible that have google base maps and a single "Dot" vector layer at 0,0:

[http://dev.noaaerma.org/ol211/](http://dev.noaaerma.org/ol211/)

[http://dev.noaaerma.org/ol212/](http://dev.noaaerma.org/ol212/)

I have also taken snapshots of the behavior on an Win7 VM with IE9.  Specifically images before and after a window resize and very small pan action to trigger the behavior.  Again, this is tested in both 2.11 and 2.12RC2.  

[OL 2.11 - Before Resize](http://www.flickr.com/photos/racicot/7136700899/)

[OL 2.11 - After Resize and small Pan](http://www.flickr.com/photos/racicot/7136699471/)

[OL 2.12 - Before Resize](http://www.flickr.com/photos/racicot/7136700223/)

[OL 2.12 - After Resize and small Pan](http://www.flickr.com/photos/racicot/7136699067/)

So, even though the dynamic moving of the map during a window resize is missing in both cases (which seems to be a problem in itself, i.e. the center point does not dynamically stay in the middle of the map) the 2.11 case does not cause a big jump in the google base map and the shift in relation to the vector layers like in 2.12 RC2.

Thoughts on these two issues?
