### PR TITLE
Update lib/OpenLayers/Layer/Bing.js

### DIFF
--- a/lib/OpenLayers/Layer/Bing.js
+++ b/lib/OpenLayers/Layer/Bing.js
@@ -307,13 +307,15 @@ OpenLayers.Layer.Bing = OpenLayers.Class(OpenLayers.Layer.XYZ, {
  * metadata - {Object} metadata as returned by the API
  */
 OpenLayers.Layer.Bing.processMetadata = function(metadata) {
+    // Remove dynamic script tag.
+    var script = document.getElementById(this._callbackId);
+    script.parentNode.removeChild(script);
+    window[this._callbackId] = undefined; // cannot delete from window in IE
+    delete this._callbackId;
+    // 200 is "OK" and 304 is "Not Modified".
     if (metadata.statusCode === 200 || metadata.statusCode === 304) {
       this.metadata = metadata;
       this.initLayer();
-      var script = document.getElementById(this._callbackId);
-      script.parentNode.removeChild(script);
-      window[this._callbackId] = undefined; // cannot delete from window in IE
-      delete this._callbackId;
     } else {
       this.events.triggerEvent( 'loaderror', metadata );
     }


### PR DESCRIPTION
If an API key expires, you will see an uninformative error "undefined is not an object evaluating this.metadata.resourceSets[0].resources".
I am not sure whether introducing a new event type ('loaderror') is the best solution, but something needed to be done to capture errors thrown by the anonymous callback dynamically added to the page as a script tag.
