### PR TITLE
Fix Google terms/poweredby/popup

### DIFF
--- a/lib/OpenLayers/Layer/Google/v3.js
+++ b/lib/OpenLayers/Layer/Google/v3.js
@@ -137,27 +137,31 @@ OpenLayers.Layer.Google.v3 = {
         var cache = OpenLayers.Layer.Google.cache[this.map.id];
         var container = this.map.viewPortDiv;
         
-        // move the Map Data popup to the container, if any
-        while (div.lastChild.style.display == "none") {
-            container.appendChild(div.lastChild);
-        }
-
         // move the ToS and branding stuff up to the container div
-        var termsOfUse = div.lastChild;
-        container.appendChild(termsOfUse);
-        termsOfUse.style.zIndex = "1100";
-        termsOfUse.style.bottom = "";
-        termsOfUse.className = "olLayerGoogleCopyright olLayerGoogleV3";
-        termsOfUse.style.display = "";
-        cache.termsOfUse = termsOfUse;
-
-        var poweredBy = div.lastChild;
-        container.appendChild(poweredBy);
-        poweredBy.style.zIndex = "1100";
-        poweredBy.style.bottom = "";
-        poweredBy.className = "olLayerGooglePoweredBy olLayerGoogleV3 gmnoprint";
-        poweredBy.style.display = "";
-        cache.poweredBy = poweredBy;
+        // depends on value of zIndex, which is not robust
+        for (var i=div.children.length-1; i>=0; --i) {
+            if (div.children[i].style.zIndex == 1000001) {
+                var termsOfUse = div.children[i];
+                container.appendChild(termsOfUse);
+                termsOfUse.style.zIndex = "1100";
+                termsOfUse.style.bottom = "";
+                termsOfUse.className = "olLayerGoogleCopyright olLayerGoogleV3";
+                termsOfUse.style.display = "";
+                cache.termsOfUse = termsOfUse;
+            }
+            if (div.children[i].style.zIndex == 1000000) {
+                var poweredBy = div.children[i];
+                container.appendChild(poweredBy);
+                poweredBy.style.zIndex = "1100";
+                poweredBy.style.bottom = "";
+                poweredBy.className = "olLayerGooglePoweredBy olLayerGoogleV3 gmnoprint";
+                poweredBy.style.display = "";
+                cache.poweredBy = poweredBy;
+            }
+            if (div.children[i].style.zIndex == 10000002) {
+                container.appendChild(div.children[i]);
+            }
+        }
 
         this.setGMapVisibility(this.visibility);
 


### PR DESCRIPTION
Fix to bring Google/v3/repositionMapElements() in line with current Google setup.
This changes the logic so it no longer depends on the order of the child divs in Google's mapObject, but uses zIndex instead. This is no more robust, but I couldn't think of any other way to distinguish the divs. AFAICS the only reliable way to fix this is to ask Google nicely if they could add an id to their divs, so OL can fish them out correctly.

examples/google-v3 with this patch shows all working - terms, logo, plus the popup when you click on 'Map.Data'.

@elemoine I assume you want this in 2.12
