### PR TITLE
Control/Navigation: support forceFixedZoomLevel as in Control/PanZoomBar

### DIFF
--- a/lib/OpenLayers/Control/Navigation.js
+++ b/lib/OpenLayers/Control/Navigation.js
@@ -73,6 +73,13 @@ OpenLayers.Control.Navigation = OpenLayers.Class(OpenLayers.Control, {
      * {Boolean} Whether the mousewheel should zoom the map
      */
     zoomWheelEnabled: true,
+
+    /**
+     * APIProperty: forceFixedZoomLevel
+     * {Boolean} Force a fixed zoom level even though the map has
+     *     fractionalZoom
+     */
+    forceFixedZoomLevel: false,
     
     /**
      * Property: mouseWheelOptions
@@ -265,7 +272,15 @@ OpenLayers.Control.Navigation = OpenLayers.Class(OpenLayers.Control, {
             deltaZ =  Math.round(deltaZ);
         }
         var currentZoom = this.map.getZoom();
-        var newZoom = this.map.getZoom() + deltaZ;
+        var newZoom;
+
+        if (this.map.fractionalZoom && this.forceFixedZoomLevel &&
+            currentZoom != Math.round(currentZoom)) {
+            newZoom = (deltaZ < 0)?Math.floor(currentZoom):Math.ceil(currentZoom);
+        } else {
+            newZoom = this.map.getZoom() + deltaZ;
+        }
+
         newZoom = Math.max(newZoom, 0);
         newZoom = Math.min(newZoom, this.map.getNumZoomLevels());
         if (newZoom === currentZoom) {


### PR DESCRIPTION
OL.Control.Navigation doesn't have had a "forceFixedZoomLevel" switch as the PanZoomBar. This commit adds this feature.
