### PR TITLE
GetCapabilities Extent ignored when Dimension not defined in the layer

### DIFF
--- a/lib/OpenLayers/Format/WMSCapabilities/v1_1.js
+++ b/lib/OpenLayers/Format/WMSCapabilities/v1_1.js
@@ -98,18 +98,25 @@ OpenLayers.Format.WMSCapabilities.v1_1 = OpenLayers.Class(
             },
             "Extent": function(node, obj) {
                 var name = node.getAttribute("name").toLowerCase();
+				extent.nearestVal = node.getAttribute("nearestValue") === "1";
+				extent.multipleVal = node.getAttribute("multipleValues") === "1";
+				extent.current = node.getAttribute("current") === "1";
+				extent["default"] = node.getAttribute("default") || "";
+				
                 if (name in obj["dimensions"]) {
                     var extent = obj.dimensions[name];
-                    extent.nearestVal = 
-                        node.getAttribute("nearestValue") === "1";
-                    extent.multipleVal = 
-                        node.getAttribute("multipleValues") === "1";
-                    extent.current = node.getAttribute("current") === "1";
-                    extent["default"] = node.getAttribute("default") || "";
                     var values = this.getChildValue(node);
                     extent.values = values.split(",");
+                } else {
+                    var extent = { name: name };
+                    var values = this.getChildValue(node);
+                    extent.values = values.split(",");
+                    if (!obj.extents) {
+                        obj.extents = {};
+                    }
+                    obj.extents[extent.name] = extent;
                 }
-                }
+            }
         }, OpenLayers.Format.WMSCapabilities.v1.prototype.readers["wms"])
     },
 


### PR DESCRIPTION
The GetCapabilities (OpenLayers.Format.WMSCapabilities.v1_1) ignores the extent element when the dimension is defined for a parent layer.
