### PR TITLE
Format/WKT.js: add @requires for geometry types

### DIFF
--- a/lib/OpenLayers/Format/WKT.js
+++ b/lib/OpenLayers/Format/WKT.js
@@ -6,6 +6,12 @@
 /**
  * @requires OpenLayers/Format.js
  * @requires OpenLayers/Feature/Vector.js
+ * @requires OpenLayers/Geometry/Point.js
+ * @requires OpenLayers/Geometry/MultiPoint.js
+ * @requires OpenLayers/Geometry/LineString.js
+ * @requires OpenLayers/Geometry/MultiLineString.js
+ * @requires OpenLayers/Geometry/Polygon.js
+ * @requires OpenLayers/Geometry/MultiPolygon.js
  */
 
 /**


### PR DESCRIPTION
I made a minimal OpenLayers build configuration file (https://gist.github.com/2936890) and noted that `OpenLayers/Geometry/MultiPolygon.js` was not pulled in.  The WKT format uses this class explicitly, so I think it should have a `@requires`  comment for it.  I'd recommend explicitly requiring all the geometry types, as in OpenLayers.Format.GML.

I'd make a pull request, but right now we're waiting on our university's legal department for word on a CLA.
