### PR TITLE
URL comparison fails in IE8

### DIFF
--- a/lib/OpenLayers/Tile/Image.js
+++ b/lib/OpenLayers/Tile/Image.js
@@ -7,6 +7,7 @@
 /**
  * @requires OpenLayers/Tile.js
  * @requires OpenLayers/Animation.js
+ * @requires OpenLayers/Util.js
  */
 
 /**
@@ -317,7 +318,7 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile, {
         this.layer.div.appendChild(this.getTile());
         this.events.triggerEvent(this._loadEvent);
         var img = this.getImage();
-        if (this.url && img.getAttribute("src") == this.url) {
+        if (this.url && OpenLayers.Util.isEquivalentUrl(img.src, this.url)) {
             this._loadTimeout = window.setTimeout(
                 OpenLayers.Function.bind(this.onImageLoad, this), 0
             );

--- a/tests/TileManager.html
+++ b/tests/TileManager.html
@@ -64,17 +64,28 @@
             gridSize = layer.div.childNodes.length;
             map.setCenter([17, 47]);
         });
+
+        function inCache(img) {
+            var search = img.src.split('?')[1];
+            for (var s in tileManager.tileCache) {
+                if (s.split('?')[1] == search) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         t.delay_call(4, function() {
             t.eq(tileManager.tileCacheIndex.length, 12, "tiles cached");
             t.ok(tileManager.tileCache[layer.grid[1][2].url] === layer.grid[1][2].imgDiv, "correct object cached");
-            t.ok(!(firstInCache.getAttribute("src") in tileManager.tileCache), "old tile discarded");
-            t.ok(sharedTile.getAttribute("src") in tileManager.tileCache, "shared tile still in cache");
+            t.ok(!inCache(firstInCache), "old tile discarded");
+            t.ok(inCache(sharedTile), "shared tile still in cache");
             firstInCache = tileManager.tileCache[tileManager.tileCacheIndex[0]];
             map.setCenter([16, 48]);
         });
         t.delay_call(6, function() {
-            t.ok(!(firstInCache.getAttribute("src") in tileManager.tileCache), "old tile discarded");
-            t.ok(sharedTile.getAttribute("src") in tileManager.tileCache, "shared tile still in cache");
+            t.ok(!inCache(firstInCache), "old tile discarded");
+            t.ok(inCache(sharedTile), "shared tile still in cache");
             t.eq(layer.div.childNodes.length, gridSize, 'no unused images left in dom');
             map.destroy();
         });


### PR DESCRIPTION
The W3C standard says that setAttribute/getAttribute on any DOM element is
a simple setter/getter thing. IE8 tries to be smarter and returns the full
URL when calling getAttribute('src') on an image instead of the one that
was set with setAttribute('src').

This change makes sure that urls are compared properly, also in IE8.
