### PR TITLE
Zooming with TileManager does not work with GeoExt 1.x and webkit browsers

### DIFF
--- a/lib/OpenLayers/Util.js
+++ b/lib/OpenLayers/Util.js
@@ -866,11 +866,17 @@ OpenLayers.Util.destinationVincenty = function(lonlat, brng, dist) {
  * url - {String} Optional url used to extract the query string.
  *                If url is null or is not supplied, query string is taken 
  *                from the page location.
+ * options - {Object} Additional options. Optional.
+ *
+ * Valid options:
+ *   splitArgs - {Boolean} Split comma delimited params into arrays? Default is
+ *       true.
  * 
  * Returns:
  * {Object} An object of key/value pairs from the query string.
  */
-OpenLayers.Util.getParameters = function(url) {
+OpenLayers.Util.getParameters = function(url, options) {
+    options = options || {};
     // if no url specified, take it from the location bar
     url = (url === null || url === undefined) ? window.location.href : url;
 
@@ -906,7 +912,9 @@ OpenLayers.Util.getParameters = function(url) {
             }
             
             // follow OGC convention of comma delimited values
-            value = value.split(",");
+            if (options.splitArgs !== false) {
+                value = value.split(",");
+            }
 
             //if there's only one value, do not return as array                    
             if (value.length == 1) {
@@ -1299,7 +1307,8 @@ OpenLayers.Util.isEquivalentUrl = function(url1, url2, options) {
     OpenLayers.Util.applyDefaults(options, {
         ignoreCase: true,
         ignorePort80: true,
-        ignoreHash: true
+        ignoreHash: true,
+        splitArgs: false
     });
 
     var urlObj1 = OpenLayers.Util.createUrlObject(url1, options);
@@ -1340,6 +1349,8 @@ OpenLayers.Util.isEquivalentUrl = function(url1, url2, options) {
  *   ignoreCase - {Boolean} lowercase url,
  *   ignorePort80 - {Boolean} don't include explicit port if port is 80,
  *   ignoreHash - {Boolean} Don't include part of url after the hash (#).
+ *   splitArgs - {Boolean} Split comma delimited params into arrays? Default is
+ *       true.
  * 
  * Returns:
  * {Object} An object with separate url, a, port, host, and args parsed out 
@@ -1395,7 +1406,8 @@ OpenLayers.Util.createUrlObject = function(url, options) {
         var qMark = url.indexOf("?");
         queryString = (qMark != -1) ? url.substr(qMark) : "";
     }
-    urlObject.args = OpenLayers.Util.getParameters(queryString);
+    urlObject.args = OpenLayers.Util.getParameters(queryString,
+            {splitArgs: options.splitArgs});
 
     // pathname
     //

--- a/tests/Util.html
+++ b/tests/Util.html
@@ -783,7 +783,7 @@
     }
 
     function test_Util_isEquivalentUrl(t) {
-        t.plan(9);
+        t.plan(10);
         
         var url1, url2, options;
 
@@ -846,6 +846,11 @@
         url2 = new Array(window.location.pathname.split("/").length-1).join("../")+"foo/bar";
         
         t.ok(OpenLayers.Util.isEquivalentUrl(url1, url2), "absolute and relative path without host works for "+url2) 
+
+  //ARGS
+        url1 = "foo.html?bbox=1,2,3,4",
+        url2 = url1;
+        t.ok(OpenLayers.Util.isEquivalentUrl(url1, url2), "equal urls with comma delimited params are equal");
     }
     
     function test_createUrlObject(t) {


### PR DESCRIPTION
While testing the latest OL 2.13-rc1 release with GeoExt, I have discovered that when zooming to any previously loaded extent/zoom the TileManager will fail to load any tiles. As a side-effect, the mousewheel zoom control becomes disabled. Tiles seem to return temporarily after using the +/- zoom control which also re-enables the mousewheel zoom control.

Affecting webkit flavours: Chrome, Chromium & Safari. 

To reproduce with basic GeoExt mappanel example:
- Modify http://api.geoext.org/1.1/examples/mappanel-div.html
- point to a local 2.13-rc1 build of OpenLayers 
- enable the TileManager:

```
    var map = new OpenLayers.Map({
        "tileManager": new OpenLayers.TileManager()
    });
```
- zoom in once
- zoom out once
