### PR TITLE
Uncache images that are no longer valid

### DIFF
--- a/lib/OpenLayers/TileManager.js
+++ b/lib/OpenLayers/TileManager.js
@@ -315,9 +315,16 @@ OpenLayers.TileManager = OpenLayers.Class({
         var tile = evt.object;
         var queued = false;
         var layer = tile.layer;
+        var url = layer.getURL(tile.bounds);
+        var img = this.tileCache[url];
+        if (img && img.className !== 'olTileImage') {
+            // cached image no longer valid, e.g. because we're olTileReplacing
+            delete this.tileCache[url];
+            OpenLayers.Util.removeItem(this.tileCacheIndex, url);
+            img = null;
+        }
         // queue only if image with same url not cached already
-        if (layer.url && (layer.async ||
-                                  !this.tileCache[layer.getURL(tile.bounds)])) {
+        if (layer.url && (layer.async || !img)) {
             // add to queue only if not in queue already
             var tileQueue = this.tileQueue[layer.map.id];
             if (!~OpenLayers.Util.indexOf(tileQueue, tile)) {


### PR DESCRIPTION
When a layer sets a cached image's className to something else than
.olTileImage (e.g. by setting .olTileReplacing), we should not keep the
image in the cache any more, because it may no longer be valid.
