### PR TITLE
Document and Folder attributes parsing for OpenLayers.Format.KML

### DIFF
--- a/lib/OpenLayers/Format/KML.js
+++ b/lib/OpenLayers/Format/KML.js
@@ -146,6 +146,18 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
     fetched: null,
 
     /**
+     * Property: document
+     * {Object} Attributes of Document element
+     */
+    "document": null,
+
+    /**
+     * Property: folder
+     * {Object} Attributes of Folder element
+     */
+    folder: null,
+
+    /**
      * APIProperty: maxDepth
      * {Integer} Maximum depth for recursive loading external KML URLs 
      *           Defaults to 0: do no external fetching
@@ -191,6 +203,8 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
         this.features = [];
         this.styles   = {};
         this.fetched  = {};
+        this["document"] = {};
+        this.folder = {};
 
         // Set default options 
         var options = {
@@ -217,9 +231,12 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
             data = OpenLayers.Format.XML.prototype.read.apply(this, [data]);
         }
 
+        this.internalns = data.firstChild.namespaceURI ? 
+                    data.firstChild.namespaceURI : this.kmlns;
+
         // Loop throught the following node types in this order and
         // process the nodes found 
-        var types = ["Link", "NetworkLink", "Style", "StyleMap", "Placemark","Document"];
+        var types = ["Link", "NetworkLink", "Style", "StyleMap", "Placemark","Document","Folder"];
         for(var i=0, len=types.length; i<len; ++i) {
             var type = types[i];
 
@@ -254,9 +271,13 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
                 case "placemark":
                     this.parseFeatures(nodes, options);
                     break;
-                // parse features
+                // parse document
                 case "document":
-                    this.parseDocument(nodes, options);
+                    this.parseDocumentAndFolder(nodes, options);
+                    break;
+                // parse folder
+                case "folder":
+                    this.parseDocumentAndFolder(nodes, options);
                     break;
             }
         }
@@ -601,24 +622,48 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
     },
 
     /**
-     * Method: parseDocument
+     * Method: parseDocumentAndFolder
      * Parses metadata attributes from this KML
      *
      * Parameters:
      * nodes    - {Array} of {DOMElement} data to read/parse. (should be one)
      * options  - {Object} Hash of options
      */
