### PR TITLE
Add option to Handler.Feature to react on touchend instead of touchstart

### DIFF
--- a/lib/OpenLayers/Handler/Feature.js
+++ b/lib/OpenLayers/Handler/Feature.js
@@ -32,8 +32,7 @@ OpenLayers.Handler.Feature = OpenLayers.Class(OpenLayers.Handler, {
         'mousemove': {'in': 'over', 'out': 'out'},
         'dblclick': {'in': 'dblclick', 'out': null},
         'mousedown': {'in': null, 'out': null},
-        'mouseup': {'in': null, 'out': null},
-        'touchstart': {'in': 'click', 'out': 'clickout'}
+        'mouseup': {'in': null, 'out': null}
     },
 
     /**
@@ -59,6 +58,15 @@ OpenLayers.Handler.Feature = OpenLayers.Class(OpenLayers.Handler, {
      * {<OpenLayers.Pixel>} The location of the last mouseup.
      */
     up: null,
+    
+    /**
+     * APIProperty: callbackOnTouchend
+     * {Boolean} Should the click/clickout callbacks be triggered on touchend
+     *     events (true) or on touchstart events (false, default). For e.g.
+     *     DragFeature then this should be set false, for e.g. SelectFeature
+     *     then true gives better results.
+     */
+    callbackOnTouchend: false,
     
     /**
      * Property: clickTolerance
@@ -132,9 +140,50 @@ OpenLayers.Handler.Feature = OpenLayers.Class(OpenLayers.Handler, {
      * {Boolean} Let the event propagate.
      */
     touchstart: function(evt) {
-        this.startTouch(); 
+    	// do we callback on the touchstart or on the touchend event?
+    	if (this.callbackOnTouchend) {
+    		this.EVENTMAP.touchstart = this.EVENTMAP.mousedown;
+    		this.EVENTMAP.touchend = this.EVENTMAP.click;
+    	} else {
+    		this.EVENTMAP.touchstart = this.EVENTMAP.click;
+    		this.EVENTMAP.touchend = this.EVENTMAP.mouseup;
+    	}
+		this.startTouch();
+        if(!this.touch) {
+            this.touch =  true;
+            this.map.events.un({
+                mousedown: this.mousedown,
+                mouseup: this.mouseup,
+                mousemove: this.mousemove,
+                click: this.click,
+                dblclick: this.dblclick,
+                scope: this
+            });
+        }
         return OpenLayers.Event.isMultiTouch(evt) ?
                 true : this.mousedown(evt);
+    },
+
+    /**
+     * Method: touchend
+     * Handle touchend events. We only actually think about handling it if
+     *    callbackOnTouchend is true, the event is a single touch event and we
+     *    already registered a start/down event.
+     * 
+     * Parameters:
+     * evt - {Event}
+     * 
+     * Returns:
+     * {Boolean} Let the event propagate.
+     */ 
+    touchend: function(evt) {
+      // We can't just call mouseup as touchend, in contrast to mouseup, doesn't
+      // always reliably report xy (spotted on iOS6): instead we have been
+      // tracking the touchmove events so we already know where the last touch
+      // occured. 
+      return ((!this.callbackOnTouchend) || OpenLayers.Event.isMultiTouch(evt) ||
+            !this.down) ?
+    		  true : (this.handle(evt) ? !this.stopUp : true);
     },
 
     /**
@@ -147,7 +196,16 @@ OpenLayers.Handler.Feature = OpenLayers.Class(OpenLayers.Handler, {
      * evt - {Event}
      */
     touchmove: function(evt) {
-        OpenLayers.Event.preventDefault(evt);
+        if (this.touch && OpenLayers.Event.isSingleTouch(evt)) {
+          // Due to touchend not reliably reporting a position then if we are
+          // providing callback at touchend then we also record the position at
+          // each touchmove so that we don't actually need the position at
+          // touchend.
+          if (this.down) {
+        	  this.up = evt.xy;
+          }
+          OpenLayers.Event.preventDefault(evt);
+        }
     },
 
     /**
@@ -164,7 +222,13 @@ OpenLayers.Handler.Feature = OpenLayers.Class(OpenLayers.Handler, {
         // This mismatch causes problems when comparing the location of the down and up
         // events in the click function so it is important ignore right-clicks.
         if (OpenLayers.Event.isLeftClick(evt) || OpenLayers.Event.isSingleTouch(evt)) {
-            this.down = evt.xy;
+        	// In the case of handling touchdown then if there is no touchmove
+        	// before the touchend we never capture an up position. Logically,
+        	// bootstrapping the up/end position with the down/start position is
+        	// the same as not recording an end position with the very slight
+        	// performance hit that we will always end up calculating a delta
+        	// for the clickTolerance check.
+            this.up = this.down = evt.xy;
         }
         return this.handle(evt) ? !this.stopDown : true;
     },
@@ -264,7 +328,8 @@ OpenLayers.Handler.Feature = OpenLayers.Class(OpenLayers.Handler, {
         var type = evt.type;
         var handled = false;
         var previouslyIn = !!(this.feature); // previously in a feature
-        var click = (type == "click" || type == "dblclick" || type == "touchstart");
+        var click = (type == "click" || type == "dblclick" ||
+                type == (this.callbackOnTouchend ? "touchend" : "touchstart"));
         this.feature = this.layer.getFeatureFromEvent(evt);
         if(this.feature && !this.feature.layer) {
             // feature has been destroyed
@@ -325,7 +390,7 @@ OpenLayers.Handler.Feature = OpenLayers.Class(OpenLayers.Handler, {
     triggerCallback: function(type, mode, args) {
         var key = this.EVENTMAP[type][mode];
         if(key) {
-            if(type == 'click' && this.up && this.down) {
+            if((key == 'click' || key == 'clickout') && this.up && this.down) {
                 // for click/clickout, only trigger callback if tolerance is met
                 var dpx = Math.sqrt(
                     Math.pow(this.up.x - this.down.x, 2) +

--- a/tests/Handler/Feature.html
+++ b/tests/Handler/Feature.html
@@ -53,7 +53,7 @@
         
     }
     function test_events(t) {
-        t.plan(35);
+        t.plan(40);
         
         var map = new OpenLayers.Map('map');
         var control = new OpenLayers.Control();
@@ -64,8 +64,8 @@
  
         // list below events that should be handled (events) and those
         // that should not be handled (nonevents) by the handler
-        var events = ["mousedown", "mouseup", "mousemove", "click", "dblclick", "touchstart", "touchmove"];
-        var nonevents = ["mouseout", "resize", "focus", "blur", "touchend"];
+        var events = ["mousedown", "mouseup", "mousemove", "click", "dblclick", "touchstart", "touchmove", "touchend"];
+        var nonevents = ["mouseout", "resize", "focus", "blur"];
         map.events.registerPriority = function(type, obj, func) {
             var output = func();
             // Don't listen for setEvent handlers (#902)
@@ -95,6 +95,102 @@
         var activated = handler.activate();
  
     }
+    
+    function test_touchEvents(t) {
+    	t.plan(14);
+        
+        var map = new OpenLayers.Map('map', {controls: []});
+        var control = new OpenLayers.Control();
+        map.addControl(control);
+        var layer = new OpenLayers.Layer();
+        map.addLayer(layer);
+ 
+        var callbacks = {};
+        var numCallbacks = 0;
+        callbacks.click = callbacks.clickout = function() {numCallbacks++;};
+        var newFeature = new OpenLayers.Feature.Vector();
+        newFeature.layer = layer;
+        var px11 = new OpenLayers.Pixel(1, 1);
+        var px22 = new OpenLayers.Pixel(2, 2);
+        var px1010 = new OpenLayers.Pixel(10, 10);
+        var evtPx = {xy: px11, touches: ['foo']};
+
+        // override the layer's getFeatureFromEvent func so that it always
+        // returns newFeature
+        layer.getFeatureFromEvent = function(evt) { return newFeature; };
+        
+        var handler = new OpenLayers.Handler.Feature(control, layer, callbacks);
+        handler.activate();
+
+        // test touch event complex with no movement and callback on touchstart
+        evtPx.type = "touchstart";
+        map.events.triggerEvent("touchstart", evtPx);
+        t.eq(numCallbacks, 1, "1 callback in response to touchstart with callbackOnTouchend == false");
+    	t.eq(handler.EVENTMAP.touchstart.in, "click", "Touchstart correctly assigned to be like click");
+    	t.eq(handler.EVENTMAP.touchend.out, null, "Touchend correctly assigned to generate no callback");
+    	numCallbacks = 0;
+    	evtPx.type = "touchend";
+    	map.events.triggerEvent("touchend", evtPx);
+    	t.eq(numCallbacks, 0, "No callback in response to touchend with callbackOnTouchend == false after no touchmoves");
+    	numCallbacks = 0;
+   	
+    	// test touch event complex with no movement and callback on touchend
+    	handler.callbackOnTouchend = true;
+    	evtPx.type = "touchstart";
+    	map.events.triggerEvent("touchstart", evtPx);
+    	t.eq(numCallbacks, 0, "No callback in response to touchstart with callbackOnTouchend == true");
+    	t.eq(handler.EVENTMAP.touchend.in, "click", "Touchend correctly assigned to be like click");
+    	t.eq(handler.EVENTMAP.touchstart.out, null, "Touchstart correctly assigned to generate no callback");
+    	numCallbacks = 0;
+    	evtPx.type = "touchend";
+    	map.events.triggerEvent("touchend", evtPx);
+    	t.eq(numCallbacks, 1, "1 callback in response to touchend with callbackOnTouchend == true after no touchmoves");
+    	numCallbacks = 0;
+    	
+    	// test touch event complex with movement and callback on touchstart
+    	handler.callbackOnTouchend = false;
+    	evtPx.type = "touchstart";
+    	map.events.triggerEvent("touchstart", evtPx);
+    	t.eq(numCallbacks, 1, "1 callback in response to touchstart with callbackOnTouchend == false");
+    	numCallbacks = 0;
+    	evtPx.type = "touchmove";
+    	evtPx.xy = px22;
+    	map.events.triggerEvent("touchmove", evtPx);
+    	evtPx.type = "touchend";
+    	map.events.triggerEvent("touchend", evtPx);
+    	t.eq(numCallbacks, 0, "No callback in response to touchend with callbackOnTouchend == false after a touchmove within the pixel tolerance");
+    	numCallbacks = 0;
+    	
+    	// test touch event complex with small movement and callback on touchend
+    	handler.callbackOnTouchend = true;
+    	evtPx.xy = px11;
+    	evtPx.type = "touchstart";
+    	map.events.triggerEvent("touchstart", evtPx);
+    	t.eq(numCallbacks, 0, "No callback in response to touchstart with callbackOnTouchend == true");
+    	numCallbacks = 0;
+    	evtPx.type = "touchmove";
+    	evtPx.xy = px22;
+    	map.events.triggerEvent("touchmove", evtPx);
+    	evtPx.type = "touchend";
+    	map.events.triggerEvent("touchend", evtPx);
+    	t.eq(numCallbacks, 1, "1 callback in response to touchend with callbackOnTouchend == true after a touchmove within the pixel tolerance");
+    	numCallbacks = 0;
+    	
+    	// test touch event complex with large movement and callback on touchend
+    	handler.callbackOnTouchend = true;
+    	evtPx.xy = px11;
+    	evtPx.type = "touchstart";
+    	map.events.triggerEvent("touchstart", evtPx);
+    	t.eq(numCallbacks, 0, "No callback in response to touchstart with callbackOnTouchend == true");
+    	numCallbacks = 0;
+    	evtPx.type = "touchmove";
+    	evtPx.xy = px1010;
+    	map.events.triggerEvent("touchmove", evtPx);
+    	evtPx.type = "touchend";
+    	map.events.triggerEvent("touchend", evtPx);
+    	t.eq(numCallbacks, 0, "No callback in response to touchend with callbackOnTouchend == false after a touchmove outside the pixel tolerance");
+    	numCallbacks = 0;
+   }
  
     function test_geometrytype_limit(t) {
         t.plan(1);


### PR DESCRIPTION
In order to allow DragPan navigation on touchscreen devices whilst a Feature handler is active, it is necessary that the Feature handler only produces click/clickout events on touchend. Otherwise, the callback from clicking the feature fires immediately the touch starts, which is probably not what the user was expecting. However, the Feature handler cannot just generally the callback on touchend as for e.g. DragFeature it is necessary that the feature is identified at the start of the touch event.

This change therefore adds an option to the Feature handler that the callback can be fired on touchend instead of touchstart. This option is off by default (current behaviour). My suggestion is that the SelectFeature control should turn it on by default, although this pull request does not currently include this.

Automated tests are included. The behaviour callbackOnTouchend has been manually tested on iOS and Android.

(Note that combining SelectFeature and DragPan controls may also require tinkering with the values for stopClick, stopDown and stopUp in the Feature handler - #891 deals with making it easier to set these)
