### PR TITLE
There is no reason to restrict graphicTitle to externalGraphic symbols.

### DIFF
--- a/examples/vector-features.html
+++ b/examples/vector-features.html
@@ -49,7 +49,8 @@
                 strokeWidth: 3,
                 strokeDashstyle: "dashdot",
                 pointRadius: 6,
-                pointerEvents: "visiblePainted"
+                pointerEvents: "visiblePainted",
+                title: "this is a green line"
             };
 
             /*
@@ -70,8 +71,8 @@
             style_mark.graphicXOffset = 10; // default is -(style_mark.graphicWidth/2);
             style_mark.graphicYOffset = -style_mark.graphicHeight;
             style_mark.externalGraphic = "../img/marker.png";
-            // graphicTitle only works in Firefox and Internet Explorer
-            style_mark.graphicTitle = "this is a test tooltip";
+            // title only works in Firefox and Internet Explorer
+            style_mark.title = "this is a test tooltip";
 
             var vectorLayer = new OpenLayers.Layer.Vector("Simple Geometry", {
                 style: layer_style,

--- a/lib/OpenLayers/Feature/Vector.js
+++ b/lib/OpenLayers/Feature/Vector.js
@@ -403,7 +403,8 @@ OpenLayers.Feature.Vector = OpenLayers.Class(OpenLayers.Feature, {
  * graphicZIndex - {Number} The integer z-index value to use in rendering.
  * graphicName - {String} Named graphic to use when rendering points.  Supported values include "circle" (default),
  *     "square", "star", "x", "cross", "triangle".
- * graphicTitle - {String} Tooltip when hovering over a feature. Not supported by the canvas renderer.
+ * graphicTitle - {String} Tooltip when hovering over a feature. *deprecated*, use title instead
+ * title - {String} Tooltip when hovering over a feature. Not supported by the canvas renderer.
  * backgroundGraphic - {String} Url to a graphic to be used as the background under an externalGraphic.
  * backgroundGraphicZIndex - {Number} The integer z-index value to use in rendering the background graphic.
  * backgroundXOffset - {Number} The x offset (in pixels) for the background graphic.

--- a/lib/OpenLayers/Renderer/Canvas.js
+++ b/lib/OpenLayers/Renderer/Canvas.js
@@ -241,8 +241,9 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
     drawExternalGraphic: function(geometry, style, featureId) {
         var img = new Image();
 
-        if (style.graphicTitle) {
-            img.title = style.graphicTitle;           
+        var title = style.title || style.graphicTitle;        
+        if (title) {
+            img.title = title;           
         }
 
         var width = style.graphicWidth || style.graphicHeight;

--- a/lib/OpenLayers/Renderer/SVG.js
+++ b/lib/OpenLayers/Renderer/SVG.js
@@ -240,16 +240,17 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         style = style  || node._style;
         options = options || node._options;
 
-        if (style.graphicTitle) {
-            node.setAttributeNS(null, "title", style.graphicTitle);
+        var title = style.title || style.graphicTitle;
+        if (title) {
+            node.setAttributeNS(null, "title", title);
             //Standards-conformant SVG
             // Prevent duplicate nodes. See issue https://github.com/openlayers/openlayers/issues/92 
             var titleNode = node.getElementsByTagName("title");
             if (titleNode.length > 0) {
-                titleNode[0].firstChild.textContent = style.graphicTitle;
+                titleNode[0].firstChild.textContent = title;
             } else {
                 var label = this.nodeFactory(null, "title");
-                label.textContent = style.graphicTitle;
+                label.textContent = title;
                 node.appendChild(label);
             }
         }

--- a/lib/OpenLayers/Renderer/VML.js
+++ b/lib/OpenLayers/Renderer/VML.js
@@ -207,8 +207,9 @@ OpenLayers.Renderer.VML = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         options = options || node._options;
         var fillColor = style.fillColor;
 
-        if (style.graphicTitle) {
-            node.title=style.graphicTitle;
+        var title = style.title || style.graphicTitle;
+        if (title) {
+            node.title = title;
         } 
 
         if (node._geometryClass === "OpenLayers.Geometry.Point") {


### PR DESCRIPTION
All I wanted was tooltips on polygons, and all I did was move the blocks that assign a graphicTitle to a place where they apply to all geometries. Tests still pass, examples work, and graphicTitle can now be used with any kind of geometry and symbol. Thanks for any review.
