### PR TITLE
Update lib/OpenLayers/Layer.js

### DIFF
--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -1162,6 +1162,59 @@ OpenLayers.Layer = OpenLayers.Class({
         return resolution;
     },
 
+         /**
+         * Find the closest resolution based on half of the difference of 2 resolution levels
+         * Given a resolutionArray
+         * resolutionArr[0] = 100
+         *              [1] = 50
+         *              [2] = 25
+         *              [3] = 12.5
+         *
+         * getClosestResolutionIdx(resolutionArray, 51) === 1 // round down to 50 as 51 is closer to 50 than it is to 100
+         * getClosestResolutionIdx(resolutionArray, 76) === 0 // round up to 100 as 76 is closer to 100 than it is to 50
+         * getClosestResolutionIdx(resolutionArray, 10) === 3 // round up to 3 as 10 is closer to 12.5 than it is to 25
+         *
+         * @param resolutionArr
+         * @param resolution
+         * @return {Number}
+         */
+        getClosestResolutionIdx: function (resolutionArr, resolution) {
+            if(!resolution) {
+                // if resolution is not defined, return zoom level 0
+                return 0;
+            }
+            for(var idx=0; idx<resolutionArr.length; idx++) {
+                if( resolutionArr[idx] <= resolution ) {
+
+                    var diff = resolution - resolutionArr[idx];
+                    if( idx > 0 ) {
+                        var halfResolutionDiff = (resolutionArr[idx-1] - resolutionArr[idx]) / 2;
+
+                        // round to nearest zoomLevel integer
+                        // ie if res1 = 10, res2 = 20
+                        //    and prevRes = 14
+                        // then round UP to 10 (nearest integer)
+                        if( diff <= halfResolutionDiff ) {
+                            // closer to resolutionArr[idx]
+                            return idx;
+                        }
+                        else {
+                            return idx-1;
+                        }
+                    }
+                    return idx;
+                }
+                else {
+                    if( (idx+1) === resolutionArr.length ) {
+                        // default to max zoom level(idx) if we can't find something more
+                        // ie previous module has much smaller scale/resolution than that of current one
+                        // so default to smallest scale/resolution this module supports
+                        return idx;
+                    }
+                }
+            }
+        },
+        
     /**
      * APIMethod: getZoomForResolution
      * 
@@ -1207,22 +1260,8 @@ OpenLayers.Layer = OpenLayers.Class({
                 zoom = lowZoom;
             }
         } else {
-            var diff;
-            var minDiff = Number.POSITIVE_INFINITY;
-            for(i=0, len=this.resolutions.length; i<len; i++) {            
-                if (closest) {
-                    diff = Math.abs(this.resolutions[i] - resolution);
-                    if (diff > minDiff) {
-                        break;
-                    }
-                    minDiff = diff;
-                } else {
-                    if (this.resolutions[i] < resolution) {
-                        break;
-                    }
-                }
-            }
-            zoom = Math.max(0, i-1);
+            //fractional zoom, so find the closest resolution to the one supplied
+            zoom = this.getClosestResolutionIdx(this.resolutions, resolution);
         }
         return zoom;
     },


### PR DESCRIPTION
Hi,

I would like to solicit advice/suggestion about the change that I made in OpenLayers.Layer.prototype.getZoomForResolution, 
"Find the closest zoom level based on half of the difference of 2 resolution levels"

/**
- Given a specified resolution and a resolutionArray,
- resolutionArr[0] = 100
-                   [1] = 50
-                   [2] = 25
-                   [3] = 12.5
  *
- getClosestResolutionIdx(resolutionArray, 51) === 1 // round down to 50 as 51 is closer to 50 than it is to 100
- getClosestResolutionIdx(resolutionArray, 76) === 0 // round up to 100 as 76 is closer to 100 than it is to 50
- getClosestResolutionIdx(resolutionArray, 10) === 3 // round up to 3 as 10 is closer to 12.5 than it is to 25
  */
