### PR TITLE
Tile images should not have an id

### DIFF
--- a/lib/OpenLayers/TileManager.js
+++ b/lib/OpenLayers/TileManager.js
@@ -363,6 +363,8 @@ OpenLayers.TileManager = OpenLayers.Class({
                 img.style.opacity = 0;
                 img.style.visibility = 'hidden';
             }
+            // Only backbuffer tiles have an id, so we don't want one here
+            img.id = null;
             tile.setImage(img);
             // LRU - move tile to the end of the array to mark it as the most
             // recently used


### PR DESCRIPTION
When the TileManager adds an image to its cache, it might be a backbuffer
image. Backbuffer images have an id with a '_bb' postfix. Regular images
do not have an id at all. In OpenLayers.Layer.Grid, in
addTileMonitoringHooks, a loadend listener is created for each tile. This
listener checks for tie image id, and will remove it from its parent node.
This will cause images to be removed from the layerDiv if the image comes
from the TileManager's tileCache and was on a backbuffer by the time it was
added to the cache.

Simply removing the image's id before assigning it to a tile resolves the
issue.
