### PR TITLE
Update lib/OpenLayers/Layer/Grid.js

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -1105,8 +1105,8 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
                 this.loading = true;
                 this.events.triggerEvent("loadstart");
             }
-            this.events.triggerEvent("tileloadstart", {tile: tile});
             this.numLoadingTiles++;
+            return this.events.triggerEvent("tileloadstart", {tile: tile});
         };
       
         tile.onLoadEnd = function(evt) {


### PR DESCRIPTION
Re-ordered a couple lines to explicitly return the value of 'events.triggerEvent' so it can be checked whether tile loading event propagation should be stopped.
