### PR TITLE
Add AMD and version options to build.py

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -60,6 +60,15 @@ def build(config_file = None, output_file = None, options = None):
         print "\nAbnormal termination."
         sys.exit("ERROR: %s" % E)
 
+    if options.amdname:
+        options.amdname = "'" + options.amdname + "',"
+    else:
+        options.amdname = ""
+        
+    if options.amd == 'pre':
+        print "\nAdding AMD function."
+        merged = "define(%sfunction(){%sreturn OpenLayers;});" % (options.amdname, merged)
+    
     print "Compressing using %s" % use_compressor
     if use_compressor == "jsmin":
         minimized = jsmin.jsmin(merged)
@@ -101,6 +110,14 @@ def build(config_file = None, output_file = None, options = None):
     else: # fallback
         minimized = merged 
 
+    if options.amd == 'post':
+        print "\nAdding AMD function."
+        minimized = "define(%sfunction(){%sreturn OpenLayers;});" % (options.amdname, minimized)
+    
+    if options.status:
+        print "\nAdding status file."
+        minimized = "// status: " + file(options.status).read() + minimized
+    
     print "\nAdding license file."
     minimized = file("license.txt").read() + minimized
 
@@ -111,7 +128,10 @@ def build(config_file = None, output_file = None, options = None):
 
 if __name__ == '__main__':
   opt = optparse.OptionParser(usage="%s [options] [config_file] [output_file]\n  Default config_file is 'full.cfg', Default output_file is 'OpenLayers.js'")
-  opt.add_option("-c", "--compressor", dest="compressor", help="compression method: one of 'jsmin', 'minimize', 'closure_ws', 'closure', or 'none'", default="jsmin")
+  opt.add_option("-c", "--compressor", dest="compressor", help="compression method: one of 'jsmin' (default), 'minimize', 'closure_ws', 'closure', or 'none'", default="jsmin")
+  opt.add_option("-s", "--status", dest="status", help="name of a file whose contents will be added as a comment at the front of the output file. For example, when building from a git repo, you can save the output of 'git describe --tags' in this file. Default is no file.", default=False)
+  opt.add_option("--amd", dest="amd", help="output should be AMD module; wrap merged files in define function; can be either 'pre' (before compilation) or 'post' (after compilation). Wrapping the OpenLayers var in a function means the filesize can be reduced by the closure compiler using 'pre', but be aware that a few functions depend on the OpenLayers variable being present. Either option can be used with jsmin or minimize compression. Default false, not AMD.", default=False)
+  opt.add_option("--amdname", dest="amdname", help="only useful with amd option. Name of AMD module. Default no name, anonymous module.", default=False)
   (options, args) = opt.parse_args()
   if not len(args):
     build(options=options)

--- a/notes/2.13.md
+++ b/notes/2.13.md
@@ -35,3 +35,13 @@ Corresponding issue/pull requests:
 
 * https://github.com/openlayers/openlayers/pull/423
 
+# New Options for Build Script
+
+* add the contents of a file as a comment at the front of the build, for example, the output of 'git describe --tags' could be saved as a file and then included
+* create build file as an AMD module
+
+run 'build.py -h' for more details
+
+Corresponding issue/pull requests:
+
+* https://github.com/openlayers/openlayers/pull/528


### PR DESCRIPTION
Adds 2 new options to build.py
- s/status: adds ability to put version info as a comment at the front of the build file, as discussed in #463. Rather than try and get python to run git, I decided it would be simpler to just generalise it to adding a text file. That way people can use whatever they like in the way of timestamps, version info, or whatever. Should also address #26
- amd: this is intended for people like me who want to convert builds into modules for use with AMD loaders like requirejs. As I say in the help text, the pre-compile option lets Closure Compiler minimise the OpenLayers var, reducing the file size a few % more, but there are a couple of functions that don't work with this and will need fixing. I'll address these in a separate issue. If there's interest in using this with the hosted builds, it might be better to use one of the boilerplates at https://github.com/umdjs/umd - probably amdWeb which returns the OpenLayers var as either a module or a global depending on whether define/require is present.
