### PR TITLE
Opera flickering because of screen refresh while javascript executed

### DIFF
--- a/lib/OpenLayers/Layer/Vector.js
+++ b/lib/OpenLayers/Layer/Vector.js
@@ -473,8 +473,27 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
     moveTo: function(bounds, zoomChanged, dragging) {
         OpenLayers.Layer.prototype.moveTo.apply(this, arguments);
         
-        var coordSysUnchanged = true;
+        var extent = this.map.getExtent().scale(this.ratio);
+        var coordSysUnchanged = this.renderer.setExtent(extent, zoomChanged);
+        
+        if (!this.drawn || zoomChanged || !coordSysUnchanged) {
+            this.drawn = true;
+            var feature;
+            for(var i=0, len=this.features.length; i<len; i++) {
+                this.renderer.locked = (i !== (len - 1));
+                feature = this.features[i];
+                this.drawFeature(feature);
+            }
+        }    
+        
         if (!dragging) {
+            if (!zoomChanged && coordSysUnchanged) {
+                for (var i in this.unrenderedFeatures) {
+                    var feature = this.unrenderedFeatures[i];
+                    this.drawFeature(feature);
+                }
+            }
+        
             this.renderer.root.style.visibility = 'hidden';
 
             var viewSize = this.map.getSize(),
@@ -490,8 +509,6 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             this.div.style.left = offsetLeft + 'px';
             this.div.style.top = offsetTop + 'px';
 
-            var extent = this.map.getExtent().scale(this.ratio);
-            coordSysUnchanged = this.renderer.setExtent(extent, zoomChanged);
 
             this.renderer.root.style.visibility = 'visible';
 
@@ -501,23 +518,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             if (OpenLayers.IS_GECKO === true) {
                 this.div.scrollLeft = this.div.scrollLeft;
             }
-            
-            if (!zoomChanged && coordSysUnchanged) {
-                for (var i in this.unrenderedFeatures) {
-                    var feature = this.unrenderedFeatures[i];
-                    this.drawFeature(feature);
-                }
-            }
         }
-        if (!this.drawn || zoomChanged || !coordSysUnchanged) {
-            this.drawn = true;
-            var feature;
-            for(var i=0, len=this.features.length; i<len; i++) {
-                this.renderer.locked = (i !== (len - 1));
-                feature = this.features[i];
-                this.drawFeature(feature);
-            }
-        }    
     },
     
     /** 


### PR DESCRIPTION
Hello,

i've noticed some filckering while panning the map in Opera.
This happens when a large number of features are rendered using Canvas renderer (so the redraw time is long).
I haven't looked at the Openlayers code but i have some clue of explanation:
While dragging the map the canvas div moves. 
After the dragging is complete the canvas div is moved back to ist original place.
After the div is in its originial position, the features on the canvas are redrawn.
Every Browser except Opera is not updating/rendering the screen while javascript is executing.
Opera does. So when the the Canvas.redraw() is executed and taking some time, Opera decides to refresh the screen before the redraw() is complete. The canvas div is showing up at its original position with the features rendered still at their old locations, until redraw() is complete.

Heres a Gist showing the problem:
https://gist.github.com/3082529
