### PR TITLE
VML::graphicRotate: handle style.rotation == "NaN"

### DIFF
--- a/lib/OpenLayers/Renderer/VML.js
+++ b/lib/OpenLayers/Renderer/VML.js
@@ -354,7 +354,7 @@ OpenLayers.Renderer.VML = OpenLayers.Class(OpenLayers.Renderer.Elements, {
      */
     graphicRotate: function(node, xOffset, yOffset, style) {
         var style = style || node._style;
-        var rotation = style.rotation || 0;
+        var rotation = parseFloat(style.rotation) || 0;
         
         var aspectRatio, size;
         if (!(style.graphicWidth && style.graphicHeight)) {
@@ -430,7 +430,7 @@ OpenLayers.Renderer.VML = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         // do the rotation again on a box, so we know the insertion point
         var centerPoint = new OpenLayers.Geometry.Point(-xOffset, -yOffset);
         var imgBox = new OpenLayers.Bounds(0, 0, width, height).toGeometry();
-        imgBox.rotate(style.rotation, centerPoint);
+        imgBox.rotate(parseFloat(style.rotation) || 0, centerPoint);
         var imgBounds = imgBox.getBounds();
 
         node.style.left = Math.round(


### PR DESCRIPTION
Bugfix: The VML renderer crashed when it hit the first "NaN" rotation, leaving remaining features unrendered.
