### PR TITLE
OL 2.13rc3: Re-adding layer to map fails with TileManager enabled

### DIFF
--- a/lib/OpenLayers/TileManager.js
+++ b/lib/OpenLayers/TileManager.js
@@ -388,6 +388,11 @@ OpenLayers.TileManager = OpenLayers.Class({
         if (img && (!img.parentNode ||
                  OpenLayers.Element.hasClass(img.parentNode, 'olBackBuffer'))) {
             if (tile.layer.backBuffer) {
+                if (tile.layer.backBuffer === img.parentNode) {
+                    // cached image is on the target layer's backbuffer already,
+                    // so nothing to do here
+                    return;
+                }
                 img.style.opacity = 0;
                 img.style.visibility = 'hidden';
             }


### PR DESCRIPTION
When the TileManager is enabled, adding and removing, and _then_ re-adding the same layer to the map will cause that layer being shown very briefly, then disappearing.
Without the TileManager this works just fine.
