### PR TITLE
Update lib/OpenLayers/Layer/Bing.js

### DIFF
--- a/lib/OpenLayers/Layer/Bing.js
+++ b/lib/OpenLayers/Layer/Bing.js
@@ -236,6 +236,11 @@ OpenLayers.Layer.Bing = OpenLayers.Class(OpenLayers.Layer.XYZ, {
             zoom = OpenLayers.Util.indexOf(this.serverResolutions,
                                            this.getServerResolution()),
             copyrights = "", provider, i, ii, j, jj, bbox, coverage;
+            
+        if (!providers) {
+            return;
+        }
+        
         for (i=0,ii=providers.length; i<ii; ++i) {
             provider = providers[i];
             for (j=0,jj=provider.coverageAreas.length; j<jj; ++j) {


### PR DESCRIPTION
Fixes problem with map type of OrdnanceSurvey, where Bing doesn't return any ImageryProviders.
Example of bug: http://www.cabotscouts.org.uk/scripts/test.html
