### PR TITLE
Avoid breaking the "OpenLayers.String.format" execution

### DIFF
--- a/lib/OpenLayers/BaseTypes.js
+++ b/lib/OpenLayers/BaseTypes.js
@@ -127,7 +127,9 @@ OpenLayers.String = {
                 if (i == 0) {
                     replacement = context;
                 }
-
+                if (replacement === undefined) {
+                    break;
+                }
                 replacement = replacement[subs[i]];
             }
 

--- a/tests/BaseTypes.html
+++ b/tests/BaseTypes.html
@@ -155,8 +155,8 @@
             }
         };
         t.eq(
-            format("${a.b.c} ${a.b.e} ${a.b.q} ${a} ${a...b...c}", context),
-            "d f undefined [object Object] d",
+            format("${a.b.c} ${a.b.e} ${a.b.q} ${a} ${a...b...c} ${aa.b} ${a.bb.c}", context),
+            "d f undefined [object Object] d undefined undefined",
             "attribute values that are objects are supported"
         );
 


### PR DESCRIPTION
Avoid breaking the "OpenLayers.String.format" execution when searching for an attribute in an undefined object.

Try changes in the tests, without the patch execution fails.

Please review, thanks.
