### PR TITLE
No .olTileReplacing class for singleTile layers

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -1080,7 +1080,7 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
             }
             this.events.triggerEvent("tileloadstart", {tile: tile});
             this.numLoadingTiles++;
-            if (this.backBuffer && this.gridResolution === this.backBufferResolution) {
+            if (!this.singleTile && this.backBuffer && this.gridResolution === this.backBufferResolution) {
                 OpenLayers.Element.addClass(tile.imgDiv, replacingCls);
             }
         };
@@ -1092,7 +1092,7 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
                 tile: tile,
                 aborted: aborted
             });
-            if (!aborted && this.backBuffer && this.gridResolution === this.backBufferResolution) {
+            if (!this.singleTile && !aborted && this.backBuffer && this.gridResolution === this.backBufferResolution) {
                 if (OpenLayers.Element.getStyle(tile.imgDiv, 'display') === 'none') {
                     var bufferTile = document.getElementById(tile.id + '_bb');
                     if (bufferTile) {

--- a/tests/Layer/Grid.html
+++ b/tests/Layer/Grid.html
@@ -1150,6 +1150,23 @@
         });
     }
 
+    function test_backbuffer_replace_singleTile(t) {
+        t.plan(1);
+        var map = new OpenLayers.Map('map');
+        var layer = new OpenLayers.Layer.WMS('', '../../img/blank.gif', null, {
+            singleTile: true,
+            transitionEffect: 'resize'
+        });
+        map.addLayer(layer);
+        map.zoomToMaxExtent();
+        
+        t.delay_call(1, function() {
+            map.zoomIn();
+            var tile = layer.grid[0][0];
+            t.ok(!OpenLayers.Element.hasClass(tile.imgDiv, 'olTileReplacing'), 'tile is not marked for being replaced for singleTile layers');
+        });
+    }
+
     function test_singleTile_move_and_zoom(t) {
 
         //


### PR DESCRIPTION
This fixes a regression for singleTile layers with transitionEffect set to
'resize', where the .olTileReplacing class was not removed from the tile.
