### PR TITLE
Url correction in ArcGISCache.js 

### DIFF
--- a/lib/OpenLayers/Layer/ArcGISCache.js
+++ b/lib/OpenLayers/Layer/ArcGISCache.js
@@ -454,7 +454,7 @@ OpenLayers.Layer.ArcGISCache = OpenLayers.Class(OpenLayers.Layer.XYZ, {
         // structure than direct access via the folder structure.
         if (this.useArcGISServer) {
             // AGS MapServers have pretty url access to tiles
-            url = url + '/tile/${z}/${y}/${x}';
+            url = url + '/${z}/${y}/${x}' + this.type;
         } else {
             // The tile images are stored using hex values on disk.
             x = 'C' + OpenLayers.Number.zeroPad(x, 8, 16);


### PR DESCRIPTION
for useArcGISServer=true

Tile url ends with ".../default/default/tile/1/0/1" but the correct url is "/tile/1.0.0/{Layer}/{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png".

Thus disturbs "/tile/" and the image type is missing.
