### PR TITLE
Wrong regexp for string replacements when using styles

### DIFF
--- a/lib/OpenLayers/Style.js
+++ b/lib/OpenLayers/Style.js
@@ -331,7 +331,7 @@ OpenLayers.Style = OpenLayers.Class({
         for (var key in symbolizer) {
             property = symbolizer[key];
             if (typeof property == "string" &&
-                    property.match(/\$\{\w+\}/)) {
+                    property.match(OpenLayers.String.tokenRegEx)) {
                 propertyStyles[key] = true;
             }
         }


### PR DESCRIPTION
OpenLayers.Style is using OpenLayers.String.format() to replace attributes like `${name}` for example in the context of Features. String.format() is using `OpenLayers.String.tokenRegEx:  /\$\{([\w.]+?)\}/g` for the actual string replacement. 

Unfortunately in OpenLayers.Style.addPropertyStyles() is using a custom, hard-coded, regexp `/\$\{\w+\}/` to build a list of placeholders that will  be finally replaced when passing strings (see: OpenLayers.Style.createLiterals())

This mismatch has some negative results:
- At the moment one can use OpenLayers.String.format() to replace nested lists ${a.b} => [a][b]. But this is not working in styles, because the regexp in OpenLayers.Style won't match a ".".
- Another Problem occurs if someone wants to extend the token matching, for example to match something like: ${addr:street} This would be really simple if OpenLayers.Style would use the tokenRegEx

My Patch is simply replacing the hardcoded regexp to use OpenLayers.String.tokenRegEx for matching and thus allowing for nested lists and custom replacement-matchings in styles.
