### PR TITLE
Handler.MouseWheel: don't always block the handler

### DIFF
--- a/lib/OpenLayers/Handler/MouseWheel.js
+++ b/lib/OpenLayers/Handler/MouseWheel.js
@@ -101,12 +101,13 @@ OpenLayers.Handler.MouseWheel = OpenLayers.Class(OpenLayers.Handler, {
         
         // Ride up the element's DOM hierarchy to determine if it or any of 
         //  its ancestors was: 
-        //   * specifically marked as scrollable
-        //   * one of our layer divs
+        //   * specifically marked as scrollable (CSS overflow property)
+        //   * one of our layer divs or a div marked as scrollable
+        //     ('olScrollable' CSS class)
         //   * the map div
         //
         var overScrollableDiv = false;
-        var overLayerDiv = false;
+        var allowScroll = false;
         var overMapDiv = false;
         
         var elem = OpenLayers.Event.element(e);
@@ -130,15 +131,18 @@ OpenLayers.Handler.MouseWheel = OpenLayers.Class(OpenLayers.Handler, {
                 }
             }
 
-            if (!overLayerDiv) {
-                for(var i=0, len=this.map.layers.length; i<len; i++) {
-                    // Are we in the layer div? Note that we have two cases
-                    // here: one is to catch EventPane layers, which have a 
-                    // pane above the layer (layer.pane)
-                    if (elem == this.map.layers[i].div 
-                        || elem == this.map.layers[i].pane) { 
-                        overLayerDiv = true;
-                        break;
+            if (!allowScroll) {
+                allowScroll = OpenLayers.Element.hasClass(elem, 'olScrollable');
+                if (!allowScroll) {
+                    for (var i = 0, len = this.map.layers.length; i < len; i++) {
+                        // Are we in the layer div? Note that we have two cases
+                        // here: one is to catch EventPane layers, which have a
+                        // pane above the layer (layer.pane)
+                        var layer = this.map.layers[i];
+                        if (elem == layer.div || elem == layer.pane) {
+                            allowScroll = true;
+                            break;
+                        }
                     }
                 }
             }
@@ -154,7 +158,7 @@ OpenLayers.Handler.MouseWheel = OpenLayers.Class(OpenLayers.Handler, {
         //
         //    otherwise 
         // 
-        //    If we are over the layer div: 
+        //    If we are over the layer div or a 'olScrollable' div:
         //     * zoom/in out
         //     then
         //     * kill event (so as not to also scroll the page after zooming)
@@ -165,7 +169,7 @@ OpenLayers.Handler.MouseWheel = OpenLayers.Class(OpenLayers.Handler, {
         //        layerswitcher or the pan/zoom control)
         //
         if (!overScrollableDiv && overMapDiv) {
-            if (overLayerDiv) {
+            if (allowScroll) {
                 var delta = 0;
                 if (!e) {
                     e = window.event;


### PR DESCRIPTION
In http://fredj.github.com/openlayers-lens/examples/layer-lens.html, the map can be zoomed in/out using the mouse wheel but not when the cursor is over the "lens" control.

The current logic is to zoom in/out only if the cursor (event target or one of its parents) is a layer div.
