### PR TITLE
Update lib/OpenLayers/Layer.js

### DIFF
--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -1218,8 +1218,18 @@ OpenLayers.Layer = OpenLayers.Class({
                     minDiff = diff;
                 } else {
                     if (this.resolutions[i] < resolution) {
+                                
+                        var ROUNDING_TOLERANCE = 0.000000001;
+                        diff = Math.abs(this.resolutions[i] - resolution);
+
+                        if( diff < ROUNDING_TOLERANCE ) {
+                            //console.log('diff too small:' + diff);
+                            // keep at same zoom level
+                            i += 1;
+                        }
+
                         break;
-                    }
+                     }
                 }
             }
             zoom = Math.max(0, i-1);


### PR DESCRIPTION
Please advise if this is useful (or not) for OpenLayers.

Guard against rounding error when getting the zoom level.
This affects layers with non-fractional zoom level or layer with tiled images.
