### PR TITLE
Make feature selection happen on touchend

### DIFF
--- a/lib/OpenLayers/Handler/Feature.js
+++ b/lib/OpenLayers/Handler/Feature.js
@@ -289,7 +289,7 @@ OpenLayers.Handler.Feature = OpenLayers.Class(OpenLayers.Handler, {
         var handled = false;
         var previouslyIn = !!(this.feature); // previously in a feature
         var click = (type == "click" || type == "dblclick" || type == "touchend");
-        if (isNaN(evt.xy.x) || isNaN(evt.xy.y)) {
+        if (evt.xy && (isNaN(evt.xy.x) || isNaN(evt.xy.y))) {
             evt.xy = this.up;
         }
         this.feature = this.layer.getFeatureFromEvent(evt);

--- a/tests/Handler/Feature.html
+++ b/tests/Handler/Feature.html
@@ -381,7 +381,7 @@
             t.ok(!handler.stopUp, "mouseup propagate with stopUp set to false" );
         });
         map.events.register("touchend", map, function(e) {
-            t.ok(!handler.stopUp, "touchend propagate with stopEnd set to false" );
+            t.ok(!handler.stopEnd, "touchend propagate with stopEnd set to false" );
         });
 
         // 0 test
@@ -390,7 +390,7 @@
         map.events.triggerEvent('mousedown', evtPx);
         // 0 test
         map.events.triggerEvent('mousedown', evtPx);
-        // 0 test
+        // 1 test
         map.events.triggerEvent('touchend', evtPx);
 
         // 1 test
@@ -401,6 +401,9 @@
         map.events.triggerEvent('mousedown', evtPx);
         // 1 test
         handler.stopUp = false;
+        map.events.triggerEvent('touchend', evtPx);
+        // 0 test
+        handler.stopEnd = true;
         map.events.triggerEvent('touchend', evtPx);
         
         // 4 tests total


### PR DESCRIPTION
Rather than on `touchstart`.
Then it’s possible to pan on a feature without selecting it (not possible at the moment).

Successfully tested on Android 2 & 4, iOS 5 & 6.
Tests pass in FF.

Please review! :)
