### PR TITLE
Rework of Google layer leads to map div transparency

### DIFF
--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -28,6 +28,10 @@ div.olLayerDiv {
 .olLayerGoogleV3.olLayerGooglePoweredBy {
     bottom: 15px !important;
 }
+/* GMaps should not set styles on its container */
+.olForeignContainer {
+    opacity: 1 !important;
+}
 .olControlAttribution {
     font-size: smaller;
     right: 3px;


### PR DESCRIPTION
GMaps sets an opacity on the container that OpenLayers creates for it. This causes all OpenLayers content to be transparent. See http://lists.osgeo.org/pipermail/openlayers-dev/2012-December/008914.html.
