### PR TITLE
Fix imageryProviders Bug

### DIFF
--- a/lib/OpenLayers/Layer/Bing.js
+++ b/lib/OpenLayers/Layer/Bing.js
@@ -248,7 +248,7 @@ OpenLayers.Layer.Bing = OpenLayers.Class(OpenLayers.Layer.XYZ, {
             this.map.getProjectionObject(),
             new OpenLayers.Projection("EPSG:4326")
         );
-        var providers = res.imageryProviders,
+        var providers = res.imageryProviders || [],
             zoom = OpenLayers.Util.indexOf(this.serverResolutions,
                                            this.getServerResolution()),
             copyrights = "", provider, i, ii, j, jj, bbox, coverage;


### PR DESCRIPTION
Sometimes imageryProviders is null so accessing providers.length on
line 255 causes a TypeError.
