### PR TITLE
KML write: Placemark elements shouldn't be extendedData

### DIFF
--- a/lib/OpenLayers/Format/KML.js
+++ b/lib/OpenLayers/Format/KML.js
@@ -1226,6 +1226,23 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
         }
         placemarkNode.appendChild(placemarkName);
         placemarkNode.appendChild(placemarkDesc);
+        
+        // add other Earth elements if present
+        if (feature.attributes.open) {
+            var placemarkOpen = this.createElementNS(this.kmlns, "open");
+            placemarkOpen.appendChild(this.createTextNode(feature.attributes.open));
+            placemarkNode.appendChild(placemarkOpen);
+        }
+        if (feature.attributes.visibility) {
+            var placemarkVisibility = this.createElementNS(this.kmlns, "visibility");
+            placemarkVisibility.appendChild(this.createTextNode(feature.attributes.visibility));
+            placemarkNode.appendChild(placemarkVisibility);
+        }
+        if (feature.attributes.Snippet) {
+            var placemarkSnippet = this.createElementNS(this.kmlns, "Snippet");
+            placemarkSnippet.appendChild(this.createTextNode(feature.attributes.Snippet));
+            placemarkNode.appendChild(placemarkSnippet);
+        }
 
         // Geometry node (Point, LineString, etc. nodes)
         var geometryNode = this.buildGeometryNode(feature.geometry);
@@ -1481,8 +1498,8 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
     buildExtendedData: function(attributes) {
         var extendedData = this.createElementNS(this.kmlns, "ExtendedData");
         for (var attributeName in attributes) {
-            // empty, name, description, styleUrl attributes ignored
-            if (attributes[attributeName] && attributeName != "name" && attributeName != "description" && attributeName != "styleUrl") {
+            // empty, name, description, styleUrl, open, visibility, Snippet attributes ignored
+            if (attributes[attributeName] && attributeName != "name" && attributeName != "description" && attributeName != "styleUrl" && attributeName != "open" && attributeName != "visibility" && attributeName != "Snippet") {
                 var data = this.createElementNS(this.kmlns, "Data");
                 data.setAttribute("name", attributeName);
                 var value = this.createElementNS(this.kmlns, "value");


### PR DESCRIPTION
A follow-up to #247. KML read stores all Placemark elements as feature attributes. At the moment, write() is then serialising these as extendedData, whereas they should be output as Placemark elements. This fix corrects this for the most common of these: open, visibility, Snippet. There are other elements (though I've never seen these in the wild), which could be added - though in that case it would probably be better to set up an array of all the elements plus a for loop to create a node for each one present.

Can easily be tested with examples/vector-formats.html (very useful for testing format read/write :-) )

Tests continue to pass.
