### PR TITLE
Wheel handler does not work on IE when interval is set

### DIFF
--- a/lib/OpenLayers/Handler/MouseWheel.js
+++ b/lib/OpenLayers/Handler/MouseWheel.js
@@ -163,9 +163,6 @@ OpenLayers.Handler.MouseWheel = OpenLayers.Class(OpenLayers.Handler, {
         if (!overScrollableDiv && overMapDiv) {
             if (allowScroll) {
                 var delta = 0;
-                if (!e) {
-                    e = window.event;
-                }
                 
                 if (e.wheelDelta) {
                     delta = e.wheelDelta;


### PR DESCRIPTION
Because our event handling assigns `window.event` to browser event listeners in IE, we need to store the event properties for use in a delayed function. Otherwise the delayed function uses `window.event` again, which may have changed or been discarded in the meantime.

This issue can be seen when trying the mouse wheel in IE in the [mobile-wmts-vienna.html](http://openlayers.org/dev/examples/mobile-wmts-vienna.html) example.
