### PR TITLE
throw TypeError on invalid transform projection

### DIFF
--- a/lib/OpenLayers/Geometry/Collection.js
+++ b/lib/OpenLayers/Geometry/Collection.js
@@ -504,13 +504,11 @@ OpenLayers.Geometry.Collection = OpenLayers.Class(OpenLayers.Geometry, {
      * {<OpenLayers.Geometry>} 
      */
     transform: function(source, dest) {
-        if (source && dest) {
-            for (var i=0, len=this.components.length; i<len; i++) {  
-                var component = this.components[i];
-                component.transform(source, dest);
-            }
-            this.bounds = null;
+        for (var i=0, len=this.components.length; i<len; i++) {  
+            var component = this.components[i];
+            component.transform(source, dest);
         }
+        this.bounds = null;
         return this;
     },
 

--- a/lib/OpenLayers/Geometry/LinearRing.js
+++ b/lib/OpenLayers/Geometry/LinearRing.js
@@ -174,13 +174,11 @@ OpenLayers.Geometry.LinearRing = OpenLayers.Class(
      * {<OpenLayers.Geometry>} 
      */
     transform: function(source, dest) {
-        if (source && dest) {
-            for (var i=0, len=this.components.length; i<len - 1; i++) {
-                var component = this.components[i];
-                component.transform(source, dest);
-            }
-            this.bounds = null;
+        for (var i=0, len=this.components.length; i<len - 1; i++) {
+            var component = this.components[i];
+            component.transform(source, dest);
         }
+        this.bounds = null;
         return this;
     },
     

--- a/lib/OpenLayers/Geometry/Point.js
+++ b/lib/OpenLayers/Geometry/Point.js
@@ -254,11 +254,9 @@ OpenLayers.Geometry.Point = OpenLayers.Class(OpenLayers.Geometry, {
      * {<OpenLayers.Geometry>} 
      */
     transform: function(source, dest) {
-        if ((source && dest)) {
-            OpenLayers.Projection.transform(
-                this, source, dest); 
-            this.bounds = null;
-        }       
+        OpenLayers.Projection.transform(
+            this, source, dest); 
+        this.bounds = null;    
         return this;
     },
 

--- a/lib/OpenLayers/Projection.js
+++ b/lib/OpenLayers/Projection.js
@@ -227,22 +227,23 @@ OpenLayers.Projection.addTransform = function(from, to, method) {
  * point - {object} A transformed coordinate.  The original point is modified.
  */
 OpenLayers.Projection.transform = function(point, source, dest) {
-    if (source && dest) {
-        if (!(source instanceof OpenLayers.Projection)) {
-            source = new OpenLayers.Projection(source);
-        }
-        if (!(dest instanceof OpenLayers.Projection)) {
-            dest = new OpenLayers.Projection(dest);
-        }
-        if (source.proj && dest.proj) {
-            point = Proj4js.transform(source.proj, dest.proj, point);
-        } else {
-            var sourceCode = source.getCode();
-            var destCode = dest.getCode();
-            var transforms = OpenLayers.Projection.transforms;
-            if (transforms[sourceCode] && transforms[sourceCode][destCode]) {
-                transforms[sourceCode][destCode](point);
-            }
+    if (!(source && dest)) {
+      throw new TypeError("source and dest must be valid Projections");
+    }
+    if (!(source instanceof OpenLayers.Projection)) {
+        source = new OpenLayers.Projection(source);
+    }
+    if (!(dest instanceof OpenLayers.Projection)) {
+        dest = new OpenLayers.Projection(dest);
+    }
+    if (source.proj && dest.proj) {
+        point = Proj4js.transform(source.proj, dest.proj, point);
+    } else {
+        var sourceCode = source.getCode();
+        var destCode = dest.getCode();
+        var transforms = OpenLayers.Projection.transforms;
+        if (transforms[sourceCode] && transforms[sourceCode][destCode]) {
+            transforms[sourceCode][destCode](point);
         }
     }
     return point;


### PR DESCRIPTION
the transform method silently fails if it's passed a `null` or `undefined` source or dest Projection. This can make debugging it very difficult. I think throwing a `TypeError` is more appropriate. 
