### PR TITLE
fix size initialization and resolution/zoom usage

### DIFF
--- a/lib/OpenLayers/Layer/Zoomify.js
+++ b/lib/OpenLayers/Layer/Zoomify.js
@@ -133,13 +133,17 @@ OpenLayers.Layer.Zoomify = OpenLayers.Class(OpenLayers.Layer.Grid, {
         this.tierImageSize.reverse();
 
         this.numberOfTiers = this.tierSizeInTiles.length;
-
+        var resolutions = [1];
         this.tileCountUpToTier = [0];
         for (var i = 1; i < this.numberOfTiers; i++) {
+            resolutions.unshift(Math.pow(2, i));
             this.tileCountUpToTier.push(
                 this.tierSizeInTiles[i-1].w * this.tierSizeInTiles[i-1].h +
                 this.tileCountUpToTier[i-1]
                 );
+        }
+        if (!this.serverResolutions) {
+            this.serverResolutions = resolutions;
         }
     },
 


### PR DESCRIPTION
clone member function tries to clone a non initialized member variable: size. Add size initialization.

must use serverResolutions if provided instead of zoom/resolution directly provided to functions.
