### PR TITLE
Fixing issue of calculating maxResolution of layer again

### DIFF
--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -1010,7 +1010,7 @@ OpenLayers.Layer = OpenLayers.Class({
            this.maxExtent != null) {
             // maxResolution for default grid sets assumes that at zoom
             // level zero, the whole world fits on one tile.
-            var tileSize = this.tileSize || this.map.getTileSize();
+            var tileSize = this.map.getTileSize();
             maxResolution = Math.max(
                 this.maxExtent.getWidth() / tileSize.w,
                 this.maxExtent.getHeight() / tileSize.h


### PR DESCRIPTION
Fixing issue of calculating maxResolution of layer again, even if a valid one is provided. Done with @ahocevar while GeoExt2 Codesprint.
