### PR TITLE
#651 - document how to use Cloudmade via Layer.OSM()

### DIFF
--- a/lib/OpenLayers/Layer/OSM.js
+++ b/lib/OpenLayers/Layer/OSM.js
@@ -21,6 +21,18 @@
  *        "http://c.tile.opencyclemap.org/cycle/${z}/${x}/${y}.png"]); 
  * (end)
  *
+ * And here's an example using Cloudmade and a custom style with the ID 70391
+ * 
+ * (code)
+ *     new OpenLayers.Layer.OSM("Cloudmade",
+ *       ["http://a.tile.cloudmade.com/8ee2a50541944fb9bcedded5165f09d9/70391/256/${z}/${x}/${y}.png",
+ *        "http://b.tile.cloudmade.com/8ee2a50541944fb9bcedded5165f09d9/70391/256/${z}/${x}/${y}.png",
+ *        "http://c.tile.cloudmade.com/8ee2a50541944fb9bcedded5165f09d9/70391/256/${z}/${x}/${y}.png"]);
+ * (end)
+ * 
+ * Note that the API key in the URLs is the Cloudmade Demo key, and you should
+ * get your own from your account page, http://cloudmade.com/user/show.
+ * 
  * Inherits from:
  *  - <OpenLayers.Layer.XYZ>
  */


### PR DESCRIPTION
Cloudmade has an HTTP Tiles API that's compatible with OSM - http://developers.cloudmade.com/projects/show/tiles
