### PR TITLE
Patch for Ticket #2020 - enhancement to the accessibility of the layer switcher

### DIFF
--- a/lib/OpenLayers/Control/LayerSwitcher.js
+++ b/lib/OpenLayers/Control/LayerSwitcher.js
@@ -345,7 +345,7 @@ OpenLayers.Control.LayerSwitcher =
                 // create span
                 var labelSpan = document.createElement("label");
                 labelSpan['for'] = inputElem.id;
-		//labelSpan.setAttribute('for',inputElem.id);
+		labelSpan.setAttribute('for',inputElem.id);
                 OpenLayers.Element.addClass(labelSpan, "labelSpan olButton");
                 labelSpan._layer = layer.id;
                 labelSpan._layerSwitcher = this.id;


### PR DESCRIPTION
This is a patch for Ticket #2020. Changing the label for the layer switcher to a fieldset/legend, to ensure better accessibility and fixing the for attribute on the label as it is currently not working on Firefox
