### PR TITLE
Google Maps and WMS layer Backbuffer error

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -653,7 +653,7 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
             if (resolution === this.gridResolution) {
                 this.div.insertBefore(backBuffer, this.div.firstChild);
             } else {
-                this.map.layerContainerDiv.insertBefore(backBuffer, this.map.baseLayer.div);
+                this.map.baseLayer.div.parentNode.insertBefore(backBuffer, this.map.baseLayer.div);
             }
             this.backBuffer = backBuffer;
 


### PR DESCRIPTION
Hi,
since the last changes on the back buffer the following error occurs when we use a Google base layer.
Firefox:
NotFoundError: Node was not found
[Break On This Error]   

...s;this.backBufferLonLat={lon:d.left,lat:d.top};this.backBufferResolution=this.gr...

In chrome the awesome message:
Uncaught Error: NotFoundError: DOM Exception 8 

you can reproduce it at 
http://regionalsprache.de/mapviewer/mapviewer.aspx?zoom=7&lat=7158097.02154&lon=907116.56876&layers=0BTTT&layerIds=640%2C-1%2C-1%2C-1%2C124&layerTypes=WMS.Extents%2CGoogle%2CVector%2CVector%2CWMS.Extents
and when you click on the button right next to "Grundkarte" in the LayerSwitcher and choose i.e. the Normal Google map. OSM or Bing works fine. Sometimes it occurs after zoom or pan.
