### PR TITLE
Fix DOM API call to setAttributeNS()

### DIFF
--- a/lib/OpenLayers/Renderer/SVG.js
+++ b/lib/OpenLayers/Renderer/SVG.js
@@ -282,7 +282,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
                 node.setAttributeNS(null, "y", (pos.y + yOffset).toFixed());
                 node.setAttributeNS(null, "width", width);
                 node.setAttributeNS(null, "height", height);
-                node.setAttributeNS(this.xlinkns, "href", style.externalGraphic);
+                node.setAttributeNS(this.xlinkns, "xlink:href", style.externalGraphic);
                 node.setAttributeNS(null, "style", "opacity: "+opacity);
                 node.onclick = OpenLayers.Event.preventDefault;
             } else if (this.isComplexSymbol(style.graphicName)) {


### PR DESCRIPTION
This is a forward-port of the old patch provided at http://trac.osgeo.org/openlayers/ticket/3611. It is adjusted to the fact that the old SVG2 renderer no longer exists. Description:

> The SVG renderer makes a questionable DOM API call to setAttributeNS(), which works in most cases due to tolerant browser implementations, but does not work in all circumstances.
> 
> In particular, this issue causes missing point markers when OpenLayers is accessed through the Juniper SSL Gateway, and the SVG renderer is used, and the point geometries are styled via externalGraphic.

I think this issue is still worth resolving for the following reasons:
- It improves the portability of OpenLayers.
- Although one could argue this should be fixed in the Juniper SSL Gateway, this is unlikely to happen in the near future, and even if they fix it, there will still be lots of old systems out there.
- This patch will not do any harm: The "link:" prefix binding to the XML namespace "http://www.w3.org/2000/xmlns/" will only happen locally in the part of the DOM tree that is under control of OpenLayers anyway. So even if the XHTML document binds the "xlink:" prefix to a different XML namespace globally, this won't be affected by this call to setAttributeNS().
