### PR TITLE
Restored zoom box behavior

### DIFF
--- a/lib/OpenLayers/Control/ZoomBox.js
+++ b/lib/OpenLayers/Control/ZoomBox.js
@@ -103,10 +103,10 @@ OpenLayers.Control.ZoomBox = OpenLayers.Class(OpenLayers.Control, {
                 oldRes = this.map.getResolution(),
                 newRes = this.map.getResolutionForZoom(zoom),
                 zoomOriginPx = {
-                    x: targetCenterPx.x +
-                        (targetCenterPx.x - centerPx.x) * newRes / oldRes,
-                    y: targetCenterPx.y +
-                        (targetCenterPx.y - centerPx.y) * newRes / oldRes
+                    x: (oldRes * targetCenterPx.x - newRes * centerPx.x) /
+                        (oldRes - newRes),
+                    y: (oldRes * targetCenterPx.y - newRes * centerPx.y) /
+                        (oldRes - newRes)
                 };
             this.map.zoomTo(zoom, zoomOriginPx);
             if (lastZoom == this.map.getZoom() && this.alwaysZoom == true){ 


### PR DESCRIPTION
With the nice animated zoom change (#800), the ZoomBox was changed to use `zoomTo` instead of `zoomToExtent`.  The [calculation of the pixel origin](https://github.com/ahocevar/openlayers/commit/21448d2fd57d3d618a9cff4d1ded6a0e947eec5a#L2R105) (or anchor) for `zoomTo` was a bit off.  Fortunately, the tests caught this!  The change in behavior can also be seen in examples using the zoom box - after zooming, the map is not centered on the center of the drawn rectangle.

With the changes here, all tests pass again.  And the examples work as expected (confirmed with @bartvde's rare `out: true` setting as well :).
