### PR TITLE
WMTS layers created from capabilities have no serverResolutions

### DIFF
--- a/lib/OpenLayers/Format/WMTSCapabilities.js
+++ b/lib/OpenLayers/Format/WMTSCapabilities.js
@@ -214,6 +214,7 @@ OpenLayers.Format.WMTSCapabilities = OpenLayers.Class(OpenLayers.Format.XML.Vers
                 units: units,
                 resolutions: config.isBaseLayer === false ? undefined :
                     resolutions,
+                serverResolutions: resolutions,
                 tileFullExtent: matrixSet.bounds,
                 dimensions: dimensions,
                 params: params

--- a/tests/Format/WMTSCapabilities/v1_0_0.html
+++ b/tests/Format/WMTSCapabilities/v1_0_0.html
@@ -150,7 +150,7 @@
         }
 
         function test_createLayer(t) {
-            t.plan(41);
+            t.plan(42);
 
             var format = new OpenLayers.Format.WMTSCapabilities();
 
@@ -225,6 +225,7 @@
             t.eq(layer.style, "ch.are.agglomerationen_isolierte_staedte-2000", "correct style identifier");
             t.eq(layer.projection.getCode(), "EPSG:21781", "correct projection");
             t.eq(layer.units, "m", "correct untis");
+            t.ok(layer.serverResolutions === layer.resolutions, "serverResolutions set");
             t.eq(layer.resolutions.length, 3, "correct resolutions length");
             t.ok((layer.resolutions[0] - 4000) < 1, "correct first resolution");
             t.eq(layer.dimensions.length, 1, "correct dimensions length");


### PR DESCRIPTION
By adding serverResolutions to the WMTS configuration, it is possible to
use WMTS layers as overlays, even if the map or the base layer is
configured with different resolutions than the WMTS.
