### PR TITLE
Fix UTFGrid isBaseLayer documentation

### DIFF
--- a/lib/OpenLayers/Layer/UTFGrid.js
+++ b/lib/OpenLayers/Layer/UTFGrid.js
@@ -42,7 +42,7 @@ OpenLayers.Layer.UTFGrid = OpenLayers.Class(OpenLayers.Layer.XYZ, {
     
     /**
      * APIProperty: isBaseLayer
-     * Default is true, as this is designed to be a base tile source. 
+     * Default is false, as UTFGrids are designed to be a transparent overlay layer. 
      */
     isBaseLayer: false,
     


### PR DESCRIPTION
Ensure the documentation matches the code with regards to the default value, and make the explanation slightly clearer as to why it defaults to false.
