### PR TITLE
call stopObserving before setting img.src to blank image as well

### DIFF
--- a/lib/OpenLayers/Tile/Image.js
+++ b/lib/OpenLayers/Tile/Image.js
@@ -324,6 +324,7 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile, {
             if (img.getAttribute("src") == this.blankImageUrl) {
                 load();
             } else {
+                OpenLayers.Event.stopObservingElement(img);
                 OpenLayers.Event.observe(img, "load", load);
                 OpenLayers.Event.observe(img, "error", load);
                 if (this.crossOriginKeyword) {


### PR DESCRIPTION
The current pull request's goal is to address an issue which can be seen in the following example:
http://bl.ocks.org/d/3760503/

In this example, some tile images are not loaded. The blank image (orange star) stays displayed.

It occurs when:
 1 - the map is zoomed to level 4 (client zoom),
 2 - a WMS image is requested (`Image::setImgSrc` is called). At this point, there's a listener on the `load` event for this image
 3 - after a small delay, the map is zoomed to zoom level 3 (same serverResolution),
 4 - `Image::initImage` is called and the image src is set to `blankImageUrl`. At this point, a new listener is put on the `load` event,
 5 - the event described in step 2 is fired before the `blankImageUrl` loading is finished,
 6 - we stop observing img (for any event),
 7 - the event described in step 4 is never fired,
 8 - no WMS image is loaded for the zoom level 3.

The attached patch proposes to also stop observing img (for any event) at step 4 before we add a new listener.
