### PR TITLE
Fix for typo in OL 2.12 release notes

### DIFF
--- a/notes/2.12.md
+++ b/notes/2.12.md
@@ -72,7 +72,7 @@ The displaying of tiles can now be animated, using CSS3 transitions. Transitions
 
 People can override this rule to use other transition settings. To remove tile animation entirely use:
 
-    .olLayerGridTile .olTileImage {
+    .olLayerGrid .olTileImage {
         -webkit-transition: none;
         -moz-transition: none;
         -o-transition: all 0 none;


### PR DESCRIPTION
`.olLayerGridTile` should be `.olLayerGrid`
