### PR TITLE
Do not add viewport to GMaps object before it is fully rendered

### DIFF
--- a/lib/OpenLayers/Layer/Google/v3.js
+++ b/lib/OpenLayers/Layer/Google/v3.js
@@ -124,9 +124,10 @@ OpenLayers.Layer.Google.v3 = {
      */
     setGMapVisibility: function(visible) {
         var cache = OpenLayers.Layer.Google.cache[this.map.id];
+        var map = this.map;
         if (cache) {
             var type = this.type;
-            var layers = this.map.layers;
+            var layers = map.layers;
             var layer;
             for (var i=layers.length-1; i>=0; --i) {
                 layer = layers[i];
@@ -139,17 +140,24 @@ OpenLayers.Layer.Google.v3 = {
             }
             var container = this.mapObject.getDiv();
             if (visible === true) {
-                if (!cache.googleControl.hasChildNodes()) {
-                    cache.googleControl.appendChild(this.map.viewPortDiv);
-                    this.map.div.appendChild(container);
+                if (container.parentNode !== map.div) {
+                    map.div.appendChild(container);
+                    if (!cache.rendered) {
+                        google.maps.event.addListenerOnce(this.mapObject, 'tilesloaded', function() {
+                            cache.googleControl.appendChild(map.viewPortDiv);
+                            cache.rendered = true;
+                        });
+                    } else {
+                        cache.googleControl.appendChild(map.viewPortDiv);
+                    }
                     google.maps.event.trigger(this.mapObject, 'resize');
                 }
                 this.mapObject.setMapTypeId(type);                
                 cache.displayed = this.id;
             } else {
                 if (cache.googleControl.hasChildNodes()) {
-                    this.map.div.removeChild(container);
-                    this.map.div.appendChild(this.map.viewPortDiv);
+                    map.div.appendChild(map.viewPortDiv);
+                    map.div.removeChild(container);
                 }
                 delete cache.displayed;
             }

--- a/tests/Layer/Google/v3.html
+++ b/tests/Layer/Google/v3.html
@@ -318,7 +318,7 @@
          var gmap = new OpenLayers.Layer.Google();
          map.addLayer(gmap);
          
-         t.delay_call(1, function() {
+         t.delay_call(4, function() {
              t.ok(map.viewPortDiv.parentNode !== map.div, 'viewport moved inside GMaps');
 
              var osm = new OpenLayers.Layer.OSM();


### PR DESCRIPTION
This avoids issues with Elements renderers, where the nodeFactory method
cannot find nodes while the map viewport is transitioning from the mapDiv
to the googleControl.
