### PR TITLE
Control.DragFeature and layer events

### DIFF
--- a/lib/OpenLayers/Control/DragFeature.js
+++ b/lib/OpenLayers/Control/DragFeature.js
@@ -29,9 +29,9 @@ OpenLayers.Control.DragFeature = OpenLayers.Class(OpenLayers.Control, {
     
     /**
      * APIProperty: onStart
-     * {Function} Define this function if you want to know when a drag starts.
-     *     The function should expect to receive two arguments: the feature
-     *     that is about to be dragged and the pixel location of the mouse.
+     * {Function} *Deprecated*.  Register for "beforefeaturemodified" instead.
+     *     The "beforefeaturemodified" event is triggered on the layer with each
+     *     feature drag.
      *
      * Parameters:
      * feature - {<OpenLayers.Feature.Vector>} The feature that is about to be
@@ -42,9 +42,9 @@ OpenLayers.Control.DragFeature = OpenLayers.Class(OpenLayers.Control, {
 
     /**
      * APIProperty: onDrag
-     * {Function} Define this function if you want to know about each move of a
-     *     feature. The function should expect to receive two arguments: the
-     *     feature that is being dragged and the pixel location of the mouse.
+     * {Function} *Deprecated*.  Register for "featuremodified" instead.
+     *     The "featuremodified" event is triggered on the layer with each
+     *     feature drag.
      *
      * Parameters:
      * feature - {<OpenLayers.Feature.Vector>} The feature that was dragged.
@@ -54,10 +54,9 @@ OpenLayers.Control.DragFeature = OpenLayers.Class(OpenLayers.Control, {
 
     /**
      * APIProperty: onComplete
-     * {Function} Define this function if you want to know when a feature is
-     *     done dragging. The function should expect to receive two arguments:
-     *     the feature that is being dragged and the pixel location of the
-     *     mouse.
+     * {Function} *Deprecated*.  Register for "afterfeaturemodified" instead.
+     *     The "afterfeaturemodified" event is triggered on the layer with each
+     *     feature drag.
      *
      * Parameters:
      * feature - {<OpenLayers.Feature.Vector>} The feature that was dragged.
@@ -273,6 +272,10 @@ OpenLayers.Control.DragFeature = OpenLayers.Class(OpenLayers.Control, {
     downFeature: function(pixel) {
         this.lastPixel = pixel;
         this.onStart(this.feature, pixel);
+        this.layer.events.triggerEvent("beforefeaturemodified", {
+            feature: this.feature
+        });
+        // FIXME: cancel if === false
     },
 
     /**
@@ -290,6 +293,9 @@ OpenLayers.Control.DragFeature = OpenLayers.Class(OpenLayers.Control, {
         this.layer.drawFeature(this.feature);
         this.lastPixel = pixel;
         this.onDrag(this.feature, pixel);
+        this.layer.events.triggerEvent("featuremodified", {
+            feature: this.feature
+        });
     },
 
     /**
@@ -315,6 +321,9 @@ OpenLayers.Control.DragFeature = OpenLayers.Class(OpenLayers.Control, {
      */
     doneDragging: function(pixel) {
         this.onComplete(this.feature, pixel);
+        this.layer.events.triggerEvent("afterfeaturemodified", {
+            feature: this.feature
+        });
     },
 
     /**


### PR DESCRIPTION
The control should trigger the `beforefeaturemodified`, `featuremodified` and `afterfeaturemodified` events just like the other controls (ModifyFeature and Split).

The functions callback (onStart, onDrag and onComplete) should be deprecated.
