### PR TITLE
Don't hex encode zoom level in AGSCache layer

### DIFF
--- a/lib/OpenLayers/Layer/ArcGISCache.js
+++ b/lib/OpenLayers/Layer/ArcGISCache.js
@@ -459,7 +459,7 @@ OpenLayers.Layer.ArcGISCache = OpenLayers.Class(OpenLayers.Layer.XYZ, {
             // The tile images are stored using hex values on disk.
             x = 'C' + OpenLayers.Number.zeroPad(x, 8, 16);
             y = 'R' + OpenLayers.Number.zeroPad(y, 8, 16);
-            z = 'L' + OpenLayers.Number.zeroPad(z, 2, 16);
+            z = 'L' + OpenLayers.Number.zeroPad(z, 2, 10);
             url = url + '/${z}/${y}/${x}.' + this.type;
         }
 


### PR DESCRIPTION
Address issue #851. Zoom levels in classic ags direct tile access schemes are not hex encoded. Tests already exists and pass now.
