### PR TITLE
Support Subdomains in Openlayers WMTS

### DIFF
--- a/lib/OpenLayers/Layer/WMTS.js
+++ b/lib/OpenLayers/Layer/WMTS.js
@@ -417,10 +417,19 @@ OpenLayers.Layer.WMTS = OpenLayers.Class(OpenLayers.Layer.Grid, {
             var matrixId = this.matrix.identifier;
             var dimensions = this.dimensions, params;
 
+            if (OpenLayers.Util.isArray(this.url)) {
+                url = this.selectUrl([
+                    this.version, this.style, this.matrixSet,
+                    this.matrix.identifier, info.row, info.col
+                ].join(","), this.url);
+            } else {
+                url = this.url;
+            }
+
             if (this.requestEncoding.toUpperCase() === "REST") {
                 params = this.params;
-                if (typeof this.url === "string" && this.url.indexOf("{") !== -1) {
-                    var template = this.url.replace(/\{/g, "${");
+                if (url.indexOf("{") !== -1) {
+                    var template = url.replace(/\{/g, "${");
                     var context = {
                         // spec does not make clear if capital S or not
                         style: this.style, Style: this.style,
@@ -454,11 +463,6 @@ OpenLayers.Layer.WMTS = OpenLayers.Class(OpenLayers.Layer.Grid, {
                     path = path + this.matrixSet + "/" + this.matrix.identifier + 
                         "/" + info.row + "/" + info.col + "." + this.formatSuffix;
 
-                    if (OpenLayers.Util.isArray(this.url)) {
-                        url = this.selectUrl(path, this.url);
-                    } else {
-                        url = this.url;
-                    }
                     if (!url.match(/\/$/)) {
                         url = url + "/";
                     }


### PR DESCRIPTION
Hi,

subdomains would enhance performance of WMTS by enabling the browser to
make more parallel requests.

While it is possible to set the url property of OSM layers using an array
of URLs, in WMTS (2.12-rc1) it is only possible to enter a single service URL.

It would make sense to support this in all tiled layers.

Best Regards,
Gerhard
