### PR TITLE
Fix: Problem decoding with EncodedPolyline format

### DIFF
--- a/lib/OpenLayers/Format/EncodedPolyline.js
+++ b/lib/OpenLayers/Format/EncodedPolyline.js
@@ -64,7 +64,7 @@ OpenLayers.Format.EncodedPolyline = OpenLayers.Class(OpenLayers.Format, {
 
         var points = this.decode(encoded, 2);
         var pointGeometries = new Array();
-        for (var i = 0; i < points.length; ++i) {
+        for (var i=0, ii=points.length; i<ii; ++i) {
             var point = points[i];
             pointGeometries.push(
                 new OpenLayers.Geometry.Point(point[1] * 1e-5, point[0] * 1e-5)


### PR DESCRIPTION
Corrected: Resulting LineString from "read" method contained various "NaN" entries at the end, which lead to errors e.g in Chrome when rendering.
