### PR TITLE
KML createPlacemark should use attributes.name

### DIFF
--- a/lib/OpenLayers/Format/KML.js
+++ b/lib/OpenLayers/Format/KML.js
@@ -1210,8 +1210,8 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
     createPlacemarkXML: function(feature) {        
         // Placemark name
         var placemarkName = this.createElementNS(this.kmlns, "name");
-        var name = feature.style && feature.style.label ? feature.style.label :
-                   feature.attributes.name || feature.id;
+        var label = (feature.style && feature.style.label) ? feature.style.label : feature.id;
+        var name = feature.attributes.name || label;
         placemarkName.appendChild(this.createTextNode(name));
 
         // Placemark description

--- a/tests/Format/KML.html
+++ b/tests/Format/KML.html
@@ -236,13 +236,13 @@
         var f = new OpenLayers.Format.KML();
 
         t.eq(f.read(f.write(feature))[0].attributes.name, feature.id, "placemark name from feature.id");
-
-        feature.attributes.name = "placemark name from attributes.name";
-        t.eq(f.read(f.write(feature))[0].attributes.name, feature.attributes.name, "placemark name from attributes.name");
         feature.style = {
             label: "placemark name from style.label"
         };
         t.eq(f.read(f.write(feature))[0].attributes.name, feature.style.label, "placemark name from style.label");
+
+        feature.attributes.name = "placemark name from attributes.name";
+        t.eq(f.read(f.write(feature))[0].attributes.name, feature.attributes.name, "placemark name from attributes.name");
     }
     function test_Format_KML_linestring_projected(t) {
         t.plan(1);


### PR DESCRIPTION
In http://trac.osgeo.org/openlayers/ticket/2441 a revised patch was promised, but ...
