### PR TITLE
Update lib/OpenLayers/Format/SOSGetObservation.js

### DIFF
--- a/lib/OpenLayers/Format/SOSGetObservation.js
+++ b/lib/OpenLayers/Format/SOSGetObservation.js
@@ -256,6 +256,8 @@ OpenLayers.Format.SOSGetObservation = OpenLayers.Class(OpenLayers.Format.XML, {
                 var node = this.createElementNSPlus("eventTime");
                 if (options.eventTime === 'latest') {
                     this.writeNode("ogc:TM_Equals", options, node);
+                }else if(options.eventTime.timePeriod){
+    	            this.writeNode("ogc:TM_During", options, node);
                 }
                 return node;
             },
@@ -278,6 +280,15 @@ OpenLayers.Format.SOSGetObservation = OpenLayers.Class(OpenLayers.Format.XML, {
                 }
                 return node;
             },
+            "TM_During": function(options) {
+                var node = this.createElementNSPlus("ogc:TM_During");
+                this.writeNode("ogc:PropertyName", {property:
+                    "urn:ogc:data:time:iso8601"}, node);
+                if (options.eventTime.timePeriod) {
+                    this.writeNode("gml:TimePeriod", options.eventTime.timePeriod, node);
+                }
+                return node;
+            },
             "PropertyName": function(options) {
                 return this.createElementNSPlus("ogc:PropertyName", 
                     {value: options.property});
@@ -291,6 +302,22 @@ OpenLayers.Format.SOSGetObservation = OpenLayers.Class(OpenLayers.Format.XML, {
             },
             "timePosition": function(options) {
                 var node = this.createElementNSPlus("gml:timePosition", 
+                    {value: options.value});
+                return node;
+            },
+            "TimePeriod": function(options) {
+                var node = this.createElementNSPlus("gml:TimePeriod");
+                this.writeNode("gml:beginPosition", {value:options.beginPosition}, node);
+                this.writeNode("gml:endPosition", {value:options.endPosition}, node);
+                return node;
+            },
+            "beginPosition": function(options) {
+                var node = this.createElementNSPlus("gml:beginPosition",
+                    {value: options.value});
+                return node;
+            },
+            "endPosition": function(options) {
+                var node = this.createElementNSPlus("gml:endPosition",
                     {value: options.value});
                 return node;
             }


### PR DESCRIPTION
Adding gml:TimePeriod support for eventTime parameter (writer only), for example:

``` javascript
eventTime: {
    timePeriod:{
        beginPosition:"2012-12-01T01:01:00+00",
        endPosition:"2013-01-10T23:30:30+00"
    }
}
```

Will produce:

``` xml
<eventTime>
    <ogc:TM_During xmlns:ogc="http://www.opengis.net/ogc">
        <ogc:PropertyName>urn:ogc:data:time:iso8601</ogc:PropertyName>
        <gml:TimePeriod xmlns:gml="http://www.opengis.net/gml">
            <gml:beginPosition>2012-12-01T01:01:00+00</gml:beginPosition>
            <gml:endPosition>2013-01-10T23:30:30+00</gml:endPosition>
        </gml:TimePeriod>
    </ogc:TM_During>
</eventTime>
```
