### PR TITLE
cleanup and always use window resize as suggested by @tonio

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -587,20 +587,13 @@ OpenLayers.Map = OpenLayers.Class({
         }
 
         if (this.autoUpdateSize === true) {
-            // Because Mozilla does not support the "resize" event for elements 
-            // other than "window", we need to put a hack here. 
-            if (parseFloat(navigator.appVersion.split("MSIE")[1]) < 9) {
-                // If IE < 9, register the resize on the div
-                this.events.register("resize", this, this.updateSize);
-            } else {
-                // Else updateSize on catching the window's resize
-                //  Note that this is ok, as updateSize() does nothing if the 
-                //  map's size has not actually changed.
-                this.updateSizeDestroy = OpenLayers.Function.bind(this.updateSize, 
-                    this);
-                OpenLayers.Event.observe(window, 'resize',
-                                this.updateSizeDestroy);
-            }
+            // updateSize on catching the window's resize
+            // Note that this is ok, as updateSize() does nothing if the 
+            // map's size has not actually changed.
+            this.updateSizeDestroy = OpenLayers.Function.bind(this.updateSize, 
+                this);
+            OpenLayers.Event.observe(window, 'resize',
+                            this.updateSizeDestroy);
         }
         
         // only append link stylesheet if the theme property is set
@@ -753,13 +746,9 @@ OpenLayers.Map = OpenLayers.Class({
         OpenLayers.Event.stopObserving(window, 'unload', this.unloadDestroy);
         this.unloadDestroy = null;
 
-        if (this.autoUpdateSize === true) {
-            if (this.updateSizeDestroy) {
-                OpenLayers.Event.stopObserving(window, 'resize', 
-                                               this.updateSizeDestroy);
-            } else {
-                this.events.unregister("resize", this, this.updateSize);
-            }
+        if (this.updateSizeDestroy) {
+            OpenLayers.Event.stopObserving(window, 'resize', 
+                                           this.updateSizeDestroy);
         }
         
         this.paddingForPopups = null;    

--- a/tests/Map.html
+++ b/tests/Map.html
@@ -2094,20 +2094,7 @@
         t.plan(1);
         OpenLayers.Event.unloadCache();
         var resizeListener = false;
-        var register = OpenLayers.Events.prototype.register;
-        OpenLayers.Events.prototype.register = function(name, el , func) {
-            if (name === 'resize') {
-                resizeListener = true;
-            }
-        };
         var map = new OpenLayers.Map({
-            events: {
-                register: function(name, el, func) {
-                    if (name === 'resize') {
-                        resizeListener = true;
-                    }
-                }
-            },
             autoUpdateSize: false,
             div: 'map',
             layers: [
@@ -2129,7 +2116,6 @@
         }
         t.eq(resizeListener, map.autoUpdateSize, "resize listener not registered when autoUpdateSize is false");
         map.destroy();
-        OpenLayers.Events.prototype.register = register;
     }
 
   </script>


### PR DESCRIPTION
Map tests still pass in FF14, Safari 6 and IE8
