### PR TITLE
Change setMap in Layer/TMS and Layer/Zoomify to use layer.maxExtent

### DIFF
--- a/lib/OpenLayers/Layer/TMS.js
+++ b/lib/OpenLayers/Layer/TMS.js
@@ -76,7 +76,7 @@ OpenLayers.Layer.TMS = OpenLayers.Class(OpenLayers.Layer.Grid, {
      *         {
      *             layername: "basic", 
      *             type: "png",
-     *             // set if different than the bottom left of map.maxExtent
+     *             // set if different than the bottom left of maxExtent
      *             tileOrigin: new OpenLayers.LonLat(-180, -90)
      *         }
      *     );
@@ -193,8 +193,8 @@ OpenLayers.Layer.TMS = OpenLayers.Class(OpenLayers.Layer.Grid, {
     setMap: function(map) {
         OpenLayers.Layer.Grid.prototype.setMap.apply(this, arguments);
         if (!this.tileOrigin) { 
-            this.tileOrigin = new OpenLayers.LonLat(this.map.maxExtent.left,
-                                                this.map.maxExtent.bottom);
+            this.tileOrigin = new OpenLayers.LonLat(this.maxExtent.left,
+                                                this.maxExtent.bottom);
         }                                       
     },
 

--- a/lib/OpenLayers/Layer/Zoomify.js
+++ b/lib/OpenLayers/Layer/Zoomify.js
@@ -252,8 +252,8 @@ OpenLayers.Layer.Zoomify = OpenLayers.Class(OpenLayers.Layer.Grid, {
      */
     setMap: function(map) {
         OpenLayers.Layer.Grid.prototype.setMap.apply(this, arguments);
-        this.tileOrigin = new OpenLayers.LonLat(this.map.maxExtent.left,
-                                                this.map.maxExtent.top);
+        this.tileOrigin = new OpenLayers.LonLat(this.maxExtent.left,
+                                                this.maxExtent.top);
     },
 
     CLASS_NAME: "OpenLayers.Layer.Zoomify"


### PR DESCRIPTION
As discussed in #823, map.maxExtent may not be set, so use maxExtent from layer instead. This is same behaviour as Layer/XYZ.

I ran the tests for TMS, but there don't appear to be any tests for Zoomify :-)