### PR TITLE
Substract page positions instance of mixing client and page position

### DIFF
--- a/lib/OpenLayers/Events/buttonclick.js
+++ b/lib/OpenLayers/Events/buttonclick.js
@@ -173,8 +173,8 @@ OpenLayers.Events.buttonclick = OpenLayers.Class({
                         this.target.triggerEvent("buttonclick", {
                             buttonElement: button,
                             buttonXY: {
-                                x: this.startEvt.clientX - pos[0],
-                                y: this.startEvt.clientY - pos[1]
+                                x: this.startEvt.pageX - pos[0],
+                                y: this.startEvt.pageY - pos[1]
                             }
                         });
                     }


### PR DESCRIPTION
- If you take this example: http://openlayers.org/dev/examples/fractional-zoom.html
- reduce the windows size to have a scrollbar
- scroll
- click on the zoombar (not the slider)
- the slider don't move on the right place

This pull request will fix this issue.

