### PR TITLE
Make click handler propagate touchend

### DIFF
--- a/lib/OpenLayers/Handler/Click.js
+++ b/lib/OpenLayers/Handler/Click.js
@@ -352,7 +352,7 @@ OpenLayers.Handler.Click = OpenLayers.Class(OpenLayers.Handler, {
                     // touch device, no dblclick event - this may be a double
                     if (this["double"]) {
                         // on Android don't let the browser zoom on the page
-                        OpenLayers.Event.stop(evt);
+                        OpenLayers.Event.preventDefault(evt);
                     }
                     this.handleDouble(evt);
                 }


### PR DESCRIPTION
This commit is a follow-up on issue #294 and commit a6119f6. Our handlers should not prevent the bubbling up of browser events. This, for example, prevents Sencha Touch's `longpress` events from working properly.
