### PR TITLE
Fix for issue #457

### DIFF
--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -1349,11 +1349,21 @@ OpenLayers.Layer = OpenLayers.Class({
         if (this.gutter) {
             // Adjust the extent of a bounds in map units by the 
             // layer's gutter in pixels.
+			var originalLeft = bounds.left
+            var originalRight = bounds.right
             var mapGutter = this.gutter * this.map.getResolution();
             bounds = new OpenLayers.Bounds(bounds.left - mapGutter,
                                            bounds.bottom - mapGutter,
                                            bounds.right + mapGutter,
                                            bounds.top + mapGutter);
+										   
+			//don't let buffer push a bounds across the dateline
+            if (originalLeft >= this.maxExtent.right && bounds.left < this.maxExtent.right) {
+                bounds.left = this.maxExtent.right
+            }
+            else if (originalRight <= this.maxExtent.left && bounds.right > this.maxExtent.left) {
+                bounds.right = this.maxExtent.left
+            }
         }
 
         if (this.wrapDateLine) {


### PR DESCRIPTION
Stop buffer from pushing bounds through dateline since wrapDateLine() does not work for bounds which cross the dateline

See openlayers/openlayers#457
