### PR TITLE
New option "featureType" for DrawFeature control

### DIFF
--- a/lib/OpenLayers/Control/DrawFeature.js
+++ b/lib/OpenLayers/Control/DrawFeature.js
@@ -24,6 +24,12 @@ OpenLayers.Control.DrawFeature = OpenLayers.Class(OpenLayers.Control, {
      * {<OpenLayers.Layer.Vector>}
      */
     layer: null,
+    
+    /**
+     * Property: featureType
+     * {String} If the layer has multiple types, use this type for new features
+     */
+    featureType: null,
 
     /**
      * Property: callbacks
@@ -82,6 +88,9 @@ OpenLayers.Control.DrawFeature = OpenLayers.Class(OpenLayers.Control, {
                     );
                 },
                 create: function(vertex, feature) {
+                    if (!feature.type && this.featureType) {
+                        feature.type = this.featureType;
+                    }
                     this.layer.events.triggerEvent(
                         "sketchstarted", {vertex: vertex, feature: feature}
                     );
@@ -91,6 +100,7 @@ OpenLayers.Control.DrawFeature = OpenLayers.Class(OpenLayers.Control, {
         );
         this.layer = layer;
         this.handlerOptions = this.handlerOptions || {};
+        this.featureType = this.featureType || (options && options.featureType) || null;
         this.handlerOptions.layerOptions = OpenLayers.Util.applyDefaults(
             this.handlerOptions.layerOptions, {
                 renderers: layer.renderers, rendererOptions: layer.rendererOptions
@@ -114,6 +124,10 @@ OpenLayers.Control.DrawFeature = OpenLayers.Class(OpenLayers.Control, {
      */
     drawFeature: function(geometry) {
         var feature = new OpenLayers.Feature.Vector(geometry);
+        if (!feature.type && this.featureType) {
+            feature.type = this.featureType;
+        }
+        
         var proceed = this.layer.events.triggerEvent(
             "sketchcomplete", {feature: feature}
         );

--- a/lib/OpenLayers/Format/GML/Base.js
+++ b/lib/OpenLayers/Format/GML/Base.js
@@ -567,7 +567,20 @@ OpenLayers.Format.GML.Base = OpenLayers.Class(OpenLayers.Format.XML, {
         },
         "feature": {
             "_typeName": function(feature) {
-                var node = this.createElementNSPlus("feature:" + this.featureType, {
+                // get correct feature type
+                var featureType;
+                if (feature.type) {
+                    featureType = feature.type;
+                }
+                else if (typeof this.featureType == "object") {
+                    // TODO: this is only a workaround -> use first feature type
+                    featureType = this.featureType[0];
+                }
+                else {
+                    featureType = this.featureType;
+                }
+                
+                var node = this.createElementNSPlus("feature:" + featureType, {
                     attributes: {fid: feature.fid}
                 });
                 if(feature.geometry) {

--- a/lib/OpenLayers/Format/WFST/v1.js
+++ b/lib/OpenLayers/Format/WFST/v1.js
@@ -316,7 +316,7 @@ OpenLayers.Format.WFST.v1 = OpenLayers.Class(OpenLayers.Format.XML, {
                     attributes: {
                         handle: options && options.handle,
                         typeName: (this.featureNS ? this.featurePrefix + ":" : "") +
-                            this.featureType
+                            (feature.type || this.featureType)
                     }
                 });
                 if(this.featureNS) {

--- a/lib/OpenLayers/Strategy/Save.js
+++ b/lib/OpenLayers/Strategy/Save.js
@@ -172,6 +172,9 @@ OpenLayers.Strategy.Save = OpenLayers.Class(OpenLayers.Strategy, {
                 if(orig.url) {
                     clone.url = orig.url;
                 }
+                if(orig.type) {
+                    clone.type = orig.type;
+                }
                 clone._original = orig;
                 clone.geometry.transform(local, remote);
                 clones[i] = clone;

--- a/tests/Control/DrawFeature.html
+++ b/tests/Control/DrawFeature.html
@@ -151,6 +151,42 @@
 
         map.destroy();
     }
+    
+    function test_featureType(t) {
+        t.plan(3);
+
+        var map = new OpenLayers.Map("map");
+        var layer = new OpenLayers.Layer.Vector("foo", {
+            maxExtent: new OpenLayers.Bounds(-10, -10, 10, 10),
+            isBaseLayer: true
+        });
+        var control = new OpenLayers.Control.DrawFeature(
+            layer, OpenLayers.Handler.Point
+        );
+        map.addLayer(layer);
+        map.addControl(control);
+        map.zoomToMaxExtent();
+
+        
+        var log;
+        layer.events.on({
+            sketchstarted: function(event) {
+                log = event;
+            }
+        });
+        
+        t.eq(control.featureType, null, "control.type is null by default");
+        
+        control.activate();
+        map.events.triggerEvent("mousemove", {xy: new OpenLayers.Pixel(0, 0)});
+        t.eq(log.feature.type, null, "feature.type is null by default");
+        control.deactivate();
+        
+        control.featureType = "f1"
+        control.activate();
+        map.events.triggerEvent("mousemove", {xy: new OpenLayers.Pixel(0, 0)});
+        t.eq(log.feature.type, "f1", "type of new feature was 'f1'");
+    }
 
     </script>
 </head>

--- a/tests/Format/GML/v2.html
+++ b/tests/Format/GML/v2.html
@@ -230,7 +230,7 @@
     }
 
     function test_multipleTypenames(t) {
-        t.plan(5);
+        t.plan(7);
         var doc = readXML("v2/multipletypenames.xml");
         var format = new OpenLayers.Format.GML.v2({
             featureType: ["LKUNSTWERK", "PKUNSTWERK", "VKUNSTWERK"],
@@ -243,6 +243,16 @@
         t.eq(features[1].type, "LKUNSTWERK", "Second feature type is from the LKUNSTWERK typename");
         t.eq(features[2].type, "PKUNSTWERK", "Third feature type is from the PKUNSTWERK typename");
         t.eq(features[0].namespace, "http://mapserver.gis.umn.edu/mapserver", "Namespace is set correctly on feature");
+        
+        var feature = features[0];
+
+        // check type name after write
+        features = format.read(format.write(feature));
+        t.eq(features[0].type, "VKUNSTWERK", "Type was correct written");
+        
+        feature.type = null;
+        features = format.read(format.write(feature));
+        t.eq(features[0].type, "LKUNSTWERK", "Default type was correct written");
     }
 
     function test_noGeom(t) {


### PR DESCRIPTION
If a GML protocol with multiple feature types renders a feature, the used feature type was an array of all types.
Now it will be checked, whether a given feature has a type. If true it will be used for the generated XML, otherwise the first type of the format is used. Therfore it must be possible to assign a type to the feature, why I added a new "featureType" option to the DrawFeature control.

_See tests\Format\GML\v2.html_

``` javascript
var format = new OpenLayers.Format.GML.v2({
    featureType: ["LKUNSTWERK", "PKUNSTWERK", "VKUNSTWERK"],
    featureNS: "http://mapserver.gis.umn.edu/mapserver",
    geometry_name: "geometry"
});

feature.type = 'PKUNSTWERK';
format.write(feature)
```

The string `[LKUNSTWERK, PKUNSTWERK, VKUNSTWERK]` was used as type.
