### PR TITLE
Atom.js: fix for issue #789 : typo in Polygon parsing causes empty GeoRSS Polygon geometry

### DIFF
--- a/lib/OpenLayers/Format/Atom.js
+++ b/lib/OpenLayers/Format/Atom.js
@@ -646,7 +646,7 @@ OpenLayers.Format.Atom = OpenLayers.Class(OpenLayers.Format.XML, {
                 }
                 components.push(
                     new OpenLayers.Geometry.Polygon(
-                        [new OpenLayers.Geometry.LinearRing(components)]
+                        [new OpenLayers.Geometry.LinearRing(points)]
                     )
                 );
             }


### PR DESCRIPTION
See OpenLayers issue #789 , var 'points' needs to be passed, not 'components' at line 649.
