### PR TITLE
OL 2.13rc2 layer.setVisibility() with TileManager does not always work with GeoExt 1.x

### DIFF
--- a/lib/OpenLayers/TileManager.js
+++ b/lib/OpenLayers/TileManager.js
@@ -175,7 +175,7 @@ OpenLayers.TileManager = OpenLayers.Class({
      * evt - {Object} Listener argument
      */
     move: function(evt) {
-        this.updateTimeout(evt.object, this.moveDelay);
+        this.updateTimeout(evt.object, this.moveDelay, true);
     },
     
     /**
@@ -272,11 +272,16 @@ OpenLayers.TileManager = OpenLayers.Class({
      * Parameters:
      * map - {<OpenLayers.Map>} The map to update the timeout for
      * delay - {Number} The delay to apply
+     * nice - {Boolean} If true, the timeout function will only be created if
+     *     the tilequeue is not empty. This is used by the move handler to
+     *     avoid impacts on dragging performance. For other events, the tile
+     *     queue may not be populated yet, so we need to set the timer
+     *     regardless of the queue size.
      */
-    updateTimeout: function(map, delay) {
+    updateTimeout: function(map, delay, nice) {
         window.clearTimeout(this.tileQueueId[map.id]);
         var tileQueue = this.tileQueue[map.id];
-        if (tileQueue.length) {
+        if (!nice || tileQueue.length) {
             this.tileQueueId[map.id] = window.setTimeout(
                 OpenLayers.Function.bind(function() {
                     this.drawTilesFromQueue(map);


### PR DESCRIPTION
When the TileManager is enabled, toggling between two different layers via layer.setVisibility(true|false) will sometimes result in no tiles being loaded. 

This is always the case when loading a portion of a layer which has not previously been loaded. Panning very slightly or zooming in/out will always force the tiles to then be loaded.

jsfiddle example: http://jsfiddle.net/HN5CQ/4/
