### PR TITLE
all examples are broken

### DIFF
--- a/lib/OpenLayers/Request.js
+++ b/lib/OpenLayers/Request.js
@@ -20,7 +20,14 @@ OpenLayers.ProxyHost = "";
  *     with XMLHttpRequests.  These methods work with a cross-browser
  *     W3C compliant <OpenLayers.Request.XMLHttpRequest> class.
  */
-OpenLayers.Request = {
+if (!OpenLayers.Requst) {
+    /**
+     * This allows for OpenLayers/Request/XMLHttpRequest.js to be included
+     * before or after this script.
+     */
+    OpenLayers.Request = {};
+}
+OpenLayers.Util.extend(OpenLayers.Request, {
     
     /**
      * Constant: DEFAULT_CONFIG
@@ -420,4 +427,4 @@ OpenLayers.Request = {
         return OpenLayers.Request.issue(config);
     }
 
-};
+});

--- a/lib/OpenLayers/Request/XMLHttpRequest.js
+++ b/lib/OpenLayers/Request/XMLHttpRequest.js
@@ -447,5 +447,12 @@
      *     XMLHttpRequest object.  From
      *     http://code.google.com/p/xmlhttprequest/.
      */
+    if (!OpenLayers.Request) {
+        /**
+         * This allows for OpenLayers/Request.js to be included
+         * before or after this script.
+         */
+        OpenLayers.Request = {};
+    }
     OpenLayers.Request.XMLHttpRequest = cXMLHttpRequest;
 })();


### PR DESCRIPTION
http://openlayers.org/dev/examples/styles-context.html is broken in at least in Chrome 18...168 (and IE8) it's complaining about the XMLHttpRequest:

Uncaught TypeError: Cannot set property 'XMLHttpRequest' of undefined
OpenLayers.ProxyHost OpenLayers.js:506
(anonymous function) OpenLayers.js:506

styles-context.html:16 Uncaught TypeError: undefined is not a function
init styles-context.html:16
(anonymous function) styles-context.html:91
onload

which seems funny since it's just a wms layer + local features..
