### PR TITLE
When using a buffer, the grid lacks rows/columns at the top/left

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -983,9 +983,9 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
 
         var viewSize = this.map.getSize();
         var minRows = Math.ceil(viewSize.h/this.tileSize.h) + 
-                      Math.max(1, 2 * this.buffer);
+                      2 * this.buffer + 1;
         var minCols = Math.ceil(viewSize.w/this.tileSize.w) +
-                      Math.max(1, 2 * this.buffer);
+                      2 * this.buffer + 1;
         
         var origin = this.getTileOrigin();
         var resolution = this.getServerResolution();

--- a/tests/Layer/Grid.html
+++ b/tests/Layer/Grid.html
@@ -76,8 +76,8 @@
         layer = new OpenLayers.Layer.WMS(name, url, params, {buffer:2});
         map.addLayer(layer);
         map.setCenter(new OpenLayers.LonLat(0,0),5);
-        t.eq( layer.grid.length, 7, "Grid rows is correct." );
-        t.eq( layer.grid[0].length, 6, "Grid cols is correct." );
+        t.eq( layer.grid.length, 8, "Grid rows is correct." );
+        t.eq( layer.grid[0].length, 7, "Grid cols is correct." );
         
     }
 
@@ -712,17 +712,17 @@
         map.setCenter(new OpenLayers.LonLat(0, 0), 4); 
         t.eq( layer0.grid.length, 3, "Grid rows with buffer:0" );
         map.setBaseLayer(layer1);
-        t.eq( layer1.grid.length, 4, "Grid rows with buffer:1" );
+        t.eq( layer1.grid.length, 5, "Grid rows with buffer:1" );
         map.setBaseLayer(layer2);
-        t.eq( layer2.grid.length, 6, "Grid rows with buffer:2" );
+        t.eq( layer2.grid.length, 7, "Grid rows with buffer:2" );
 
         // zooming in on Greenland exercises the bug from pre-r4313
         map.setCenter(new OpenLayers.LonLat(0, 90), 4); 
         t.eq( layer0.grid.length, 3, "Grid rows with buffer:0" );
         map.setBaseLayer(layer1);
-        t.eq( layer1.grid.length, 4, "Grid rows with buffer:1" );
+        t.eq( layer1.grid.length, 5, "Grid rows with buffer:1" );
         map.setBaseLayer(layer2);
-        t.eq( layer2.grid.length, 6, "Grid rows with buffer:2" );
+        t.eq( layer2.grid.length, 7, "Grid rows with buffer:2" );
     }
 
     function test_Layer_Grid_destroy (t) {


### PR DESCRIPTION
This is because the threshold used for deciding when a column or row is shifted is too far to the bottom right. A tiny fix, but effective. A new test makes sure that we don't shift columns more than necessary when the layer is dragged.
