### PR TITLE
FramedCloud Popup: adjust the insertion point.

### DIFF
--- a/lib/OpenLayers/Popup/FramedCloud.js
+++ b/lib/OpenLayers/Popup/FramedCloud.js
@@ -90,12 +90,12 @@ OpenLayers.Popup.FramedCloud =
                 { // stem
                     size: new OpenLayers.Size(81, 35),
                     anchor: new OpenLayers.Bounds(null, 0, 0, null),
-                    position: new OpenLayers.Pixel(0, -688)
+                    position: new OpenLayers.Pixel(0, -687)
                 }
             ]
         },
         "tr": {
-            'offset': new OpenLayers.Pixel(-45, 0),
+            'offset': new OpenLayers.Pixel(-44, 0),
             'padding': new OpenLayers.Bounds(8, 40, 8, 9),
             'blocks': [
                 { // top-left
@@ -114,9 +114,9 @@ OpenLayers.Popup.FramedCloud =
                     position: new OpenLayers.Pixel(0, -631)
                 },
                 { //bottom-right
-                    size: new OpenLayers.Size(22, 19),
+                    size: new OpenLayers.Size(22, 18),
                     anchor: new OpenLayers.Bounds(null, 32, 0, null),
-                    position: new OpenLayers.Pixel(-1238, -631)
+                    position: new OpenLayers.Pixel(-1238, -632)
                 },
                 { // stem
                     size: new OpenLayers.Size(81, 35),
@@ -126,7 +126,7 @@ OpenLayers.Popup.FramedCloud =
             ]
         },
         "bl": {
-            'offset': new OpenLayers.Pixel(45, 0),
+            'offset': new OpenLayers.Pixel(44, 0),
             'padding': new OpenLayers.Bounds(8, 9, 8, 40),
             'blocks': [
                 { // top-left


### PR DESCRIPTION
Using `Popup.FramedCloud` the insertion point is moved one pixel in some cases (depending on relative position is used):
- "tl": 1px to up
- "bl": 1px to right
- "tr": 1px to left
- "br": is ok!

and in "tl" the border around the stem is two pixels instead of one.

See http://jsfiddle.net/jorix/kUPXr/ (need to zoom your browser to see the mismatches) 
and dev+patch: http://jsfiddle.net/jorix/kPKzM/ (fixed)

(some time ago I saw some of these mismatches so is not only a problem of the current version)
