### PR TITLE
Raise feature in layer

### DIFF
--- a/lib/OpenLayers/Layer/Vector.js
+++ b/lib/OpenLayers/Layer/Vector.js
@@ -699,28 +699,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
             this.events.triggerEvent("featuresremoved", {features: features});
         }
     },
-	
-    /**
-	 * APIMethod: raiseFeature
-	 * Changes the index of the given feature by delta and redraws the layer. If delta is positive, the feature is moved up the layer's feature stack; if delta is negative, the feature is moved down.
-	 * If delta + current is negative it is set to 0 and feature will be at the bottom; if it is bigger then the features count than it is set to the last index and the feature will be at the top.
-	 */
-	raiseFeature:function(feature, delta) {
-		var base = this.features.indexOf(feature);
-		var idx = base + delta;
-        if (idx < 0) {
-            idx = 0;
-        } else if (idx > this.features.length) {
-            idx = this.features.length;
-        }
-        if (base != idx) {
-			this.features.splice(base, 1);
-			this.features.splice(idx, 0, feature);
-			this.eraseFeatures(this.features);
-			this.redraw();
-		}
-	},
-	
+    
     /** 
      * APIMethod: removeAllFeatures
      * Remove all features from the layer.

--- a/tests/Layer/Vector.html
+++ b/tests/Layer/Vector.html
@@ -461,44 +461,7 @@
         
         layer.features = [];
     }
-    function test_drawfeature_ng(t) {
-        t.plan(3);
-        var layer = new OpenLayers.Layer.Vector();
-        layer.drawn = true;
-        var log = [];
-        
-        // Bogus layer renderer needs some methods
-        // for functional tests.
-        var renderer = {
-            initialize: function() {},
-            drawFeature: function(feature, style) {
-                log.push(style);
-            },
-            root: document.createElement("div"),
-            destroy: function() { },
-            eraseFeatures: function() {},
-            setExtent: function() {},
-            setSize: function() {}
-        };
-        var OrigRendererNG = OpenLayers.Renderer.NG;
-        OpenLayers.Renderer.NG = OpenLayers.Class(renderer);
-
-        layer.renderer = new OpenLayers.Renderer.NG();
-        layer.drawFeature(new OpenLayers.Feature.Vector());
-        t.eq(log[0]._createSymbolizer, undefined, "no _createSymbolizer function for static styles");
-        
-        var styleMap = new OpenLayers.StyleMap(new OpenLayers.Style({foo: "${bar}"},
-            {context: {"bar": function(feature){ return "baz" }}}
-        ));
-        layer.styleMap = styleMap;
-        layer.drawFeature(new OpenLayers.Feature.Vector());
-        t.eq(log[1]._createSymbolizer().foo, "baz", "_createSymbolizer function added to style and returns correct result");
-        OpenLayers.Renderer.NG = OrigRendererNG;
-
-       layer.renderer = renderer;
-       layer.drawFeature(new OpenLayers.Feature.Vector());
-        t.eq(log[2]._createSymbolizer, undefined, "no _createSymbolizer function for non-NG renderer");
-    }
+    
     function test_deleted_state(t) {
         t.plan(9);
         
@@ -906,23 +869,6 @@
             "featuresadded event received expected number of features");
     }
 
-	function test_raiseFeature(t) {
-		t.plan(4);
-        var map = new OpenLayers.Map('map');
-        layer = new OpenLayers.Layer.Vector("");
-        map.addLayer(layer);
-        var feature1 = new OpenLayers.Feature.Vector(new OpenLayers.Geometry(1.0, 1.0));
-        var feature2 = new OpenLayers.Feature.Vector(new OpenLayers.Geometry(2.0, 2.0));
-        layer.addFeatures([feature1,feature2]);
-		layer.raiseFeature(feature1, 1);
-        t.eq(layer.features.indexOf(feature1), 1, "first feature raised one up");
-		layer.raiseFeature(feature1, -1);
-        t.eq(layer.features.indexOf(feature1), 0, "first feature raised one down");
-		layer.raiseFeature(feature1, -1);
-        t.eq(layer.features.indexOf(feature1), 0, "feature stays at index 0 because there is no lower position than index 0.");
-		layer.raiseFeature(feature1, 2);
-        t.eq(layer.features.indexOf(feature1), 1, "first feature raised 2 up, but has index 1 because there are only two features in layer.");
-	}
 
 
   </script>


### PR DESCRIPTION
If you can draw and load features into a map, it sometimes happens that i.e. a polygon is over a point. If you then want to select the point or modify it is not possible because the polygon is over it. So I made a function to move a feature in the feature array, like the one in OL.Map.
The moving itself is not a big thing, everyone can implement moving feature in features array in own code, but it's tricky to find that you have to erase the features not only redraw. So it is a useful api method for people who don't dive into OL code.
