### PR TITLE
Popup.getContentDivPadding: Check if parent is an element (IE issues)

### DIFF
--- a/lib/OpenLayers/Popup.js
+++ b/lib/OpenLayers/Popup.js
@@ -838,7 +838,7 @@ OpenLayers.Popup = OpenLayers.Class({
         var contentDivPadding = this._contentDivPadding;
         if (!contentDivPadding) {
 
-            if (this.div.parentNode == null) {
+            if (this.div.parentNode == null || !OpenLayers.Util.isElement(this.div.parentNode)) {
                 //make the div invisible and add it to the page        
                 this.div.style.display = "none";
                 document.body.appendChild(this.div);

--- a/tests/manual/popup-autoSize-quirks.html
+++ b/tests/manual/popup-autoSize-quirks.html
@@ -1,0 +1,23 @@
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <title>Test &quot;quirks&quot;: Popups auto-size</title>
+        <link rel="stylesheet" href="../theme/default/style.css" type="text/css">
+        <link rel="stylesheet" href="style.css" type="text/css">
+        <style type="text/css">
+            .paddind20 {
+                padding: 20px;
+            }     
+        </style>
+    </head>
+    <body>
+        <h3>Test &quot;quirks&quot;: Popups auto-size</h3>
+        related test: <a href="popup-autoSize-w3c.html">popup-autoSize-w3c.html</a>
+        <div id="out"></div>
+        <div id="map" style="width:512px; height:256px; background-color:#aaa"></div>
+        <script src="../../lib/OpenLayers.js"></script>
+        <script src="popup-autoSize.js"></script>
+    </body>
+</html>

--- a/tests/manual/popup-autoSize-w3c.html
+++ b/tests/manual/popup-autoSize-w3c.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <title>Test &quot;w3c&quot;: Popups auto-size</title>
+        <link rel="stylesheet" href="../theme/default/style.css" type="text/css">
+        <link rel="stylesheet" href="style.css" type="text/css">
+        <style type="text/css">
+            .paddind20 {
+                padding: 20px;
+            }     
+        </style>
+    </head>
+    <body>
+        <h3>Test &quot;w3c&quot;: Popups auto-size</h3>
+        related test: <a href="popup-autoSize-quirks.html">popup-autoSize-quirks.html</a>
+        <div id="out"></div>
+        <div id="map" style="width:512px; height:256px; background-color:#aaa"></div>
+        <script src="../../lib/OpenLayers.js"></script>
+        <script src="popup-autoSize.js"></script>
+    </body>
+</html>

--- a/tests/manual/popup-autoSize.js
+++ b/tests/manual/popup-autoSize.js
@@ -1,0 +1,56 @@
+// To use the same syntax as in "\tests"
+var t = {
+    count: 0,
+    plan: function(n) {
+        var out = document.getElementById("out"); 
+        out.innerHTML += "<hr><b>Plan = " + n + "</b><br>";
+        t.count = 0;
+    },
+    eq: function(a, b, msg) {
+        t.count += 1;
+        var out = document.getElementById("out"); 
+        if (a == b) {
+            out.innerHTML += t.count + ": ok " + msg + "<br>";
+        }
+        else {
+            out.innerHTML += t.count + ": <span style=\"color:red\">Fail (" + a + " not eq " + b + "): " + msg + "<span><br>";
+        }   
+    },
+    ok: function(a, msg) {
+        t.count += 1;
+        var out = document.getElementById("out"); 
+        if (a) {
+            out.innerHTML += t.count + ": ok " + msg + "<br>";
+        } else {
+            out.innerHTML += t.count + ": <span style=\"color:red\">Fail: " + msg + "<span><br>";
+        }
+    }
+};
+
+// Tests
+function test_Popup_autoSize(t) {
+    t.plan(3);
+    var map = new OpenLayers.Map('map');
+    map.addLayer(new OpenLayers.Layer('name', {'isBaseLayer':true}));
+    map.zoomToMaxExtent();
+    
+    var popupAutoSize = OpenLayers.Class(OpenLayers.Popup, {
+            contentDisplayClass: "paddind20",
+            autoSize: true
+    });
+    popup = new popupAutoSize(
+        null, 
+        new OpenLayers.LonLat(-100,50),
+        new OpenLayers.Size(100,100),
+        "<div style='width: 100px; height: 50px; background-color:#aff'>a b c</div>",
+        null, true
+    );
+    map.addPopup(popup);
+    var pPadd = popup.getContentDivPadding();
+    t.ok(pPadd.equals(new OpenLayers.Bounds(20,20,20,20)),"{padding:20px} is correctly calculated: (" + popup.getContentDivPadding() + ")");
+    
+    //map.destroy();
+}
+    
+// Start tests
+test_Popup_autoSize(t);


### PR DESCRIPTION
When using IE (tested from IE6 to IE9) creating a div without adding to _document_, `parentNode` can be an object. This causes "Popup.getContentDivPadding" detect a zero padding instead of right padding.

Note: In IE9 fails in all cases except using _tests/manual/popup-autoSize-w3c.html_ with not compatibility mode, IE8 fails in all four cases ([quirks&w3c]*[compatibility on&off])

Where it does not work you can see that when a popup has close box this box has no padding right and top.

---

Have added two manual tests (quirks/w3c), works on: 
- IE 8 & 9 (compatibility on&off)
- IE6 & 7
- FF 1.5 & 12.0
- Chrome 19.0
- Safari 5.1
- Opera 11.64

Note: the popup shown in the manual tests can have an incorrect padding. This is a topic for another patch that I was working when I saw this problem.
