### PR TITLE
Don't applyBackBuffer when moving to extent outside of current bounds

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -457,8 +457,20 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
                         this.removeBackBuffer();
                     }
 
-                    if(!zoomChanged || this.transitionEffect === 'resize') {
-                        this.applyBackBuffer(serverResolution);
+                    if( this.transitionEffect === 'resize' ) {
+
+                            // if new-bounds is within old-bounds (zoom-out)
+                            if( (tilesBounds && tilesBounds.containsBounds(bounds))
+
+                                // if old-bounds intersects new-bounds (pan)
+                                || (tilesBounds && tilesBounds.intersectsBounds(bounds))
+
+                                // if old-bounds is within new-bounds (zoom-in)
+                                || (bounds && tilesBounds
+                                    && bounds.containsBounds(tilesBounds))  )
+                            {
+                                    this.applyBackBuffer(serverResolution);
+                            }
                     }
 
                     this.initSingleTile(bounds);


### PR DESCRIPTION
https://github.com/openlayers/openlayers/issues/582

With fix ( Layer/Grid-new.js )
http://demo.mapsolutions.com.au/IntraMaps80/Frontend/tests/integration/melton/default-dev-new.htm

Without fix ( Layer/Grid.js )
http://demo.mapsolutions.com.au/IntraMaps80/Frontend/tests/integration/melton/default-dev.htm

To compare them, 
TYPE these address into “Enter your address” search box,
Select first match under dropdown
and press ENTER after each:

11 Abbington CR
3 Abelia CRT
60-78 Abey RD

Focus on the transition between images.

Default behaviour is to apply a backbuffer, which seems like blanking the map.

Proposed behaviour (default-dev-new.htm) is to apply backbuffer only when:
1.  new bounds intersect with old bounds.
2.  New bounds contains old bounds or vice versa (zoom-in/out)

The ideal behaviour is 
to update map when image arrives on programmatic zoomToExtent,
http://gis.stackexchange.com/questions/28724/can-we-request-new-openlayer-wms-image-for-an-extent-without-moving-the-map 

However, the proposed behaviour mentioned above is closest we can get (without much refactoring).
http://demo.mapsolutions.com.au/mapcontrol/melton/ is our map without openlayers.

Browser I’m using:
Chrome 20.0.1132.47 m /Win7

Let us know if you need more info.
