### PR TITLE
Using display:block instead of position:absolute.

### DIFF
--- a/lib/OpenLayers/Renderer/SVG.js
+++ b/lib/OpenLayers/Renderer/SVG.js
@@ -447,7 +447,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
      */
     createRenderRoot: function() {
         var svg = this.nodeFactory(this.container.id + "_svgRoot", "svg");
-        svg.style.position = "absolute";
+        svg.style.display = "block";
         return svg;
     },
 


### PR DESCRIPTION
This fixes a regression that can be seen e.g. when using the FeatureRenderer in GeoExt, causing an incorrect alignment of the renderer. See #392.
