### PR TITLE
Tween: skip frames when minimum frame rate is not reached

### DIFF
--- a/lib/OpenLayers/Tween.js
+++ b/lib/OpenLayers/Tween.js
@@ -54,12 +54,12 @@ OpenLayers.Tween = OpenLayers.Class({
     
     /**
      * APIProperty: minFrameRate
-     * {Number} The minimum framerate for animations. After each step, the time
-     * spent in the animation is compared to the calculated time at this frame
-     * rate. If the animation runs longer than the calculated time, the next
-     * step is skipped.
+     * {Number} The minimum framerate for animations in frames per second. After
+     * each step, the time spent in the animation is compared to the calculated
+     * time at this frame rate. If the animation runs longer than the calculated
+     * time, the next step is skipped. Default is 30.
      */
-    minFrameRate: 30,
+    minFrameRate: null,
 
     /**
      * Property: startTime
@@ -99,7 +99,8 @@ OpenLayers.Tween = OpenLayers.Class({
      * begin - {Object} values to start the animation with
      * finish - {Object} values to finish the animation with
      * duration - {int} duration of the tween (number of steps)
-     * options - {Object} hash of options (for example callbacks (start, eachStep, done))
+     * options - {Object} hash of options (callbacks (start, eachStep, done),
+     *     minFrameRate)
      */
     start: function(begin, finish, duration, options) {
         this.playing = true;
@@ -107,6 +108,7 @@ OpenLayers.Tween = OpenLayers.Class({
         this.finish = finish;
         this.duration = duration;
         this.callbacks = options.callbacks;
+        this.minFrameRate = options.minFrameRate || 30;
         this.time = 0;
         this.startTime = new Date().getTime();
         OpenLayers.Animation.stop(this.animationId);

--- a/tests/Tween.html
+++ b/tests/Tween.html
@@ -79,29 +79,32 @@
         t.plan(2);
         
         var tween = new OpenLayers.Tween();
-        var log1 = 0;
+        var log = 0;
         tween.start({count: 0}, {count: 10}, 10, {
             callbacks: {
                 eachStep: function() {
-                    log1++;
+                    log++;
                 }
             },
             minFrameRate: 10000
         });
         
-        var log2 = 0;
-        tween.start({count: 0}, {count: 10}, 10, {
-            callbacks: {
-                eachStep: function() {
-                    log2++;
-                }
-            },
-            minFrameRate: 1
-        });
-
         t.delay_call(0.8, function() {
-            t.eq(log1, 0, 'all frames skipped at a frame rate of 10000');            
-            t.eq(log2, 11, 'no frames skipped at a frame rate of 1');            
+            t.eq(log, 0, 'all frames skipped at a frame rate of 10000');
+            
+            log = 0;
+            tween.start({count: 0}, {count: 10}, 10, {
+                callbacks: {
+                    eachStep: function() {
+                        log++;
+                    }
+                },
+                minFrameRate: 1
+            });
+        });
+        
+        t.delay_call(1.6, function() {
+            t.eq(log, 11, 'no frames skipped at a frame rate of 1');            
         });
     }
 


### PR DESCRIPTION
The new minFrameRate option is used to make sure that an animation does not
run longer than the time calculated from that frame rate. Time is made up
by skipping frames, i.e. skipping execution of the eachStep callback.
