### PR TITLE
Overview map should use map.getMaxExtent

### DIFF
--- a/lib/OpenLayers/Control/OverviewMap.js
+++ b/lib/OpenLayers/Control/OverviewMap.js
@@ -453,7 +453,7 @@ OpenLayers.Control.OverviewMap = OpenLayers.Class(OpenLayers.Control, {
      */
     isSuitableOverview: function() {
         var mapExtent = this.map.getExtent();
-        var maxExtent = this.map.maxExtent;
+        var maxExtent = this.map.getMaxExtent();
         var testExtent = new OpenLayers.Bounds(
                                 Math.max(mapExtent.left, maxExtent.left),
                                 Math.max(mapExtent.bottom, maxExtent.bottom),


### PR DESCRIPTION
following on from #822 there is a small regression with https://github.com/openlayers/openlayers/commit/11966d231ffac3753534e231341c706b0daf1daa which removed the default setting of map.maxExtent for maps not in 4326/web mercator. Control/OverviewMap uses this and fails if it is not set. A comment was added to map.projection to set maxExtent if not in those projections, but not to map.maxExtent.

AFAICS map.maxExtent is only used by Layer as a default, and in 3 other classes: Control/OverviewMap and Layer/TMS and Layer/Zoomify.

ISTM it would be better if OverviewMap were changed to use the accessor. Layer/XYZ uses its own maxExtent; cannot TMS and Zoomify do the same? If so, then it would no longer be necessary to set map.maxExtent except as a convenience for layer default.
