### PR TITLE
Adds documentDrag to ModifyFeature

### DIFF
--- a/lib/OpenLayers/Control/ModifyFeature.js
+++ b/lib/OpenLayers/Control/ModifyFeature.js
@@ -28,6 +28,7 @@ OpenLayers.Control.ModifyFeature = OpenLayers.Class(OpenLayers.Control, {
      *     mouse cursor leaves the map viewport. Default is false.
      */
 		documentDrag: false,
+
     /**
      * APIProperty: geometryTypes
      * {Array(String)} To restrict modification to a limited set of geometry


### PR DESCRIPTION
When you dragging a vertice with the ModifyFeature-Control you can't control if the internal ModifyFeature DragFreature-Control is dragging even if the cursor leaves the viewport. 
So i added the documentDrag variable and pass the value to the internal DragFeature.

lg,

fastrde
