### PR TITLE
Google Maps rendering bug on fresh reload

### DIFF
--- a/lib/OpenLayers/Layer/Google/v3.js
+++ b/lib/OpenLayers/Layer/Google/v3.js
@@ -92,6 +92,7 @@ OpenLayers.Layer.Google.v3 = {
             googleControl.style.width = '100%';
             googleControl.style.height = '100%';
             mapObject.controls[google.maps.ControlPosition.TOP_LEFT].push(googleControl);
+            this.map.div.appendChild(container);
             
             // cache elements for use by any other google layers added to
             // this same map
@@ -140,26 +141,13 @@ OpenLayers.Layer.Google.v3 = {
             }
             var container = this.mapObject.getDiv();
             if (visible === true) {
-                if (container.parentNode !== map.div) {
-                    map.div.appendChild(container);
-                    if (!cache.rendered) {
-                        google.maps.event.addListenerOnce(this.mapObject, 'tilesloaded', function() {
-                            cache.googleControl.appendChild(map.viewPortDiv);
-                            cache.rendered = true;
-                        });
-                    } else {
-                        cache.googleControl.appendChild(map.viewPortDiv);
-                    }
-                    google.maps.event.trigger(this.mapObject, 'resize');
-                }
+                container.style.display = '';
+                cache.googleControl.appendChild(map.viewPortDiv);
+                google.maps.event.trigger(this.mapObject, 'resize');
                 this.mapObject.setMapTypeId(type);                
-                cache.displayed = this.id;
             } else {
-                if (cache.googleControl.hasChildNodes()) {
-                    map.div.appendChild(map.viewPortDiv);
-                    map.div.removeChild(container);
-                }
-                delete cache.displayed;
+                map.div.appendChild(map.viewPortDiv);
+                container.style.display = 'none';
             }
         }
     },


### PR DESCRIPTION
When loading the Google v3 Maps example here -> http://openlayers.org/dev/examples/google-v3.html the containing div momentarily appears below its intended destination before 'snapping' into place causing a flicker type effect on first load.

This can be reproduced by viewing the example page on Chrome, Firefox, Opera and Safari and watching how the elements load.

The effect also appears in demo maps set up locally using 2.13-dev and not just isolated to the online examples.
