### PR TITLE
Document the Google map types

### DIFF
--- a/lib/OpenLayers/Layer/Google.js
+++ b/lib/OpenLayers/Layer/Google.js
@@ -72,9 +72,12 @@ OpenLayers.Layer.Google = OpenLayers.Class(
 
     /**
      * APIProperty: type
-     * {GMapType}
+     * {String} The MapTypeId, from 
+     *     https://developers.google.com/maps/documentation/javascript/maptypes#BasicMapTypes
+     *     Lowercase values work. Default is "roadmap". Others values are
+     *     "satellite', "hybrid" (aerial imagery with labels), and "terrain".
      */
-    type: null,
+    type: "roadmap",
 
     /**
      * APIProperty: wrapDateLine


### PR DESCRIPTION
At http://dev.openlayers.org/apidocs/files/OpenLayers/Layer/Google-js.html#OpenLayers.Layer.Google.type, there should be some documentation about the [supported Google layer types](https://developers.google.com/maps/documentation/javascript/maptypes#BasicMapTypes). Right now, there's only

```
type
{GMapType}
```
