### PR TITLE
KML: export style

### DIFF
--- a/examples/vector-formats.html
+++ b/examples/vector-formats.html
@@ -76,7 +76,7 @@
                 OpenLayers.Util.extend({}, gmlOptions),
                 out_options
             );
-            var kmlOptionsIn = OpenLayers.Util.extend(
+            var kmlOptions = OpenLayers.Util.extend(
                 {extractStyles: true}, in_options);
             formats = {
               'in': {
@@ -85,7 +85,7 @@
                 georss: new OpenLayers.Format.GeoRSS(in_options),
                 gml2: new OpenLayers.Format.GML.v2(gmlOptionsIn),
                 gml3: new OpenLayers.Format.GML.v3(gmlOptionsIn),
-                kml: new OpenLayers.Format.KML(kmlOptionsIn),
+                kml: new OpenLayers.Format.KML(kmlOptions),
                 atom: new OpenLayers.Format.Atom(in_options),
                 gpx: new OpenLayers.Format.GPX(in_options)
               }, 
@@ -95,7 +95,7 @@
                 georss: new OpenLayers.Format.GeoRSS(out_options),
                 gml2: new OpenLayers.Format.GML.v2(gmlOptionsOut),
                 gml3: new OpenLayers.Format.GML.v3(gmlOptionsOut),
-                kml: new OpenLayers.Format.KML(out_options),
+                kml: new OpenLayers.Format.KML(kmlOptions),
                 atom: new OpenLayers.Format.Atom(out_options),
                 gpx: new OpenLayers.Format.GPX(out_options)
               } 

--- a/lib/OpenLayers/Format/KML.js
+++ b/lib/OpenLayers/Format/KML.js
@@ -46,6 +46,18 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
      */
     placemarksDesc: "No description available",
     
+     /** 
+     * APIProperty: documentsName
+     * {String} Name of the documents.  Default is "OpenLayers export".
+     */
+    documentsName: "OpenLayers export",
+
+    /**
+     * APIProperty: documentsDesc
+     * {String} Description of the documents. Default is "Exported on [date]".
+     */
+    documentsDesc: "Exported on " + new Date(),
+
     /** 
      * APIProperty: foldersName
      * {String} Name of the folders.  Default is "OpenLayers export".
@@ -84,10 +96,11 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
     kvpAttributes: false,
     
     /**
-     * Property: extractStyles
-     * {Boolean} Extract styles from KML.  Default is false.
+     * APIProperty: extractStyles
+     * {Boolean} Extract styles from and to KML.  Default is false.
      *           Extracting styleUrls also requires extractAttributes to be
-     *           set to true
+     *           set to true.
+     *           See also <styleNodes>, <styleMapNodes> and <colorNames>
      */
     extractStyles: false,
     
@@ -138,6 +151,46 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
      */
     styleBaseUrl: "",
 
+    /**
+     * APIProperty: styleNodes
+     * {Array({DOMElement})} KML shared Style elements.
+     *     Only useful if extractStyles=true.
+     *     Incoming shared Style nodes will be stored here on read();
+     *     write() will then output them as shared Styles.
+     *     You can add/modify/delete these as you wish.
+     *     The styleUrl element referring to these is stored as an attribute
+     *     on each feature (feature.attributes.styleUrl) and output in the
+     *     Placemark on write().
+     *     The style for features without a styleUrl attribute will be converted
+     *     to an inline Style element.
+     */
+    styleNodes: [],
+    
+    /**
+     * APIProperty: styleMapNodes
+     * {Array({DOMElement})} KML StyleMap elements
+     *     Only useful if extractStyles=true.
+     *     Incoming StyleMap nodes will be stored here on read(), and output
+     *     on write().
+     *     You can add/modify/delete these as you wish.
+     *     Highlight style not currently used in OpenLayers.
+     */
+    styleMapNodes: [],
+    
+    /**
+     * APIProperty: colorNames
+     * {Object} Table of colorName:hex value pairs
+     *     Only useful if extractStyles=true.
+     *     KML only accepts hex colors, so any named colors in feature styles
+     *     must be converted on write().
+     *     Include all the colors you want converted in this object.
+     *     Any colors not included will be output as #000000 (black)
+     *     Example: {blue: '#0000ff', green: '#008000'}
+     *     Can also be used for RGB colors.
+     *     Default is null, meaning all non-hex colors will be output as black.
+     */
+    colorNames: null,
+    
     /**
      * Property: fetched
      * {Object} Storage of KML URLs that have been fetched before
@@ -320,6 +373,7 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
      */
     parseStyles: function(nodes, options) {
         for(var i=0, len=nodes.length; i<len; i++) {
+            this.styleNodes.push(nodes[i]);
             var style = this.parseStyle(nodes[i]);
             if(style) {
                 var styleName = (options.styleBaseUrl || "") + "#" + style.id;
@@ -570,6 +624,7 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
 
         for(var i=0, len=nodes.length; i<len; i++) {
             var node = nodes[i];
+            this.styleMapNodes.push(node);
             var pairs = this.getElementsByTagNameNS(node, "*", 
                             "Pair");
 
@@ -633,6 +688,9 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
                                 feature.style, inlineStyle
                             );
                         }
+                    }
+                    if (feature.geometry.CLASS_NAME == "OpenLayers.Geometry.Point") {
+                        feature.style.pointRadius = 6; // default so points without icons displayed
                     }
                 }
 
@@ -1159,12 +1217,50 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
             features = [features];
         }
         var kml = this.createElementNS(this.kmlns, "kml");
