### PR TITLE
Add style = "position: absolute;" on the SVG to skip the bug of Chrome 18

### DIFF
--- a/lib/OpenLayers/Renderer/SVG.js
+++ b/lib/OpenLayers/Renderer/SVG.js
@@ -446,7 +446,9 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
      * {DOMElement} The specific render engine's root element
      */
     createRenderRoot: function() {
-        return this.nodeFactory(this.container.id + "_svgRoot", "svg");
+        var svg = this.nodeFactory(this.container.id + "_svgRoot", "svg");
+        svg.style.position = "absolute";
+        return svg;
     },
 
     /**


### PR DESCRIPTION
See #392

All test ok on: FF 12.0; Chrome 18.0.1025.168 m; IE9; Safari 5.1.7 except "Layer/Google.html" since they are not used a proper key.

NOTE: Using Opera 11.60 fail some test, the same with or without patch, so no problem of the patch. (falis: Format/XML.html,  Format/KML.html, Format/WMTSCapabilities/v1_0_0.html, Format/WPSExecute.html:  Format/OWSCommon/v1_1_0.html, Format/ArcXML.html, Layer/Markers.html)

I tried it on several examples that use features: zoom-in, zoom-out, pan, modify, and of course reduce the size of the window on full screen. Everything seems ok.
