### PR TITLE
Cluster: Refresh the cache after removing features.

### DIFF
--- a/lib/OpenLayers/Strategy/Cluster.js
+++ b/lib/OpenLayers/Strategy/Cluster.js
@@ -79,7 +79,7 @@ OpenLayers.Strategy.Cluster = OpenLayers.Class(OpenLayers.Strategy, {
         if(activated) {
             this.layer.events.on({
                 "beforefeaturesadded": this.cacheFeatures,
-                "featuresremoved": this.clearCache,
+                "featuresremoved": this.refreshCache,
                 "moveend": this.cluster,
                 scope: this
             });
@@ -101,7 +101,7 @@ OpenLayers.Strategy.Cluster = OpenLayers.Class(OpenLayers.Strategy, {
             this.clearCache();
             this.layer.events.un({
                 "beforefeaturesadded": this.cacheFeatures,
-                "featuresremoved": this.clearCache,
+                "featuresremoved": this.refreshCache,
                 "moveend": this.cluster,
                 scope: this
             });
@@ -124,11 +124,32 @@ OpenLayers.Strategy.Cluster = OpenLayers.Class(OpenLayers.Strategy, {
         var propagate = true;
         if(!this.clustering) {
             this.clearCache();
-            this.features = event.features;
-            this.cluster();
+            var layerFeatures = this.layer.features,
+                layerFeature,
+                features = event.features.slice();
+            for (var i = 0, len = layerFeatures.length; i < len; i++) {
+                layerFeature = layerFeatures[i];
+                if (layerFeature.cluster) {
+                    Array.prototype.push.apply(features, layerFeature.cluster);
+                } else {
+                    features.push(layerFeature);
+                }
+            }
+            if (features.length) {
+                this.features = features;
+                this.cluster();
+            }
             propagate = false;
         }
         return propagate;
+    },
+    
+    /**
+     * Method: refreshCache
+     * Refresh the cached features.
+     */
+    refreshCache: function() {
+        this.cacheFeatures({features: []});
     },
     
     /**
@@ -136,9 +157,7 @@ OpenLayers.Strategy.Cluster = OpenLayers.Class(OpenLayers.Strategy, {
      * Clear out the cached features.
      */
     clearCache: function() {
-        if(!this.clustering) {
-            this.features = null;
-        }
+        this.features = null;
     },
     
     /**

--- a/tests/Strategy/Cluster.html
+++ b/tests/Strategy/Cluster.html
@@ -19,7 +19,7 @@
     }
 
     function test_clusters(t) {
-        t.plan(22);
+        t.plan(32);
 
         function featuresEq(got, exp) {
             var eq = false;
@@ -120,6 +120,39 @@
         t.ok(!strategy.features,
                     "[remove features] cluster has no cache after zoom");
 
+        // remove one feature and zoom
+        layer.addFeatures(features);
+        map.setCenter(new OpenLayers.LonLat(0, 0), 2);
+        t.eq(strategy.features.length, 81, 
+                    "[remove one feature] cluster has cache");
+        t.eq(layer.features.length, 4, "[remove one feature] layer has four clusters");
+        var lenCluster0 = layer.features[0].cluster.length;
+        lenCluster0++; // NOTE: feature without geometry disappears.
+        layer.removeFeatures([layer.features[0]]);
+        t.eq(strategy.features ? strategy.features.length : 0, 81 - lenCluster0, 
+                    "[remove one feature] cluster has reduced cache");
+        t.eq(layer.features.length, 3, 
+                    "[remove one feature] layer has three clusters");
+        map.zoomOut();
+        map.zoomIn();
+        t.eq(strategy.features ? strategy.features.length : 0, 81 - lenCluster0, 
+                    "[remove one feature] cluster has same cache after zoomOut & zoomIn");
+        t.eq(layer.features.length, 3, 
+                    "[remove one feature] layer has three clusters after zoomOut & zoomIn");
+ 
+        // add one feature and zoom 
+        layer.addFeatures([layer.features[0].cluster[0].clone()]);
+        t.eq(strategy.features ? strategy.features.length : 0, 81 + 1 - lenCluster0, 
+                    "[add one feature] cluster cache has one feature plus after add one feature.");
+        t.eq(layer.features.length, 3, 
+                    "[add one feature] layer has three clusters after after add one feature");
+        map.zoomOut();
+        map.zoomIn();
+        t.eq(strategy.features ? strategy.features.length : 0, 81 + 1 - lenCluster0, 
+                    "[add one feature] cluster has same cache after zoomOut & zoomIn");
+        t.eq(layer.features.length, 3, 
+                    "[add one feature] layer has three clusters after zoomOut & zoomIn");
+            
         map.destroy();
     }
 


### PR DESCRIPTION
When only removed some features should refresh the cache instead of
clear.

Bug: after destroying one feature does not recalculate the clusters on zooming.

See also #709
