### PR TITLE
Elliminate flickering when calling mergeNewParams

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -426,6 +426,31 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
     },    
 
     /**
+     * Method: replace
+     * Replace the current tiles with new reloaded tiles, if possible
+     * delay until the new tiles have been loaded to reduce flickering.
+     */
+     replace: function() {
+        if (!this.grid || !this.grid[0]) {
+            return;
+        }
+        var lst=[];
+        for (var i =0; i < this.grid.length; ++i) {
+            for (var j = 0; j < this.grid[i].length; ++j) {
+                var dx = i - this.grid.length/2;
+                var dy = j - this.grid[i].length/2;
+                var dst = Math.sqrt(dx*dx+dy*dy);
+                lst.push([dst, this.grid[i][j]]);
+            }
+        }
+        lst.sort();
+        for (var i = 0; i < lst.length; ++i) {
+            lst[i][1].replace();
+        }
+    },
+    
+
+    /**
      * Method: moveTo
      * This function is called whenever the map is moved. All the moving
      * of actual 'tiles' is done by the map, but moveTo's role is to accept

--- a/lib/OpenLayers/Layer/HTTPRequest.js
+++ b/lib/OpenLayers/Layer/HTTPRequest.js
@@ -122,7 +122,7 @@ OpenLayers.Layer.HTTPRequest = OpenLayers.Class(OpenLayers.Layer, {
      */
     mergeNewParams:function(newParams) {
         this.params = OpenLayers.Util.extend(this.params, newParams);
-        var ret = this.redraw();
+        var ret = this.replace();
         if(this.map != null) {
             this.map.events.triggerEvent("changelayer", {
                 layer: this,
@@ -130,6 +130,16 @@ OpenLayers.Layer.HTTPRequest = OpenLayers.Class(OpenLayers.Layer, {
             });
         }
         return ret;
+    },
+
+
+    /**
+     * Method: replace
+     * Replace the current content with new content, if possible delay
+     * replacing until new content has been loaded, to reduce flickering.
+     */
+    replace: function() {
+        this.redraw();
     },
 
     /**

--- a/lib/OpenLayers/Tile.js
+++ b/lib/OpenLayers/Tile.js
@@ -184,6 +184,15 @@ OpenLayers.Tile = OpenLayers.Class({
         this.eventListeners = null;
         this.events = null;
     },
+
+    /**
+     * Method: replace
+     * Replace the current tile with a new tile, if possible replace only
+     * once the new tile has loaded, to reduce flickering.
+     */
+    replace: function() {
+        this.draw();
+    },
     
     /**
      * Method: draw

--- a/lib/OpenLayers/Tile/Image.js
+++ b/lib/OpenLayers/Tile/Image.js
@@ -115,6 +115,8 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile, {
         
         this.layerAlphaHack = this.layer.alpha && OpenLayers.Util.alphaHack();
 
+        this.replacee = null;
+
         if (this.maxGetUrlLength != null || this.layer.gutter || this.layerAlphaHack) {
             // only create frame if it's needed
             this.frame = document.createElement("div");
@@ -373,14 +375,36 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile, {
     },
 
     /**
+     * Method: replace
+     * Replace the current image, with a new image once that has loaded
+     */
+    replace: function() {
+        if (!this.replacee && !this.frame) {
+            this.replacee = this.createBackBuffer();
+        }
+        this.draw();
+    },
+
+    /**
      * Method: onImageLoad
      * Handler for the image onload event
      */
     onImageLoad: function() {
         var img = this.imgDiv;
         OpenLayers.Event.stopObservingElement(img);
+
+        if (this.replacee) {
+            img.parentNode.removeChild(img);
+        }
+
         img.style.visibility = 'inherit';
         img.style.opacity = this.layer.opacity;
+	
+        if (this.replacee) {
+            this.replacee.parentNode.replaceChild(img, this.replacee);
+            this.replacee = null;
+        }
+
         this.isLoading = false;
         this.canvasContext = null;
         this.events.triggerEvent("loadend");


### PR DESCRIPTION
We are calling mergeNewParams quite alot, to make small incremental changes to our tileset. The constant flickering is driving us mad. I  would guess that we are not alone in wanting a more fluent behaviour of mergeNewParams.  The following patch implements this, by adding a reload method to HTTPRequest layers, this is then specialised in the GridLayer where replace is called on all grid tiles.
By default "replace" on a tile, will just redraw it, while on an Image tile, it will delay the redraw until the new image has been reloaded, which will then dom replace node the old image.
