### PR TITLE
Improved touch support for Handler.Path.undo

### DIFF
--- a/lib/OpenLayers/Handler/Path.js
+++ b/lib/OpenLayers/Handler/Path.js
@@ -271,6 +271,16 @@ OpenLayers.Handler.Path = OpenLayers.Class(OpenLayers.Handler.Point, {
         var target = components[index];
         var undone = geometry.removeComponent(target);
         if (undone) {
+            // On touch devices, set the current ("mouse location") point to
+            // match the last digitized point.
+            if (this.touch && index > 0) {
+                components = geometry.components; // safety
+                var lastpt = components[index - 1];
+                var curptidx = this.getCurrentPointIndex();
+                var curpt = components[curptidx];
+                curpt.x = lastpt.x;
+                curpt.y = lastpt.y;
+            }
             if (!this.redoStack) {
                 this.redoStack = [];
             }

--- a/tests/Handler/Path.html
+++ b/tests/Handler/Path.html
@@ -601,6 +601,12 @@
         handler.mousedown({type: "mousedown", xy: px});
         handler.mouseup({type: "mouseup", xy: px});
     }
+    function userTap(handler, x, y) {
+        var px = new OpenLayers.Pixel(x, y);
+        handler.touchstart({xy: px});
+        handler.touchmove({xy: px});
+        handler.touchend({});
+    }
 
     /**
      * Editing method tests: insertXY, insertDeltaXY, insertDirectionXY,
@@ -720,7 +726,7 @@
     }
 
     function test_undoredo1(t) {
-        t.plan(4);
+        t.plan(5);
         var obj = editingMethodsSetup();
         var map = obj.map;
         var handler = obj.handler;
@@ -746,6 +752,17 @@
         // one redo
         handler.redo();
         t.geom_eq(original, handler.line.geometry, "one redo undoes one undo");
+        
+        // add point via touch
+        userTap(handler, 10, 50);
+        handler.undo();
+        currentLen = handler.line.geometry.components.length;
+        t.geom_eq(
+            handler.line.geometry.components[currentLen-1],
+            handler.line.geometry.components[currentLen-2],
+            "current point (mouse position) is set to the last digitized " + 
+            "point after undo on touch devices"
+        );
         
         // cleanup
         map.destroy();


### PR DESCRIPTION
This is a redo of #512 because I botched that PR.  It's a simple tweak to the handler code that is (I think) ready for review.

In OpenLayers.Handler.Path.undo on touch devices, set the current ("mouse location") point to match the _new_ last vertex in the linestring. Touch devices have no current mouse position (just a last-tapped position), and it's misleading to leave the current point sitting at the last-tapped position, which is likely the location of the vertex that has just been undone, giving the impression that the vertex is still there.

There's currently no built-in UI for invoking undo on touch devices, but for developers (like me) who are calling into the handler from their code, this fix is helpful.
