### PR TITLE
Handle negative numbers in CQL Values

### DIFF
--- a/lib/OpenLayers/Format/CQL.js
+++ b/lib/OpenLayers/Format/CQL.js
@@ -31,7 +31,7 @@ OpenLayers.Format.CQL = (function() {
         IS_NULL: /^IS NULL/i,
         COMMA: /^,/,
         LOGICAL: /^(AND|OR)/i,
-        VALUE: /^('([^']|'')*'|\d+(\.\d*)?|\.\d+)/,
+        VALUE: /^('([^']|'')*'|-?\d+(\.\d*)?|\.\d+)/,
         LPAREN: /^\(/,
         RPAREN: /^\)/,
         SPATIAL: /^(BBOX|INTERSECTS|DWITHIN|WITHIN|CONTAINS)/i,


### PR DESCRIPTION
As of 2013-01-26, negative values in CQL statements cause errors.

For example:

```
format = new OpenLayers.Format.CQL(); format.read('foo < -1')
```

The included pull request alters the 'VALUE' pattern to handle negative numbers.
