### PR TITLE
OpenLayers.Control (2.12): Losing the Input focus in a custom control

### DIFF
--- a/lib/OpenLayers/Handler/Drag.js
+++ b/lib/OpenLayers/Handler/Drag.js
@@ -172,9 +172,6 @@ OpenLayers.Handler.Drag = OpenLayers.Class(OpenLayers.Handler, {
             this.down(evt);
             this.callback("down", [evt.xy]);
 
-            // prevent document dragging
-            OpenLayers.Event.preventDefault(evt);
-
             if(!this.oldOnselectstart) {
                 this.oldOnselectstart = document.onselectstart ?
                     document.onselectstart : OpenLayers.Function.True;
@@ -204,6 +201,9 @@ OpenLayers.Handler.Drag = OpenLayers.Class(OpenLayers.Handler, {
         this.lastMoveEvt = evt;
         if (this.started && !this.timeoutId && (evt.xy.x != this.last.x ||
                                                 evt.xy.y != this.last.y)) {
+            // prevent document dragging
+            OpenLayers.Event.preventDefault(evt);
+
             if(this.documentDrag === true && this.documentEvents) {
                 if(evt.element === document) {
                     this.adjustXY(evt);


### PR DESCRIPTION
When I created a custom control for OpenLayers 2.11, the inputs text that I put inside, ran perfectly. I have decided migrate the code to new version of OL. I have found that the input texts don't work in this version! 
The focus of the input lose the position and when try to type something, the input does not write the text.

Do you know how solve the problem?

Thank you in advance
