### PR TITLE
Make license.txt compatible with compiler

### DIFF
--- a/build/license.txt
+++ b/build/license.txt
@@ -1,5 +1,5 @@
-/*
-
+/**
+  @license
   OpenLayers.js -- OpenLayers Map Viewer Library
 
   Copyright (c) 2006-2012 by OpenLayers Contributors
@@ -11,9 +11,7 @@
   (For uncompressed versions of the code used, please see the
   OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
 
-*/
 
-/**
  * Contains XMLHttpRequest.js <http://code.google.com/p/xmlhttprequest/>
  * Copyright 2007 Sergey Ilinsky (http://www.ilinsky.com)
  *
@@ -21,9 +19,8 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
-
-/**
+ 
+ 
  * OpenLayers.Util.pagePosition is based on Yahoo's getXY method, which is
  * Copyright (c) 2006, Yahoo! Inc.
  * All rights reserved.


### PR DESCRIPTION
Adding the license tag to the beginning of the comment means that Closure Compiler will not strip the comment in any input file containing it. It seems to be choosy about what it can handle: only seems to work when all the various licenses are combined into 1 comment.