### PR TITLE
Fix click on PanZoomBar when page is scrolled (issue #798)

### DIFF
--- a/lib/OpenLayers/Events/buttonclick.js
+++ b/lib/OpenLayers/Events/buttonclick.js
@@ -170,6 +170,12 @@ OpenLayers.Events.buttonclick = OpenLayers.Class({
                 } else if (this.startEvt) {
                     if (this.completeRegEx.test(evt.type)) {
                         var pos = OpenLayers.Util.pagePosition(button);
+                        var viewportElement = OpenLayers.Util.getViewportElement();
+                        var scrollTop = window.pageYOffset || viewportElement.scrollTop;
+                        var scrollLeft = window.pageXOffset || viewportElement.scrollLeft;
+                        pos[0] = pos[0] - scrollLeft;
+                        pos[1] = pos[1] - scrollTop;
+                        
                         this.target.triggerEvent("buttonclick", {
                             buttonElement: button,
                             buttonXY: {


### PR DESCRIPTION
buttonclick used page position of the PanZoomBar but clientX/Y (relative to the viewport) from the event object. The fix is to subtract page scroll from button position.
