### PR TITLE
Format.WMSGetFeatureInfo requires Format.GML

### DIFF
--- a/lib/OpenLayers/Format/WMSGetFeatureInfo.js
+++ b/lib/OpenLayers/Format/WMSGetFeatureInfo.js
@@ -5,6 +5,7 @@
 
 /**
  * @requires OpenLayers/Format/XML.js
+ * @requires OpenLayers/Format/GML.js
  */
 
 /**


### PR DESCRIPTION
This class does ```new OpenLayers.Format.GML()``` in several places, it should have a dependency declaration for it.