### PR TITLE
Configure handlers via options to Control.SelectFeature

### DIFF
--- a/lib/OpenLayers/Control/SelectFeature.js
+++ b/lib/OpenLayers/Control/SelectFeature.js
@@ -128,6 +128,21 @@ OpenLayers.Control.SelectFeature = OpenLayers.Class(OpenLayers.Control, {
      *     send a list of strings corresponding to the geometry class names.
      */
     geometryTypes: null,
+    
+    /**
+     * APIProperty: featureOptions
+     * {Object} Options passed to the Handler.Feature instance used by this
+     *     control. Note that geometryTypes may be separately specified.
+     */
+    featureOptions: null,
+    
+    /**
+     * APIProperty: boxOptions
+     * {Object} Options passed to the Handler.Box instance used by this control.
+     *     Note that boxDivClassName is set to "olHandlerBoxSelectFeature" by
+     *     default.
+     */
+    boxOptions: null,
 
     /**
      * Property: layer
@@ -200,14 +215,17 @@ OpenLayers.Control.SelectFeature = OpenLayers.Class(OpenLayers.Control, {
         this.handlers = {
             feature: new OpenLayers.Handler.Feature(
                 this, this.layer, this.callbacks,
-                {geometryTypes: this.geometryTypes}
+                OpenLayers.Util.extend({geometryTypes: this.geometryTypes},
+                    this.featureOptions)
             )
         };
 
         if (this.box) {
             this.handlers.box = new OpenLayers.Handler.Box(
                 this, {done: this.selectBox},
-                {boxDivClassName: "olHandlerBoxSelectFeature"}
+                OpenLayers.Util.extend(
+                    {boxDivClassName: "olHandlerBoxSelectFeature"},
+                    this.boxOptions)
             ); 
         }
     },

--- a/tests/Control/SelectFeature.html
+++ b/tests/Control/SelectFeature.html
@@ -3,7 +3,7 @@
     <script src="../OLLoader.js"></script>
     <script type="text/javascript">
     function test_Control_SelectFeature_constructor(t) {
-        t.plan(5);
+        t.plan(7);
         var options = {
 //            geometryTypes: "foo"
         };
@@ -20,6 +20,14 @@
         control = new OpenLayers.Control.SelectFeature(layer, options);
         t.eq(control.layers, null, "this.layers is null if constructor called with a single layer");
         t.eq(control.layer, layer, "this.layer holds the layer that was passed with the constructor if called with a single layer")
+        
+        var myStopDown = false, myBoxDivClassName = "myBoxDiv";
+        control = new OpenLayers.Control.SelectFeature(layer, {
+          featureOptions: {stopDown: myStopDown},
+          box: true,
+          boxOptions: {boxDivClassName: myBoxDivClassName}});
+        t.eq(control.handlers.feature.stopDown, myStopDown, "featureOptions are passed on to the Feature Handler");
+        t.eq(control.handlers.box.boxDivClassName, myBoxDivClassName, "boxOptions are passed on to the Box Handler");
     }
 
     function test_Control_SelectFeature_destroy(t) {


### PR DESCRIPTION
Currently there is no direct way to influence the behaviour of the handlers associated with a Control.SelectFeature (i.e. by setting options in the constructor) - only by going through e.g. myControl.handlers.feature

In order to allow easier configuration of the handlers, e.g. to fix problems with mouse events being swallowed when the controls are in an unexpected order, the properties featureOptions and boxOptions are added to Control.SelectFeature analogue to e.g. the properties dragPanOptions and pinchZoomOptions in Control.Navigation. These are then passed to the constructors of the appropriate handlers. The new properties of the Control.SelectFeature s are declared as API properties.

The commit also includes simple tests for this functionality.
