### PR TITLE
CORS support in Request: remove console warning if not same origin

### DIFF
--- a/lib/OpenLayers/Lang/en.js
+++ b/lib/OpenLayers/Lang/en.js
@@ -83,9 +83,6 @@ OpenLayers.Lang.en = {
         "This method has been deprecated and will be removed in 3.0. " +
         "Please use ${newMethod} instead.",
 
-    'proxyNeeded': "You probably need to set OpenLayers.ProxyHost to access ${url}."+
-        "See http://trac.osgeo.org/openlayers/wiki/FrequentlyAskedQuestions#ProxyHost",
-
     // **** end ****
     'end': ''
     

--- a/lib/OpenLayers/Lang/fr.js
+++ b/lib/OpenLayers/Lang/fr.js
@@ -49,7 +49,5 @@ OpenLayers.Lang["fr"] = OpenLayers.Util.applyDefaults({
 
     'reprojectDeprecated': "Vous utilisez l\'option \'reproject\' sur la couche ${layerName}. Cette option est dépréciée : Son usage permettait d\'afficher des données au dessus de couches raster commerciales.Cette fonctionalité est maintenant supportée en utilisant le support de la projection Mercator Sphérique. Plus d\'information est disponible sur http://trac.openlayers.org/wiki/SphericalMercator.",
 
-    'methodDeprecated': "Cette méthode est dépréciée, et sera supprimée à la version 3.0. Merci d\'utiliser ${newMethod} à la place.",
-
-    'proxyNeeded': "Vous avez très probablement besoin de renseigner OpenLayers.ProxyHost pour accéder à ${url}. Voir http://trac.osgeo.org/openlayers/wiki/FrequentlyAskedQuestions#ProxyHost"
+    'methodDeprecated': "Cette méthode est dépréciée, et sera supprimée à la version 3.0. Merci d\'utiliser ${newMethod} à la place."
 });

--- a/lib/OpenLayers/Lang/pl.js
+++ b/lib/OpenLayers/Lang/pl.js
@@ -85,9 +85,5 @@ OpenLayers.Lang["pl"] = OpenLayers.Util.applyDefaults({
     // console message
     'methodDeprecated':
         "Ta metoda jest przestarzała i będzie usunięta od wersji 3.0. " +
-        "W zamian użyj ${newMethod}.",
-
-    'proxyNeeded': "Prawdopodobnie musisz ustawić OpenLayers.ProxyHost aby otrzymać dostęp do ${url}."+
-        "See http://trac.osgeo.org/openlayers/wiki/FrequentlyAskedQuestions#ProxyHost"
-
+        "W zamian użyj ${newMethod}."
 });

--- a/lib/OpenLayers/Request.js
+++ b/lib/OpenLayers/Request.js
@@ -106,9 +106,6 @@ OpenLayers.Util.extend(OpenLayers.Request, {
                 } else {
                     url = proxy + encodeURIComponent(url);
                 }
-            } else {
-                OpenLayers.Console.warn(
-                    OpenLayers.i18n("proxyNeeded"), {url: url});
             }
         }
         return url;


### PR DESCRIPTION
In principle, makeSameOrigin() in Request.js should be changed, as CORS removes the requirement for same origin. However, the current logic supports CORS as is (simply leave ProxyHost set to ''), so in practice there's no need to change anything. I would however suggest getting rid of the redundant Console.warn (which AFAICS serves no useful purpose anyway).
