### PR TITLE
guard against null tileInfo

### DIFF
--- a/lib/OpenLayers/Layer/UTFGrid.js
+++ b/lib/OpenLayers/Layer/UTFGrid.js
@@ -148,7 +148,7 @@ OpenLayers.Layer.UTFGrid = OpenLayers.Class(OpenLayers.Layer.XYZ, {
     getFeatureInfo: function(location) {
         var info = null;
         var tileInfo = this.getTileData(location);
-        if (tileInfo.tile) {
+        if (tileInfo && tileInfo.tile) {
             info = tileInfo.tile.getFeatureInfo(tileInfo.i, tileInfo.j);
         }
         return info;


### PR DESCRIPTION
Occasionally getTileData will return null. If statement should catch that condition. 
