### PR TITLE
Credits on an example map are wrong.

### DIFF
--- a/examples/mapquest.js
+++ b/examples/mapquest.js
@@ -24,7 +24,7 @@ var map = new OpenLayers.Map({
                 "http://oatile4.mqcdn.com/naip/${z}/${x}/${y}.png"
             ],
             {
-                attribution: "Tiles Courtesy of <a href='http://open.mapquest.co.uk/' target='_blank'>MapQuest</a> <img src='http://developer.mapquest.com/content/osm/mq_logo.png' border='0'>",
+                attribution: "Tiles Courtesy of <a href='http://open.mapquest.co.uk/' target='_blank'>MapQuest</a>. Portions Courtesy NASA/JPL-Caltech and U.S. Depart. of Agriculture, Farm Service Agency. <img src='http://developer.mapquest.com/content/osm/mq_logo.png' border='0'>",
                 transitionEffect: "resize"
             }
         )


### PR DESCRIPTION
This pull request has 2 commits, both commit comments include a link to the web page that seems to specify the required credit.

See comments on one of the commits for further discussion.

But note I am not officially part of OpenStreetMap or MapQuest, I'm just going off what the web pages say. I may be wrong, should be checked carefully.
