### PR TITLE
"OpenLayers.Util.getScrollbarWidth" does not work correctly in some browsers.

### DIFF
--- a/lib/OpenLayers/Util.js
+++ b/lib/OpenLayers/Util.js
@@ -1665,9 +1665,11 @@ OpenLayers.Util.getScrollbarWidth = function() {
         wNoScroll = inn.offsetWidth;
     
         // Add the scrollbar
-        scr.style.overflow = 'scroll';
+        scr.style.overflow = 'auto';
+        scr.style.overflowY = 'scroll';
+        scr.style.overflowX = 'hidden';
         // Width of the inner div width scrollbar
-        wScroll = inn.offsetWidth;
+        wScroll = scr.clientWidth;
     
         // Remove the scrolling div from the doc
         document.body.removeChild(document.body.lastChild);


### PR DESCRIPTION
I am investigating the behavior of poupus when using "autoSize". There are several problems, one is that "OpenLayers.Util.getScrollbarWidth" returns 0 for some browsers:

The function results using different browsers:
- IE9 & 8 (not compatible mode)  = 17
- IE9 & 8 (compatible mode)  = **0**
- IE6 = **0**
- Safari 5.1.7 = **0**
- Chrome 18 & 19 = **0**
- Opera 11.64= 17
- FF 12.0 = **0**