+        var document = this.createDocumentXML();
+        if (this.extractStyles) {
+            // copy over Style and StyleMap nodes from input data
+            var nodes = this.styleNodes;
+            for(var i=0; i<nodes.length; i++) {
+                document.appendChild(nodes[i]);
+            }
+            nodes = this.styleMapNodes;
+            for(var i=0; i<nodes.length; i++) {
+                document.appendChild(nodes[i]);
+            }
+        }
         var folder = this.createFolderXML();
         for(var i=0, len=features.length; i<len; ++i) {
             folder.appendChild(this.createPlacemarkXML(features[i]));
         }
-        kml.appendChild(folder);
+        document.appendChild(folder);
+        kml.appendChild(document);
         return OpenLayers.Format.XML.prototype.write.apply(this, [kml]);
+    },
+ 
+     /**
+     * Method: createDocumentXML
+     * Creates and returns a KML document node
+     *
+     * Returns:
+     * {DOMElement}
+     */
+    createDocumentXML: function() {
+        // Document name
+        var documentName = this.createElementNS(this.kmlns, "name");
+        var documentNameText = this.createTextNode(this.documentsName);
+        documentName.appendChild(documentNameText);
+
+        // Document description
+        var documentDesc = this.createElementNS(this.kmlns, "description");
+        var documentDescText = this.createTextNode(this.documentsDesc);
+        documentDesc.appendChild(documentDescText);
+
+        var document = this.createElementNS(this.kmlns, "Document");
+        document.appendChild(documentName);
+        document.appendChild(documentDesc);
+
+        return document;
     },
 
     /**
@@ -1231,6 +1327,17 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
         var geometryNode = this.buildGeometryNode(feature.geometry);
         placemarkNode.appendChild(geometryNode);        
         
+        if (this.extractStyles) {
+            var styleNode;
+            if (feature.attributes.styleUrl) {
+                styleNode = this.createElementNS(this.kmlns, "styleUrl");
+                styleNode.appendChild(this.createTextNode(feature.attributes.styleUrl));
+            } else {
+                styleNode = this.buildStyleNode(this.computedStyle(feature));
+            }
+            placemarkNode.appendChild(styleNode);
+        }
+
         // output attributes as extendedData
         if (feature.attributes) {
             var edNode = this.buildExtendedData(feature.attributes);
@@ -1240,7 +1347,167 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
         }
         
         return placemarkNode;
-    },    
+    },
+    
+    /**
+     * Method: computedStyle
+     * Finds style for a feature
+     * 
+     * Parameters:
+     * feature - {<OpenLayers.Feature>}
+     *
+     * Returns:
+     * {<OpenLayers.Style>}
+     */
+    computedStyle: function(feature) {
+        if (feature.style) { 
+            return feature.style; 
+        } else if (feature.layer) { 
+            if (feature.layer.style) { 
+                return feature.layer.style; 
+            } else { 
+                return feature.layer.styleMap.createSymbolizer(feature); 
+            } 
+        } 
+    }, 
+
+    /**
+     * Method: createKmlColorNode
+     * Convert style colors to #aabbggrr
+     *
+     * Parameters:
+     * color - {String}
+     * opacity - {Float}
+     *
+     * Returns:
+     * {DOMElement}
+     */
+    createKmlColorNode: function(color, opacity) {
+        if (opacity === undefined || opacity === null) {
+            var alpha = "ff";
+        } else {
+            var alpha = Math.round(parseFloat(opacity) * 255).toString(16);
+        }
+
+        var nColor = "#000000"; // default black
+        if (color.indexOf("#") != -1) {
+            if (color.length == 4) {
+                // '#rgb' => '#rrggbb'
+                nColor = "#"+color.charAt(1)+color.charAt(1)+color.charAt(2)+color.charAt(2)+color.charAt(3)+color.charAt(3);
+            } else {
+                // '#rrggbb'
+                nColor = color;
+            }
+        }
+        if (color.indexOf("#") == -1 && this.colorNames[color]) {
+            // named colors
+            nColor = this.colorNames[color];
+        }
+        var r = nColor.slice(1, 3);
+        var g = nColor.slice(3, 5);
+        var b = nColor.slice(5, 7);
+
+        var colorNode = this.createElementNS(this.kmlns, "color");
+
+        colorNode.appendChild(this.createTextNode(alpha + b + g + r));
+        return colorNode;
+    },
+
+    /**
+     * Method: buildStyleNode
+     *
+     * Parameters:
+     * style - {<OpenLayers.Style>}
+     *
+     * Returns:
+     * {DOMElement}
+     */
+    buildStyleNode: function(style) {
+        var styleNode = this.createElementNS(this.kmlns, "Style");
+        var id = OpenLayers.Util.createUniqueID("style_")
+        styleNode.setAttribute("id", id);
+
+        // LineStyle
+        if (style.strokeColor != undefined) {
+            var lineNode = this.createElementNS(this.kmlns, "LineStyle");
+            var colorNode = this.createKmlColorNode(style.strokeColor, style.strokeOpacity);
+            lineNode.appendChild(colorNode);
+
+            if (style.strokeWidth != undefined) {
+                var width = this.createElementNS(this.kmlns, "width");
+                width.appendChild(this.createTextNode(style.strokeWidth));
+                lineNode.appendChild(width);
+            }
+            styleNode.appendChild(lineNode);
+        }
+
+        // PolyStyle
+        if (style.fillColor != undefined) {
+            var polyNode = this.createElementNS(this.kmlns, "PolyStyle");
+            var colorNode = this.createKmlColorNode(style.fillColor, style.fillOpacity);
+            polyNode.appendChild(colorNode);
+            styleNode.appendChild(polyNode);
+        } else if (style.fillColor == "none") {
+            var polyNode = this.createElementNS(this.kmlns, "PolyStyle");
+            var fill = this.createElementNS(this.kmlns, "fill");
+            fill.appendChild(this.createTextNode("1"));
+            polyNode.appendChild(fill);
+            styleNode.appendChild(polyNode);
+        }
+        if (polyNode && style.strokeWidth == "0") {
+            var outline = this.createElementNS(this.kmlns, "outline");
+            outline.appendChild(this.createTextNode("1"));
+            polyNode.appendChild(outline);
+            styleNode.appendChild(polyNode);
+        }
+
+        // IconStyle
+        if (style.externalGraphic != undefined && style.graphic !== false) {
+            var iconstyleNode = this.createElementNS(this.kmlns, "IconStyle");
+            var iconNode = this.createElementNS(this.kmlns, "Icon");
+
+            var href = this.createElementNS(this.kmlns, "href");
+            var urlObj = OpenLayers.Util.createUrlObject(
+                style.externalGraphic,
+                {ignorePort80: true}
+            );
+            url = [urlObj.protocol, '//', urlObj.host, urlObj.port, urlObj.pathname].join('');
+            href.appendChild(this.createTextNode(url));
+            iconNode.appendChild(href);
+            iconstyleNode.appendChild(iconNode);
+
+            var scaleNode = this.createElementNS(this.kmlns, "scale");
+
+            // in KML 2.2, w and h <Icon> attributes are deprecated
+            // this means that we can't modify the width/height ratio of the image
+            var scale = style.graphicWidth || style.graphicHeight || style.pointRadius * 2;
+
+            scaleNode.appendChild(this.createTextNode(scale/32));
+            iconstyleNode.appendChild(scaleNode);
+
+            // graphicOpacity, since opacity seems to be only supported using a color node in KML,
+            // which will eventually change the color of the image, we choose not
+            // to support it
+
+            // graphicXOffset and graphicYOffset (hotSpots), not supported yet
+
+            // rotation (heading), not supported yet
+
+            // graphicName, cannot be supported since nothing similar exists in KML
+
+            styleNode.appendChild(iconstyleNode);
+        }
+
+        // LabelStyle
+        if (style.fontColor != undefined) {
+            var colorNode = this.createKmlColorNode(style.fontColor, style.fontOpacity);
+            var labelStyle = this.createElementNS(this.kmlns, "LabelStyle");
+            labelStyle.appendChild(colorNode);
+            styleNode.appendChild(labelStyle);
+        }
+
+        return styleNode;
+    },
 
     /**
      * Method: buildGeometryNode

--- a/tests/Format/KML.html
+++ b/tests/Format/KML.html
@@ -32,6 +32,7 @@
             internalProjection: new OpenLayers.Projection("EPSG:900913"),
             externalProjection: new OpenLayers.Projection("EPSG:4326")
         });
+        f.style = {};
         var data = format.write(f);
         var found = (data.search('139.734') != -1);
         t.ok(found, "Found 139.734 (correct reprojection) in data output.");


### PR DESCRIPTION
Builds on http://trac.osgeo.org/openlayers/ticket/2409 with the following additions/changes:
1. stores incoming document-level 'shared' styles and stylemaps so they can be output as input
2. if feature has attributes.styleUrl this will be output (and assumed to refer to a stored style)
3. if no styleUrl, Placemark style will be created specific to feature
4. named colors ('blue', 'red' etc) catered for by cross-reference object which developers can supply as they wish (I decided this was better than providing a large object with all colors, as most sites won't use most colors)

Open issues:
- shared styles are in Document element, which means the Folder element output at the moment is now redundant. I would prefer to get rid of this, but name/description are currently API properties. If people want to keep the Folder for bc, a possible compromise would be to add code not to output if name null
- as noted in the patch on trac, current OL code should be updated to kml 2.2. I'll look into this and put in separate pull request
- OL style (at least if you use the defaults) returns a symbolizer which caters for all geometry types. It would reduce the output file size if the feature style only output the style for the geometry type. I've left that for someone else to do if they like :-)

Tests which compare output will have to be changed, but I have left that pending decision on what to do with folder. I can add a few basic style output tests, but there are so many different variations and combinations that it's impossible to test everything.
I have tested with some test data of my own, plus with live data. I have also uploaded output to maps.google.com, made changes, downloaded to OL, changed, re-uploaded and back again, and have not noticed any problems. It would be good, though, if others could test this with their own data to see if there are issues.

I have changed vector-formats example as in trac patch, and you can use this for testing, though if you want to test the output of saved style elements you'll have to copy the saved styles from formats.in.kml to formats.out.kml