### PR TITLE
use minus sign

### DIFF
--- a/lib/OpenLayers/Control/Zoom.js
+++ b/lib/OpenLayers/Control/Zoom.js
@@ -37,9 +37,9 @@ OpenLayers.Control.Zoom = OpenLayers.Class(OpenLayers.Control, {
     /**
      * APIProperty: zoomOutText
      * {String}
-     * Text for zoom-out link.  Default is "-".
+     * Text for zoom-out link.  Default is "−".
      */
-    zoomOutText: "-",
+    zoomOutText: "−",
 
     /**
      * APIProperty: zoomOutId


### PR DESCRIPTION
Use the minus sign in the Zoom controller, see more documentation:
http://en.wikipedia.org/wiki/Plus_and_minus_signs

Illustration, on the left the new version, on the right the current one.
https://plus.google.com/photos/110906094708123391897/albums/5764322547487866273?authkey=CKqq0PWB5oST2gE
