### PR TITLE
WFST 1.0.0 InsertResult not read correctly

### DIFF
--- a/lib/OpenLayers/Format/WFST/v1_0_0.js
+++ b/lib/OpenLayers/Format/WFST/v1_0_0.js
@@ -103,7 +103,7 @@ OpenLayers.Format.WFST.v1_0_0 = OpenLayers.Class(
             "InsertResult": function(node, container) {
                 var obj = {fids: []};
                 this.readChildNodes(node, obj);
-                container.insertIds.push(obj.fids[0]);
+                container.insertIds = container.insertIds.concat(obj.fids);
             },
             "TransactionResult": function(node, obj) {
                 this.readChildNodes(node, obj);

--- a/tests/Format/WFST/v1_0_0.html
+++ b/tests/Format/WFST/v1_0_0.html
@@ -11,7 +11,7 @@
     }
     
     function test_read(t) {
-        t.plan(2);
+        t.plan(3);
         
         var data = readXML("Transaction_Response");        
         var format = new OpenLayers.Format.WFST.v1_0_0({
@@ -19,7 +19,8 @@
             featureType: "states"
         });
         var result = format.read(data);
-        t.eq(result.insertIds[0], "none", "InsertIds read correctly");
+        t.eq(result.insertIds[0], "parcelle.40", "First InsertId read correctly");
+        t.eq(result.insertIds[1], "parcelle.41", "Second InsertId read correctly");
         t.eq(result.success, true, "Success read correctly");
     }
     
@@ -91,7 +92,8 @@
 <div id="Transaction_Response"><!--
 <wfs:WFS_TransactionResponse version="1.0.0" xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc">
     <wfs:InsertResult>
-        <ogc:FeatureId fid="none"/>
+        <ogc:FeatureId fid="parcelle.40"/>
+        <ogc:FeatureId fid="parcelle.41"/>
     </wfs:InsertResult>
     <wfs:TransactionResult>
         <wfs:Status>

--- a/tests/Format/WFST/v1_1_0.html
+++ b/tests/Format/WFST/v1_1_0.html
@@ -11,7 +11,7 @@
     }
     
     function test_read(t) {
-        t.plan(2);
+        t.plan(3);
         
         var data = readXML("TransactionResponse");        
         var format = new OpenLayers.Format.WFST.v1_1_0({
@@ -19,7 +19,8 @@
             featureType: "states"
         });
         var result = format.read(data);
-        t.eq(result.insertIds[0], "none", "InsertIds read correctly");
+        t.eq(result.insertIds[0], "parcelle.40", "First InsertId read correctly");
+        t.eq(result.insertIds[1], "parcelle.41", "Second InsertId read correctly");
         t.eq(result.success, true, "Success read correctly");
     }
 
@@ -137,7 +138,10 @@
     <wfs:TransactionResults/>
     <wfs:InsertResults>
         <wfs:Feature>
-            <ogc:FeatureId fid="none"/>
+            <ogc:FeatureId fid="parcelle.40"/>
+        </wfs:Feature>
+        <wfs:Feature>
+            <ogc:FeatureId fid="parcelle.41"/>
         </wfs:Feature>
     </wfs:InsertResults>
 </wfs:TransactionResponse>


### PR DESCRIPTION
Hi,

I think WFST format v1.0.0 doesn't read correctly the InsertResult element from WFST response.

Relatively to http://portal.opengeospatial.org/files/?artifact_id=7176
Chapter 11.3

The InsertResult element can contain severals featureId like : 

``` javascript
<wfs:InsertResult>
  <ogc:FeatureId fid="parcelle.40"/>
  <ogc:FeatureId fid="parcelle.41"/>
</wfs:InsertResult> 
```

OpenLayers just read the first featureId:

``` javascript
"InsertResult": function(node, container) {
                var obj = {fids: []};
                this.readChildNodes(node, obj);
                container.insertIds.push(obj.fids[0]);
            },
```

I propose :

``` javascript
"InsertResult": function(node, container) {
                var obj = {fids: []};
                this.readChildNodes(node, obj);
                container.insertIds = obj.fids;
            },
```
