### PR TITLE
Filter.v1 methods need to be available when using Filter writers

### DIFF
--- a/lib/OpenLayers/Format/WPSExecute.js
+++ b/lib/OpenLayers/Format/WPSExecute.js
@@ -16,7 +16,8 @@
  * Inherits from:
  *  - <OpenLayers.Format.XML>
  */
-OpenLayers.Format.WPSExecute = OpenLayers.Class(OpenLayers.Format.XML, {
+OpenLayers.Format.WPSExecute = OpenLayers.Class(OpenLayers.Format.XML,
+                                            OpenLayers.Format.Filter.v1_1_0, {
     
     /**
      * Property: namespaces


### PR DESCRIPTION
Format classes that define member methods need to be mixed into other
format classes that use their writers. In this case, methods from
Filter.v1 were missing so a test for Format.WPSExecute failed.
