### PR TITLE
OpenLayers-2.12-rc2 + jQuery-1.7.2 Memory leak in Internet Explorer 9 

### DIFF
--- a/lib/OpenLayers/Control/Geolocate.js
+++ b/lib/OpenLayers/Control/Geolocate.js
@@ -45,8 +45,15 @@ OpenLayers.Control.Geolocate = OpenLayers.Class(OpenLayers.Control, {
     /**
      * Property: geolocation
      * {Object} The geolocation engine, as a property to be possibly mocked.
+     * This is set lazily to avoid a memory leak in IE9.
      */
-    geolocation: navigator.geolocation,
+    geolocation: null,
+
+    /**
+     * Property: available
+     * {Boolean} The navigator.geolocation object is available.
+     */
+    available: ('geolocation' in navigator),
 
     /**
      * APIProperty: bind
@@ -90,6 +97,10 @@ OpenLayers.Control.Geolocate = OpenLayers.Class(OpenLayers.Control, {
      * {Boolean} The control was effectively activated.
      */
     activate: function () {
+        if (this.available && !this.geolocation) {
+            // set lazily to avoid IE9 memory leak
+            this.geolocation = navigator.geolocation;
+        }
         if (!this.geolocation) {
             this.events.triggerEvent("locationuncapable");
             return false;

--- a/tests/Control/Geolocate.html
+++ b/tests/Control/Geolocate.html
@@ -101,18 +101,6 @@
         map.removeControl(control);
         map.setCenter(centerLL);
     }
-    function test_uncapable(t) {
-        t.plan(1);
-        var control = new OpenLayers.Control.Geolocate({
-            geolocation: null,
-            bind: false
-        });
-        control.events.register('locationuncapable', null, function() {
-            t.ok(true,'uncapable browser fired locationuncapable event');
-        });
-        map.addControl(control);
-        control.activate();
-    }
     function test_destroy(t) {
         t.plan(1);
         var control = new OpenLayers.Control.Geolocate({


### PR DESCRIPTION
- Memory leak in Internet Explorer 9 (Browser-Mode: IE9, Document-Mode: IE9 standards) when reloading page continuously.
- Browser-Mode:IE9, Document-Mode: IE7 and IE8 do NOT have this memory leak.
- IE 10 Consumer Preview do NOT have this memory leak
- using jQuery 1.7.2 and OpenLayers-2.12-rc2 a2c556f
- Loading WITHOUT jQuery does NOT leak memory
- OpenLayers 2.11  shows the same problem.

Test pages:

https://s3-ap-southeast-1.amazonaws.com/openlayers/index212-rc2-a2c556f.html 

OpenLayers closured compiled:
https://s3-ap-southeast-1.amazonaws.com/openlayers/index212-rc2-a2c556f-closured.html

https://s3-ap-southeast-1.amazonaws.com/openlayers/index212-rc1-bce40d9.html

https://s3-ap-southeast-1.amazonaws.com/openlayers/index211.html
