### PR TITLE
Support for Ajax mocking frameworks

### DIFF
--- a/lib/OpenLayers/Request/XMLHttpRequest.js
+++ b/lib/OpenLayers/Request/XMLHttpRequest.js
@@ -17,10 +17,6 @@
  */
 
 (function () {
-
-    // Save reference to earlier defined object implementation (if any)
-    var oXMLHttpRequest    = window.XMLHttpRequest;
-
     // Define on browser type
     var bGecko    = !!window.controllers,
         bIE        = window.document.all && !window.opera,
@@ -28,7 +24,7 @@
 
     // Enables "XMLHttpRequest()" call next to "new XMLHttpReques()"
     function fXMLHttpRequest() {
-        this._object    = oXMLHttpRequest && !bIE7 ? new oXMLHttpRequest : new window.ActiveXObject("Microsoft.XMLHTTP");
+        this._object    = window.XMLHttpRequest && !bIE7 ? new window.XMLHttpRequest() : new window.ActiveXObject("Microsoft.XMLHTTP");
         this._listeners    = [];
     };
 
@@ -39,8 +35,8 @@
     cXMLHttpRequest.prototype    = fXMLHttpRequest.prototype;
 
     // BUGFIX: Firefox with Firebug installed would break pages if not executed
-    if (bGecko && oXMLHttpRequest.wrapped)
-        cXMLHttpRequest.wrapped    = oXMLHttpRequest.wrapped;
+    if (bGecko && window.XMLHttpRequest.wrapped)
+        cXMLHttpRequest.wrapped    = window.XMLHttpRequest.wrapped;
 
     // Constants
     cXMLHttpRequest.UNSENT                = 0;


### PR DESCRIPTION
Rather than capturing and reusing the window.XMLHttpRequest at
the time of load, OpenLayers.Request.XMLHttpRequest will 
instantiate a new window.XMLHttpRequest object.  This allows
mocking frameworks (e.g. sinon.js) to temporarily mock the object
in unit tests.
