### PR TITLE
Also trigger beforefeaturemodified event in non-standalone mode

### DIFF
--- a/lib/OpenLayers/Control/ModifyFeature.js
+++ b/lib/OpenLayers/Control/ModifyFeature.js
@@ -335,9 +335,9 @@ OpenLayers.Control.ModifyFeature = OpenLayers.Class(OpenLayers.Control, {
     /**
      * APIMethod: selectFeature
      * Select a feature for modification in standalone mode. In non-standalone
-     * mode, this method is called when the select feature control selects a
-     * feature. Register a listener to the beforefeaturemodified event and
-     * return false to prevent feature modification.
+     * mode, this method is called when a feature is selected by clicking.
+     * Register a listener to the beforefeaturemodified event and return false
+     * to prevent feature modification.
      *
      * Parameters:
      * feature - {<OpenLayers.Feature.Vector>} the selected feature.
@@ -347,7 +347,7 @@ OpenLayers.Control.ModifyFeature = OpenLayers.Class(OpenLayers.Control, {
                 feature.geometry.CLASS_NAME) == -1) {
             return;
         }
-        if (!this.standalone || this.beforeSelectFeature(feature) !== false) {
+        if (this.beforeSelectFeature(feature) !== false) {
             if (this.feature) {
                 this.unselectFeature(this.feature);
             }

--- a/tests/Control/ModifyFeature.html
+++ b/tests/Control/ModifyFeature.html
@@ -204,7 +204,7 @@
     }
 
     function test_selectFeature(t) {
-        t.plan(9);
+        t.plan(12);
         var map = new OpenLayers.Map('map');
         var layer = new OpenLayers.Layer.Vector("Vectors!", {isBaseLayer: true});
         map.addLayer(layer);


### PR DESCRIPTION
d2a32d5 accidently changed the number of assertions in the
test_selectFeature function, so the change in behavior that no
beforefeaturemodified event is called any more in non-standalone mode got
unnoticed: Before unhacking ModifyFeature, the SelectFeature control
called the beforeSelectFeature method directly. Now, without a built-in
SelectFeature control, we need to call it from the selectFeature method in
both standalone and non-standalone mode.
