### PR TITLE
Fix: LinearRing.js: transform all points

### DIFF
--- a/lib/OpenLayers/Geometry/LinearRing.js
+++ b/lib/OpenLayers/Geometry/LinearRing.js
@@ -175,7 +175,7 @@ OpenLayers.Geometry.LinearRing = OpenLayers.Class(
      */
     transform: function(source, dest) {
         if (source && dest) {
-            for (var i=0, len=this.components.length; i<len - 1; i++) {
+            for (var i=0, len=this.components.length; i<len; i++) {
                 var component = this.components[i];
                 component.transform(source, dest);
             }


### PR DESCRIPTION
Don't miss the last point when transforming a LinearRing.
