### PR TITLE
Canvas graphic rotation support and canvas graphic redraw optimizations 

### DIFF
--- a/lib/OpenLayers/Renderer/Canvas.js
+++ b/lib/OpenLayers/Renderer/Canvas.js
@@ -276,9 +276,24 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
                             // which drawImage works out of the box.
                             320 / window.screen.width : 1
                     );
-                canvas.drawImage(
-                    img, x*factor, y*factor, width*factor, height*factor
-                );
+                
+                //Draw with rotation
+                if(style.rotation) {
+                    canvas.save(); 
+                    canvas.translate(x * factor, y * factor);
+                    canvas.translate(width * factor / 2, height * factor / 2);
+                    canvas.rotate(style.rotation * Math.PI / 180);
+                    canvas.drawImage(
+                        img, -(width * factor / 2), -(height * factor / 2), width * factor, height * factor
+                    );
+                    canvas.restore();
+                //Draw without rotation
+                } else {
+                    canvas.drawImage(
+                        img, x*factor, y*factor, width*factor, height*factor
+                    );
+                }
+                
                 if (this.hitDetection) {
                     this.setHitContextStyle("fill", featureId);
                     this.hitContext.fillRect(x, y, width, height);
@@ -286,8 +301,20 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
             }
         };
 
-        img.onload = OpenLayers.Function.bind(onLoad, this);
-        img.src = style.externalGraphic;
+        //Load from cache
+        if(this.prevGraphicSrc == style.externalGraphic) {
+            img = this.prevGraphicImg;
+            onLoad.call(this);
+        //Load from image source
+        } else {
+            img.onload = OpenLayers.Function.bind(onLoad, this);
+            img.src = style.externalGraphic;
+        
+            //Save to cache
+            this.prevGraphicSrc = style.externalGraphic;
+            this.prevGraphicImg = img;
+        }
+    
     },
 
     /**


### PR DESCRIPTION
#1

Added canvas graphic rotation support (style.rotation), at the moment works only with SVG (did not test VML).
#2

With the current implementation every time a graphic is drawn a new image is created, then the onload handler is attached and the render process is executed in this handler's success result. 
This has some performance implication (flickering) - if many features have the same graphic (typical in maps), or when the graphic  is redrawn often with a rotation, offset, position etc. I added a quick fix which caches the last image, it did get rid of flicking in all of my use cases.
