### PR TITLE
Remove error class from image element that might be present from previous load attempts

### DIFF
--- a/lib/OpenLayers/Tile/Image.js
+++ b/lib/OpenLayers/Tile/Image.js
@@ -378,7 +378,12 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile, {
      */
     onImageLoad: function() {
         var img = this.imgDiv;
+        
+        // Remove error class from previous uses of the image DOM element if there
+        OpenLayers.Element.removeClass(img, "olImageLoadError");
+        // Remove event handler for load monitoring
         OpenLayers.Event.stopObservingElement(img);
+        
         img.style.visibility = 'inherit';
         img.style.opacity = this.layer.opacity;
         this.events.triggerEvent("loadend");


### PR DESCRIPTION
When image elements are reused to load other tiles it could happen that the `olImageLoadError` CSS class from the previous image is still assigned and leaves a correctly loaded image invisible.

Or in other words:
- The first image fails to load, therefore `olImageLoadError` is assigned to hide the image element
- The image element gets reused to load and display another tile (which loads fine)
- Because the previously assigned class is still there the second tile is never shown

This patch makes sure the `olImageLoadError` class is removed when an image loaded successfully so that failed images don't prevent other images from being shown later.
