### PR TITLE
Process queue immediately when params change

### DIFF
--- a/lib/OpenLayers/TileManager.js
+++ b/lib/OpenLayers/TileManager.js
@@ -114,6 +114,7 @@ OpenLayers.TileManager = OpenLayers.Class({
         map.events.on({
             move: this.move,
             zoomend: this.zoomEnd,
+            changelayer: this.changeLayer,
             addlayer: this.addLayer,
             preremovelayer: this.removeLayer,
             scope: this
@@ -141,6 +142,7 @@ OpenLayers.TileManager = OpenLayers.Class({
             map.events.un({
                 move: this.move,
                 zoomend: this.zoomEnd,
+                changelayer: this.changeLayer,
                 addlayer: this.addLayer,
                 preremovelayer: this.removeLayer,
                 scope: this
@@ -171,6 +173,19 @@ OpenLayers.TileManager = OpenLayers.Class({
      */
     zoomEnd: function(evt) {
         this.updateTimeout(evt.object, this.zoomDelay);
+    },
+    
+    /**
+     * Method: changeLayer
+     * Handles the map's changeLayer event
+     *
+     * Parameters:
+     * evt - {Object} Listener argument
+     */
+    changeLayer: function(evt) {
+        if (evt.property === 'params') {
+            this.updateTimeout(evt.object, 0);
+        }
     },
     
     /**


### PR DESCRIPTION
This fixes an issue where the queue would never be processed when a layer
is updated using mergeNewParams.
