### PR TITLE
Protect ZoomBox from division by zero

### DIFF
--- a/lib/OpenLayers/Control/ZoomBox.js
+++ b/lib/OpenLayers/Control/ZoomBox.js
@@ -101,14 +101,18 @@ OpenLayers.Control.ZoomBox = OpenLayers.Class(OpenLayers.Control, {
                 centerPx = {x: size.w / 2, y: size.h / 2},
                 zoom = this.map.getZoomForExtent(bounds),
                 oldRes = this.map.getResolution(),
-                newRes = this.map.getResolutionForZoom(zoom),
-                zoomOriginPx = {
+                newRes = this.map.getResolutionForZoom(zoom);
+            if (oldRes == newRes) {
+                this.map.setCenter(this.map.getLonLatFromPixel(targetCenterPx));
+            } else {
+              var zoomOriginPx = {
                     x: (oldRes * targetCenterPx.x - newRes * centerPx.x) /
                         (oldRes - newRes),
                     y: (oldRes * targetCenterPx.y - newRes * centerPx.y) /
                         (oldRes - newRes)
                 };
-            this.map.zoomTo(zoom, zoomOriginPx);
+                this.map.zoomTo(zoom, zoomOriginPx);
+            }
             if (lastZoom == this.map.getZoom() && this.alwaysZoom == true){ 
                 this.map.zoomTo(lastZoom + (this.out ? -1 : 1)); 
             }


### PR DESCRIPTION
When the map is at the highest zoom level, the old and the current
resolution will be the same. This would cause a division by zero, which
the JavaScript engine does not recognize as such. So we have to protect
zoomOriginPx from becoming {x: Infinity, y: Infinity}.
