### PR TITLE
clear() and setImgSrc() cleanup

### DIFF
--- a/lib/OpenLayers/Tile/Image.js
+++ b/lib/OpenLayers/Tile/Image.js
@@ -224,6 +224,10 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile, {
         OpenLayers.Tile.prototype.clear.apply(this, arguments);
         var img = this.imgDiv;
         if (img) {
+            var tile = this.getTile();
+            if (tile.parentNode === this.layer.div) {
+                this.layer.div.removeChild(tile);
+            }
             this.setImgSrc();
         }
         this.canvasContext = null;


### PR DESCRIPTION
Because clear() is bypassed when draw(true) is called, the
olImageLoadError class is better removed in setImgSrc(). Same goes for the
alphaHack filter. It also turned out that both setImgSrc() and clear()
remove the image from the dom, so this can be removed from clear()
because clear() also calls setImgSrc().
