### PR TITLE
Replace eval in Geometry.Collection.clone()

### DIFF
--- a/lib/OpenLayers/Geometry/Collection.js
+++ b/lib/OpenLayers/Geometry/Collection.js
@@ -75,7 +75,7 @@ OpenLayers.Geometry.Collection = OpenLayers.Class(OpenLayers.Geometry, {
      * {<OpenLayers.Geometry.Collection>} An exact clone of this collection
      */
     clone: function() {
-        var geometry = eval("new " + this.CLASS_NAME + "()");
+        var geometry = new OpenLayers.Geometry[this.CLASS_NAME.split(".").pop()]();
         for(var i=0, len=this.components.length; i<len; i++) {
             geometry.addComponent(this.components[i].clone());
         }


### PR DESCRIPTION
Apart from being evil, this eval won't work in the situation where the OpenLayers var is wrapped in an AMD define function and then run through the closure compiler; the compiler will change 'OpenLayers' to 'c' or something.

This simple fix should work with all geometry types, as the class names are all OpenLayers.Geometry.xxx, and the clone tests continue to pass.

There's a similar issue with Symbolizer.clone() which also uses an eval. However, to fix this would require more fiddling around to cater for class-names of both OpenLayers.Symbolizer and OpenLayers.Symbolizer.xxx. As I don't use Symbolizer, that's not a priority for me.