-    parseDocument: function(nodes,options) {
-        var docNode = nodes[0];
-        var metadata = {};
+    parseDocumentAndFolder: function(nodes,options) {
+        var node = nodes[0];
+        var params = {};
 
-        // name
-        var names = this.getElementsByTagNameNS(docNode, this.internalns,"Name");
-        if (names.length > 0) {
-            metadata.name = names[0].firstChild.nodeValue;
+        for (var i = 0, len = node.childNodes.length; i < len; i++) {
+            var elem = node.childNodes[i];
+            var nodeName = elem.nodeName;
+
+            // get clear node name, without namespace
+            nodeName = nodeName.search(":") > -1 ? nodeName.split(":")[1] : nodeName;
+
+            switch(nodeName) {
+                case "open":
+                case "visibility":
+                        params[nodeName]= !!elem.firstChild.nodeValue;
+                        break;
+                case "name":
+                case "address":
+                case "phoneNumber":
+                case "styleUrl":
+                case "snipped":
+                case "description":
+                        params[nodeName] = elem.firstChild.nodeValue;
+                        break;
+                // TODO: more elements to be parsed
+            }
         }
-        TADY
-    };
+       
+        if (node.nodeName.search("Document") > - 1) {
+            this["document"] = params;
+        }
+        else if (node.nodeName.search("Folder") > - 1) {
+            this.folder = params;
+        }
+    },
 
     /**
      * Method: parseFeatures
@@ -803,8 +848,6 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
         var type, nodeList, geometry, parser;
         for(var i=0, len=order.length; i<len; ++i) {
             type = order[i];
-            this.internalns = node.namespaceURI ? 
-                    node.namespaceURI : this.kmlns;
             nodeList = this.getElementsByTagNameNS(node, 
                                                    this.internalns, type);
             if(nodeList.length > 0) {

--- a/tests/Format/KML.html
+++ b/tests/Format/KML.html
@@ -1,5 +1,5 @@
 <html> 
-<head> 
+
     <script src="../OLLoader.js"></script> 
     <script type="text/javascript">
 
@@ -8,13 +8,8 @@
     var test_style_fill = '<kml xmlns="http://earth.google.com/kml/2.0"> <Placemark>    <Style> <PolyStyle> <fill>1</fill> <color>870000ff</color> <width>10</width> </PolyStyle> </Style>  <LineString> <coordinates> -112,36 -113,37 </coordinates> </LineString> </Placemark><Placemark>    <Style> <PolyStyle> <fill>0</fill> <color>870000ff</color> <width>10</width> </PolyStyle> </Style>  <LineString> <coordinates> -112,36 -113,37 </coordinates> </LineString> </Placemark></kml>';
     var test_style_outline = '<kml xmlns="http://earth.google.com/kml/2.0"> <Placemark>    <Style> <PolyStyle> <outline>0</outline> <color>870000ff</color> <width>10</width> </PolyStyle> </Style>  <LineString> <coordinates> -112,36 -113,37 </coordinates> </LineString> </Placemark></kml>';
     var test_style_font = '<kml xmlns="http://earth.google.com/kml/2.0"> <Placemark><Style><LabelStyle><color>870000ff</color><scale>1.5</scale></LabelStyle></Style><LineString><coordinates> -112,36 -113,37 </coordinates></LineString></Placemark></kml>';
-    var test_nl = '<kml xmlns="http://earth.google.com/kml/2.2"> '+
-                  '<Document> <Name>name of the document</Name><visibility>1</visibility><open>1</open>'+
-                  '<address>Stree 5, 111111 State</address>'+
-                  '<phoneNumber>+555 555 555</phoneNumber>'+
-                  '<phoneNumber>+555 555 555</phoneNumber>'+
-                  '<description>some description</description>'+
-                  '<NetworkLink> <Link> <href>http://maker.geocommons.com/maps/1717/overlays/0</href> </Link> </NetworkLink> </Document></kml>';
+    var test_nl = '<kml xmlns="http://earth.google.com/kml/2.2"> <NetworkLink> <Link> <href>http://maker.geocommons.com/maps/1717/overlays/0</href> </Link> </NetworkLink></kml>';
+
     function test_Format_KML_constructor(t) { 
         t.plan(5); 
          
@@ -72,6 +67,36 @@
         }
         f.read(test_nl);
     }
+
+    function test_Format_KML_document(t) {
+        t.plan(9);
+        var test_document = '<kml xmlns="http://earth.google.com/kml/2.0"> '+
+                '<Document>'+
+                        '<name>name of the document</name>'+
+                        '<visibility>1</visibility>'+
+                        '<open>1</open>'+
+                        '<address>Street 5, 111111 State</address>'+
+                        '<phoneNumber>+555 555 555</phoneNumber>'+
+                        '<snipped><![CDATA[<p>snipped</p>]]></snipped>'+
+                        '<description>some description</description>'+
+                        '<styleUrl>http://foo/bar/styleUrl</styleUrl>'+
+                '</Document></kml>';
+
+        var f = new OpenLayers.Format.KML();
+        var features = f.read(test_document);
+
+        var doc = f["document"];
+        t.ok(doc,"Document exists");
+        t.eq(doc.name,"name of the document","Document name parsed");
+        t.eq(doc.visibility,true,"Document visibility parsed");
+        t.eq(doc.open,true,"Document open parsed");
+        t.eq(doc.address,"Street 5, 111111 State","Document address parsed");
+        t.eq(doc.phoneNumber,"+555 555 555","Document phone parsed");
+        t.eq(doc.snipped,"<p>snipped</p>","Document snipped parsed");
+        t.eq(doc.description,"some description","Document description parsed");
+        t.eq(doc.styleUrl,"http://foo/bar/styleUrl","Document styleUrl parsed");
+    }
+
     function test_Format_KML_readCdataAttributes_21(t) {
         t.plan(2);
         var cdata = '<kml xmlns="http://earth.google.com/kml/2.1"><Document><Placemark><name><![CDATA[Pezinok]]></name><description><![CDATA[Full of text.]]></description><styleUrl>#rel1.0</styleUrl><Point> <coordinates>17.266666, 48.283333</coordinates></Point></Placemark></Document></kml>';


### PR DESCRIPTION
Currently, name, description, author and other attributes of KML elements Document and Folder are ignored silently. 

This tries to parse those attributes and store it to the OpenLayers.Format.KML instance as attributes.

Tests included.
