### PR TITLE
Change order of instructions

### DIFF
--- a/lib/OpenLayers/Control/DrawFeature.js
+++ b/lib/OpenLayers/Control/DrawFeature.js
@@ -119,8 +119,8 @@ OpenLayers.Control.DrawFeature = OpenLayers.Class(OpenLayers.Control, {
         );
         if(proceed !== false) {
             feature.state = OpenLayers.State.INSERT;
-            this.layer.addFeatures([feature]);
             this.featureAdded(feature);
+            this.layer.addFeatures([feature]);
             this.events.triggerEvent("featureadded",{feature : feature});
         }
     },


### PR DESCRIPTION
It looks like now impossible to add any custom properties before rendering features created by DrawFeature control. For example I have a vector layer and `label: "${title}"` is used as one of style property for its rendering. Now for newly created feature label is equal "undefined".

With this fix  you can previously perform featureAdded function, for example:

```
featureAdded = function(f) {
    f.attributes.title = "any title";
}
```

And after that add this feature to layer.
