### PR TITLE
Bing Layers should fetch metadata over HTTPS when the document is server over HTTPS

### DIFF
--- a/lib/OpenLayers/Layer/Bing.js
+++ b/lib/OpenLayers/Layer/Bing.js
@@ -145,7 +145,7 @@ OpenLayers.Layer.Bing = OpenLayers.Class(OpenLayers.Layer.XYZ, {
             jsonp: this._callbackId,
             include: "ImageryProviders"
         }, this.metadataParams);
-        var url = "http://dev.virtualearth.net/REST/v1/Imagery/Metadata/" +
+        var url = "//dev.virtualearth.net/REST/v1/Imagery/Metadata/" +
             this.type + "?" + OpenLayers.Util.getParameterString(params);
         var script = document.createElement("script");
         script.type = "text/javascript";


### PR DESCRIPTION
Currently trying to use a bing maps baselayer on a page served over SSL gives an error like:

`[blocked] The page at https://ushahidi.vm/ ran insecure content from http://dev.virtualearth.net/REST/v1/Imagery/Metadata/Aerial?key=Apumcka0uPOF2lKLorq8aeo4nuqfVVeNRqJjqOcLMJ9iMCTsnMsNd9_OvpA8gR0i&jsonp=_callback_OpenLayers_Layer_Bing_6&include=ImageryProviders.`

The Bing REST api provides metadata over SSL http://msdn.microsoft.com/en-us/library/ff701720.aspx
so Openlayers should use this when a site is using SSL.
