### PR TITLE
Added dependency on QueryStringFilter

### DIFF
--- a/lib/OpenLayers/Protocol/HTTP.js
+++ b/lib/OpenLayers/Protocol/HTTP.js
@@ -5,6 +5,7 @@
 
 /**
  * @requires OpenLayers/Protocol.js
+ * @requires OpenLayers/Format/QueryStringFilter.js
  * @requires OpenLayers/Request/XMLHttpRequest.js
  */
 


### PR DESCRIPTION
This is a neccessary fix because of the:

``` javascript
var format = new OpenLayers.Format.QueryStringFilter({...});
```

inside the initialize function of the HTTP protocol class.
