### PR TITLE
the tileQueue is not always cleared, for instance when adding a layer in...

### DIFF
--- a/lib/OpenLayers/TileManager.js
+++ b/lib/OpenLayers/TileManager.js
@@ -183,7 +183,7 @@ OpenLayers.TileManager = OpenLayers.Class({
      * evt - {Object} Listener argument
      */
     changeLayer: function(evt) {
-        if (evt.property === 'params') {
+        if (evt.property === 'visibility' || evt.property === 'params') {
             this.updateTimeout(evt.object, 0);
         }
     },


### PR DESCRIPTION
... GeoExplorer and then switching base layers, so make sure we also clear the tileQueue when the visibility of a layer changes
