### PR TITLE
singleTile layer hides when calling redraw

### DIFF
--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -277,6 +277,24 @@ OpenLayers.Layer = OpenLayers.Class({
      * {Float}
      */
     minResolution: null,
+    
+    /**
+     * Property: resolution
+     * {Float} Current resolution that the layer is drawn in. This is
+     *     used to determine whether the zoom has changed when calling
+     *     <moveTo> from <redraw>. Subclasses may set this.resolution to
+     *     null prior to calling redraw to force passing zoomChanged
+     *     true to moveTo.
+     */
+    resolution: null,
+
+    /**
+     * Property: containerOrigin
+     * {OpenLayers.LonLat} Current layerContainer origin of the map that the
+     *     layer is drawn in. This is used to determine whether to use
+     *     zoomChanged when calling <moveTo> from <redraw>.
+     */
+    containerOrigin: null,
 
     /**
      * APIProperty: numZoomLevels
@@ -558,7 +576,9 @@ OpenLayers.Layer = OpenLayers.Class({
             var extent = this.getExtent();
 
             if (extent && this.inRange && this.visibility) {
-                var zoomChanged = true;
+                zoomChanged = this.resolution == null ||
+                              this.resolution !== this.map.getResolution() ||
+                              !this.containerOrigin.equals(this.map.layerContainerOrigin);
                 this.moveTo(extent, zoomChanged, false);
                 this.events.triggerEvent("moveend",
                     {"zoomChanged": zoomChanged});
@@ -583,6 +603,8 @@ OpenLayers.Layer = OpenLayers.Class({
             display = display && this.inRange;
         }
         this.display(display);
+        this.resolution = this.map.getResolution();
+        this.containerOrigin = this.map.layerContainerOrigin.clone();
     },
 
     /**
@@ -638,6 +660,8 @@ OpenLayers.Layer = OpenLayers.Class({
             
             // deal with gutters
             this.setTileSize();
+
+            this.resolution = null;
         }
     },
     

--- a/lib/OpenLayers/Layer/HTTPRequest.js
+++ b/lib/OpenLayers/Layer/HTTPRequest.js
@@ -122,6 +122,7 @@ OpenLayers.Layer.HTTPRequest = OpenLayers.Class(OpenLayers.Layer, {
      */
     mergeNewParams:function(newParams) {
         this.params = OpenLayers.Util.extend(this.params, newParams);
+        this.resolution = null;
         var ret = this.redraw();
         if(this.map != null) {
             this.map.events.triggerEvent("changelayer", {
@@ -146,7 +147,7 @@ OpenLayers.Layer.HTTPRequest = OpenLayers.Class(OpenLayers.Layer, {
         if (force) {
             return this.mergeNewParams({"_olSalt": Math.random()});
         } else {
-            return OpenLayers.Layer.prototype.redraw.apply(this, []);
+            return OpenLayers.Layer.prototype.redraw.call(this);
         }
     },
     

--- a/tests/Layer.html
+++ b/tests/Layer.html
@@ -685,18 +685,81 @@
         // test that the moveend event was triggered
         t.ok(log.event, "an event was logged");
         t.eq(log.event.type, "moveend", "moveend was triggered");
-        t.eq(log.event.zoomChanged, true, "event says zoomChanged true - poor name");
+        t.eq(log.event.zoomChanged, false, "event says zoomChanged false");
 
         layer.moveTo = function(bounds, zoomChanged, dragging) {
             var extent = layer.map.getExtent();
             t.ok(bounds.equals(extent),
                  "redraw calls moveTo with the map extent");
-            t.ok(zoomChanged,
-                 "redraw calls moveTo with zoomChanged true");
+            t.ok(!zoomChanged,
+                 "redraw calls moveTo with zoomChanged false");
             t.ok(!dragging,
                  "redraw calls moveTo with dragging false");
         }
         layer.redraw();
+    }
+
+    // This function includes integration tests to verify that the
+    // layer's moveTo function is called with the expected value
+    // for zoomChanged
+    function test_moveTo_zoomChanged(t) {
+        t.plan(6);
+
+        var log = {};
+        var map = new OpenLayers.Map('map');
+
+        var l1 = new OpenLayers.Layer('l1', {isBaseLayer: true});
+        l1.moveTo = function(bounds, zoomChanged, dragging) {
+            log.moveTo = {zoomChanged: zoomChanged};
+            OpenLayers.Layer.prototype.moveTo.apply(this, arguments);
+        };
+
+        map.addLayer(l1);
+        map.zoomToMaxExtent();
+
+        log = {};
+        l1.redraw();
+        t.eq(log.moveTo.zoomChanged, false,
+                "[a] redraw calls moveTo with zoomChanged false");
+
+        log = {};
+        l1.resolution = null;
+        l1.redraw();
+        t.eq(log.moveTo.zoomChanged, true,
+             "[b] redraw calls moveTo with zoomChanged true");
+
+        l1.setVisibility(false);
+        log = {};
+        l1.setVisibility(true);
+        t.eq(log.moveTo.zoomChanged, false,
+             "[c] redraw calls moveTo with zoomChanged false");
+
+        l1.setVisibility(false);
+        map.zoomIn();
+        log = {};
+        l1.setVisibility(true);
+        t.eq(log.moveTo.zoomChanged, true,
+             "[d] redraw calls moveTo with zoomChanged true");
+
+        l1.moveTo = OpenLayers.Layer.prototype.moveTo;
+
+        var l2 = new OpenLayers.Layer('l2');
+        l2.moveTo = function(bounds, zoomChanged, dragging) {
+            log.moveTo = {zoomChanged: zoomChanged};
+            OpenLayers.Layer.prototype.moveTo.apply(this, arguments);
+        };
+        log = {};
+        map.addLayer(l2);
+        t.eq(log.moveTo.zoomChanged, true,
+             "[e] redraw calls moveTo with zoomChanged true");
+
+        map.removeLayer(l2);
+        log = {};
+        map.addLayer(l2);
+        t.eq(log.moveTo.zoomChanged, true,
+             "[f] redraw calls moveTo with zoomChanged true");
+
+        map.destroy();
     }
       
     function test_layer_setIsBaseLayer(t) {

--- a/tests/Layer/HTTPRequest.html
+++ b/tests/Layer/HTTPRequest.html
@@ -68,7 +68,7 @@
     }
 
     function test_Layer_HTTPRequest_mergeNewParams (t) {
-        t.plan( 8 );
+        t.plan( 9 );
 
         var map = new OpenLayers.Map('map');
         layer = new OpenLayers.Layer.HTTPRequest(name, url, params, options);
@@ -100,7 +100,9 @@
         
         layer.redraw = function() {
             t.ok(true, "layer.mergeNewParams calls layer.redraw");
-        }
+            t.ok(layer.resolution === null, "layer.mergeNewParams sets resolution to null");
+        };
+        layer.resolution = 'fake';
         layer.mergeNewParams();
     }
 

--- a/tests/Tile/Image.html
+++ b/tests/Tile/Image.html
@@ -316,6 +316,38 @@
 
         map.destroy();
     }
+
+    // test for https://github.com/openlayers/openlayers/pull/36
+    // (more an integration test than a unit test)
+    function test_olImageLoadError(t) {
+        t.plan(2);
+
+        var map = new OpenLayers.Map('map');
+        var layer = new OpenLayers.Layer.WMS("invalid",  "", {layers: 'basic'});
+        map.addLayer(layer);
+
+        var size = new OpenLayers.Size(5, 6);
+        var position = new OpenLayers.Pixel(20, 30);
+        var bounds = new OpenLayers.Bounds(1, 2, 3, 4);
+
+        var tile = new OpenLayers.Tile.Image(layer, position, bounds, null, size);
+        tile.draw();
+
+        t.delay_call(0.1, function() {
+
+            // check initial state
+            t.ok(OpenLayers.Element.hasClass(tile.imgDiv, 'olImageLoadError'),
+                 'tile image has the olImageLoadError class (init state)');
+
+            layer.setVisibility(false);
+            layer.setVisibility(true);
+
+            t.ok(OpenLayers.Element.hasClass(tile.imgDiv, 'olImageLoadError'),
+                 'tile image still has the olImageLoadError class');
+
+            map.destroy();
+        });
+    }
     
     function test_createBackBuffer(t) {
         t.plan(3);


### PR DESCRIPTION
# Description

When calling `redraw` on a singleTile layer, the images are removed before the new images are loaded.
# Test

In the firebug, try the following console command:

<pre>
map.layers[0].redraw()
</pre>


http://dev.openlayers.org/releases/OpenLayers-2.12/examples/transition.html
http://dev.openlayers.org/releases/OpenLayers-2.11/examples/transition.html

In 2.11, the map stays displayed. In 2.12, we can see a 'flickr' effect.
# Explanation

I think this is due to the introduction of backbuffers.
When calling `redraw` (See `OpenLayers.Layer.js`, `moveTo` is called with `zoomChanged` set to true (which is in our case false).
In 2.12, when `zoomChanged` is true and no `transitionEffect` is provided, the backbuffers are removed.
