### PR TITLE
Use transitionend listeners where available

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -286,6 +286,15 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
     rowSign: null,
 
     /**
+     * Property: transitionendEvents
+     * {Array} Event names for transitionend
+     */
+    transitionendEvents: [
+        'transitionend', 'webkitTransitionEnd', 'otransitionend',
+        'oTransitionEnd'
+    ],
+
+    /**
      * Constructor: OpenLayers.Layer.Grid
      * Create a new grid layer
      *
@@ -759,10 +768,10 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
      */
     removeBackBuffer: function() {
         if (this._transitionElement) {
-            OpenLayers.Event.stopObserving(this._transitionElement, 'transitionend', this._removeBackBuffer);
-            OpenLayers.Event.stopObserving(this._transitionElement, 'webkitTransitionEnd', this._removeBackBuffer);
-            OpenLayers.Event.stopObserving(this._transitionElement, 'otransitionend', this._removeBackBuffer);
-            OpenLayers.Event.stopObserving(this._transitionElement, 'oTransitionEnd', this._removeBackBuffer);
+            for (var i=this.transitionendEvents.length-1; i>=0; --i) {
+                OpenLayers.Event.stopObserving(this._transitionElement,
+                    this.transitionendEvents[i], this._removeBackBuffer);
+            }
             delete this._transitionElement;
         }
         if(this.backBuffer) {
@@ -1129,10 +1138,11 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
                 this.events.triggerEvent("loadend");
                 if(this.backBuffer) {
                     this._transitionElement = tile.imgDiv;
-                    OpenLayers.Event.observe(this._transitionElement, 'transitionend', this._removeBackBuffer);
-                    OpenLayers.Event.observe(this._transitionElement, 'webkitTransitionEnd', this._removeBackBuffer);
-                    OpenLayers.Event.observe(this._transitionElement, 'otransitionend', this._removeBackBuffer);
-                    OpenLayers.Event.observe(this._transitionElement, 'oTransitionEnd', this._removeBackBuffer);
+                    for (var i=this.transitionendEvents.length-1; i>=0; --i) {
+                        OpenLayers.Event.observe(this._transitionElement,
+                            this.transitionendEvents[i],
+                            this._removeBackBuffer);
+                    }
                     // the removal of the back buffer is delayed to prevent                     // flash effects due to the animation of tile displaying
                     this.backBufferTimerId = window.setTimeout(
                         this._removeBackBuffer, this.removeBackBufferDelay


### PR DESCRIPTION
In addition to relying on removeBackBufferDelay, we can remove the
backbuffer earlier without flicker in an ontransitionend listener on the
last loaded tile.
