### PR TITLE
Clear the bounds in Protocol.BBOX when a load fails

### DIFF
--- a/lib/OpenLayers/Strategy/BBOX.js
+++ b/lib/OpenLayers/Strategy/BBOX.js
@@ -262,20 +262,24 @@ OpenLayers.Strategy.BBOX = OpenLayers.Class(OpenLayers.Strategy, {
      */
     merge: function(resp) {
         this.layer.destroyFeatures();
-        var features = resp.features;
-        if(features && features.length > 0) {
-            var remote = this.layer.projection;
-            var local = this.layer.map.getProjectionObject();
-            if(!local.equals(remote)) {
-                var geom;
-                for(var i=0, len=features.length; i<len; ++i) {
-                    geom = features[i].geometry;
-                    if(geom) {
-                        geom.transform(remote, local);
+        if (resp.success()) {
+            var features = resp.features;
+            if(features && features.length > 0) {
+                var remote = this.layer.projection;
+                var local = this.layer.map.getProjectionObject();
+                if(!local.equals(remote)) {
+                    var geom;
+                    for(var i=0, len=features.length; i<len; ++i) {
+                        geom = features[i].geometry;
+                        if(geom) {
+                            geom.transform(remote, local);
+                        }
                     }
                 }
+                this.layer.addFeatures(features);
             }
-            this.layer.addFeatures(features);
+        } else {
+            this.bounds = null;
         }
         this.response = null;
         this.layer.events.triggerEvent("loadend", {response: resp});


### PR DESCRIPTION
If a load fails then we won't have any features, but we also won't try and load them again for any part of that area because the bounds tell us we have already loaded them. So clear the bounds in order that reloads will be triggered.
