### PR TITLE
Fix for Issue #778 as suggested by elemoine

### DIFF
--- a/lib/OpenLayers/Handler/Pinch.js
+++ b/lib/OpenLayers/Handler/Pinch.js
@@ -129,7 +129,6 @@ OpenLayers.Handler.Pinch = OpenLayers.Class(OpenLayers.Handler, {
             this.last = current;
             // prevent document dragging
             OpenLayers.Event.stop(evt);
-            return false;
         } else if (this.started) {
             // Some webkit versions send fake single-touch events during
             // multitouch, which cause the drag handler to trigger


### PR DESCRIPTION
This is a fix for Issue #778.

Removed `return false` as suggested by @elemoine. Tested and working on iPhone 4 with iOS 5 and iOS6, iPhone 5, Android 2.2, 2.3, 4.0, 4.1 and 4.2. Found no problems on a scrollable page either (#742).
