### PR TITLE
Safeguard against listeners that recreate the grid

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -1104,8 +1104,6 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
             }
             //if that was the last tile, then trigger a 'loadend' on the layer
             if (this.numLoadingTiles === 0) {
-                this.loading = false;
-                this.events.triggerEvent("loadend");
                 if(this.backBuffer) {
                     this._transitionElement = tile.imgDiv;
                     for (var i=this.transitionendEvents.length-1; i>=0; --i) {
@@ -1119,6 +1117,8 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
                         this._removeBackBuffer, this.removeBackBufferDelay
                     );
                 }
+                this.loading = false;
+                this.events.triggerEvent("loadend");
             }
         };
         


### PR DESCRIPTION
We need to handle the backbuffer before we fire the loadend event.
Otherwise listeners that call e.g. mergeNewParams() will cause the
backbuffer removal code to fail, because tile.imgDiv (and hence
this._transitionElement) will be null.
