### PR TITLE
OpenStreetMap attribution has changed

### DIFF
--- a/lib/OpenLayers/Layer/OSM.js
+++ b/lib/OpenLayers/Layer/OSM.js
@@ -57,7 +57,7 @@ OpenLayers.Layer.OSM = OpenLayers.Class(OpenLayers.Layer.XYZ, {
      * Property: attribution
      * {String} The layer attribution.
      */
-    attribution: "© <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors",
+    attribution: "&copy; <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors",
 
     /**
      * Property: sphericalMercator


### PR DESCRIPTION
OpenStreetMap has changed its licence.

The default attribution for OSM tiles should now be:

&copy; OpenStreetMap contributors - <a href="http://www.openstreetmap.org/copyright">license</a>
