### PR TITLE
Measure API enhancements

### DIFF
--- a/lib/OpenLayers/Control/Measure.js
+++ b/lib/OpenLayers/Control/Measure.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2006-2013 by OpenLayers Contributors (see authors.txt for
+/* Copyright (c) 2006-2013 by OpenLayers Contributors (see authors.txt for 
  * full list of contributors). Published under the 2-clause BSD license.
  * See license.txt in the OpenLayers distribution or repository for the
  * full text of the license. */


### PR DESCRIPTION
This pull requests suggests to change Measure.js so that:
1. `displaySystem` & `geodesic` properties get promoted to API properties
2. The documentation for `measureImmediate` contains all parameters
3. removes dangling whitespace

The points 2. and 3. are trivial. 1. is non-trivial, but makes sense, since `geodesic` is used in the official examples as API property and `displaySystem` is the easiest way for users to configure the measure output.

Please review. 
