### PR TITLE
Make feature handler propagate touch events

### DIFF
--- a/lib/OpenLayers/Handler/Feature.js
+++ b/lib/OpenLayers/Handler/Feature.js
@@ -164,7 +164,7 @@ OpenLayers.Handler.Feature = OpenLayers.Class(OpenLayers.Handler, {
      * evt - {Event}
      */
     touchmove: function(evt) {
-        OpenLayers.Event.stop(evt);
+        OpenLayers.Event.preventDefault(evt);
     },
 
     /**
@@ -295,7 +295,7 @@ OpenLayers.Handler.Feature = OpenLayers.Class(OpenLayers.Handler, {
             if(type === "touchstart") {
                 // stop the event to prevent Android Webkit from
                 // "flashing" the map div
-                OpenLayers.Event.stop(evt);
+                OpenLayers.Event.preventDefault(evt);
             }
             var inNew = (this.feature != this.lastFeature);
             if(this.geometryTypeMatches(this.feature)) {


### PR DESCRIPTION
This commit is a follow-up on issue #294 (commit a6119f6) and #861 (commit c7a4045). The feature handler should not stop the bubbling up of browser events. In this particular case, when the feature handler is activated, Sencha Touch will trigger longpress events when panning the map because the feature handler stops touchmove.
