### PR TITLE
fix issue with orientation changes on mobile devices (tested on Motorola...

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -588,8 +588,13 @@ OpenLayers.Map = OpenLayers.Class({
             // Else updateSize on catching the window's resize
             //  Note that this is ok, as updateSize() does nothing if the 
             //  map's size has not actually changed.
-            this.updateSizeDestroy = OpenLayers.Function.bind(this.updateSize, 
-                this);
+            var me = this;
+            // We need to call this in the next cycle, otherwise it can cause
+            // issues on mobile devices on orientation change. It will use the
+            // height of the previous orientation otherwise.
+            this.updateSizeDestroy = function() {
+                window.setTimeout(function() { me.updateSize(); }, 0);
+            };
             OpenLayers.Event.observe(window, 'resize',
                             this.updateSizeDestroy);
         }


### PR DESCRIPTION
... Xoom 2 with Android 3.2.2 in the stock browser)

Tested in IE8 and the fullScreen example still works as expected. Also the Map.html tests still pass in IE8 and Safari 6.

TIA for any review.

To elaborate on the original issue, when changing the orientation of the device, the height of the map's div would be the previous height, so when moving from portrait to landscape, the landscape map would be much higher than needed.
