### PR TITLE
return response object on "loadend" event for Fixed strategy

### DIFF
--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -87,7 +87,9 @@ OpenLayers.Layer = OpenLayers.Class({
      *
      * Supported map event types:
      * loadstart - Triggered when layer loading starts.
-     * loadend - Triggered when layer loading ends.
+     * loadend - Triggered when layer loading ends.  When using Fixed or BBOX
+     *     strategies, the event object includes a *response* property holding
+     *     an OpenLayers.Protocol.Response object.
      * visibilitychanged - Triggered when layer visibility is changed.
      * move - Triggered when layer moves (triggered with every mousemove
      *     during a drag).
@@ -119,7 +121,7 @@ OpenLayers.Layer = OpenLayers.Class({
  
     /**
      * Property: alpha
-     * {Boolean} The layer's images have an alpha channel.  Default is false. 
+     * {Boolean} The layer's images have an alpha channel.  Default is false.
      */
     alpha: false,
 

--- a/lib/OpenLayers/Strategy/BBOX.js
+++ b/lib/OpenLayers/Strategy/BBOX.js
@@ -278,7 +278,7 @@ OpenLayers.Strategy.BBOX = OpenLayers.Class(OpenLayers.Strategy, {
             this.layer.addFeatures(features);
         }
         this.response = null;
-        this.layer.events.triggerEvent("loadend");
+        this.layer.events.triggerEvent("loadend", {response: resp});
     },
    
     CLASS_NAME: "OpenLayers.Strategy.BBOX" 

--- a/lib/OpenLayers/Strategy/Fixed.js
+++ b/lib/OpenLayers/Strategy/Fixed.js
@@ -124,7 +124,7 @@ OpenLayers.Strategy.Fixed = OpenLayers.Class(OpenLayers.Strategy, {
             }
             layer.addFeatures(features);
         }
-        layer.events.triggerEvent("loadend");
+        layer.events.triggerEvent("loadend", {response: resp});
     },
 
     CLASS_NAME: "OpenLayers.Strategy.Fixed"


### PR DESCRIPTION
This is a fix as suggested by @elemoine in #85.
