### PR TITLE
Change Projection so Proj4js no longer has to be global

### DIFF
--- a/lib/OpenLayers/Projection.js
+++ b/lib/OpenLayers/Projection.js
@@ -62,7 +62,7 @@ OpenLayers.Projection = OpenLayers.Class({
     initialize: function(projCode, options) {
         OpenLayers.Util.extend(this, options);
         this.projCode = projCode;
-        if (window.Proj4js) {
+        if (typeof Proj4js == "object") {
             this.proj = new Proj4js.Proj(projCode);
         }
     },
@@ -115,7 +115,7 @@ OpenLayers.Projection = OpenLayers.Class({
             if (!(p instanceof OpenLayers.Projection)) {
                 p = new OpenLayers.Projection(p);
             }
-            if (window.Proj4js && this.proj.defData && p.proj.defData) {
+            if ((typeof Proj4js == "object") && this.proj.defData && p.proj.defData) {
                 equals = this.proj.defData.replace(this.titleRegEx, "") ==
                     p.proj.defData.replace(this.titleRegEx, "");
             } else if (p.getCode) {


### PR DESCRIPTION
Anyone got any problems with changing this to simply check whether Proj4js object is present rather than requiring it to be a global?

Just in case, ran projection test plus a couple of other class tests that create projection object. Also tried using-proj4js example. All continue to work without problem.
