### PR TITLE
Fix regression introduced by #732

### DIFF
--- a/lib/OpenLayers/Format/WMTSCapabilities.js
+++ b/lib/OpenLayers/Format/WMTSCapabilities.js
@@ -165,14 +165,12 @@ OpenLayers.Format.WMTSCapabilities = OpenLayers.Class(OpenLayers.Format.XML.Vers
                 (projection === "EPSG:4326" ? "degrees" : "m");
 
         var resolutions = [];
-        if (config.isBaseLayer !== false) {
-            for (var mid in matrixSet.matrixIds) {
-                if (matrixSet.matrixIds.hasOwnProperty(mid)) {
-                    resolutions.push(
-                        matrixSet.matrixIds[mid].scaleDenominator * 0.28E-3 /
-                            OpenLayers.METERS_PER_INCH /
-                            OpenLayers.INCHES_PER_UNIT[units]);
-                }
+        for (var mid in matrixSet.matrixIds) {
+            if (matrixSet.matrixIds.hasOwnProperty(mid)) {
+                resolutions.push(
+                    matrixSet.matrixIds[mid].scaleDenominator * 0.28E-3 /
+                        OpenLayers.METERS_PER_INCH /
+                        OpenLayers.INCHES_PER_UNIT[units]);
             }
         }
 


### PR DESCRIPTION
Now that serverResolutions are set for all layers, we need to generate
resolutions also for non-baselayers.
