### PR TITLE
Util: Add google-style polyline decoder

### DIFF
--- a/lib/OpenLayers/Util.js
+++ b/lib/OpenLayers/Util.js
@@ -1830,3 +1830,43 @@ OpenLayers.Util.decodeGoogleLoD = function(levels, num_levels) {
 
     return lod;
 };
+
+/**
+ * APIFunction: decodeGoogle
+ * This function will decode a google-style string to an array
+ *
+ * Algorithm by http://facstaff.unca.edu/mcmcclur/GoogleMaps/EncodePolyline/
+ *
+ * Parameters:
+ * list- {String} encoded list
+ *
+ * Returns:
+ * {Array(int} decoded list
+ */
+OpenLayers.Util.decodeGoogle = function(list_encoded) {
+    var list = new Array();
+
+    var b;
+    var i = 0;
+    var result;
+    var shift;
+    var value = 0;
+
+    while (i < list_encoded.length) {
+      result = 0;
+      shift = 0;
+
+      do {
+        b = list_encoded.charCodeAt(i++) - 63;
+        result |= (b & 0x1f) << shift;
+        shift += 5;
+      } while (b >= 0x20);
+
+      value += (result & 1) ? ~(result >> 1) : (result >> 1);
+
+      list.push(value);
+    }
+
+    return list;
+};
+


### PR DESCRIPTION
Google polyline encoding is a really good way to save some bytes on the wire, especially for large linestrings. Together with my ProgressiveLineString class it would be possible to have self-refining polylines like the polylines in google maps API.

As a example, i've an application which displays GPS tracks with up to 10000 fixes. Encoded with the google algorithm those polylines take only 22 kb.

I'd like to have some feedback on this to continue working towards integration in OL.
