### PR TITLE
Prevent KeyboardDefaults.js from triggering keyboard events when user is...

### DIFF
--- a/lib/OpenLayers/Control/KeyboardDefaults.js
+++ b/lib/OpenLayers/Control/KeyboardDefaults.js
@@ -75,6 +75,14 @@ OpenLayers.Control.KeyboardDefaults = OpenLayers.Class(OpenLayers.Control, {
      */
     defaultKeyPress: function (evt) {
         var size, handled = true;
+
+        if((typeof evt.target) != 'undefined' &&
+            (evt.target.tagName == 'INPUT' ||
+             evt.target.tagName == 'TEXTAREA' ||
+             evt.target.tagName == 'SELECT')) {
+            return;
+        }
+
         switch(evt.keyCode) {
             case OpenLayers.Event.KEY_LEFT:
                 this.map.pan(-this.slideFactor, 0);


### PR DESCRIPTION
Prevent KeyboardDefaults.js from triggering keyboard events when user is typing into the form elements.
For example I couldn't write "-" or "+" signs in the form elements when the KeyboardDefaults was active.
