### PR TITLE
Use Util.indexOf in Layer.Bing

### DIFF
--- a/lib/OpenLayers/Layer/Bing.js
+++ b/lib/OpenLayers/Layer/Bing.js
@@ -224,7 +224,8 @@ OpenLayers.Layer.Bing = OpenLayers.Class(OpenLayers.Layer.XYZ, {
             new OpenLayers.Projection("EPSG:4326")
         );
         var providers = res.imageryProviders,
-            zoom = this.serverResolutions.indexOf(this.getServerResolution()),
+            zoom = OpenLayers.Util.indexOf(this.serverResolutions,
+                                           this.getServerResolution()),
             copyrights = "", provider, i, ii, j, jj, bbox, coverage;
         for (i=0,ii=providers.length; i<ii; ++i) {
             provider = providers[i];


### PR DESCRIPTION
It looks like 9ab6d08fb03bb60679bfc953591129c5fc145e2e has introduced a regression in IE 8. See http://trac.openlayers.org/ticket/3656.
