### PR TITLE
Kinetic dragging causes multiple requests and hangs an application.

### DIFF
--- a/lib/OpenLayers/Control/DragPan.js
+++ b/lib/OpenLayers/Control/DragPan.js
@@ -32,11 +32,12 @@ OpenLayers.Control.DragPan = OpenLayers.Class(OpenLayers.Control, {
     /**
      * Property: interval
      * {Integer} The number of milliseconds that should ellapse before
-     *     panning the map again. Defaults to 1 millisecond. In most cases
-     *     you won't want to change this value. For slow machines/devices
-     *     larger values can be tried out.
+     *     panning the map again. Defaults to 0 milliseconds, which means that
+     *     no separate cycle is used for panning. In most cases you won't want
+     *     to change this value. For slow machines/devices larger values can be
+     *     tried out.
      */
-    interval: 1,
+    interval: 0,
     
     /**
      * APIProperty: documentDrag


### PR DESCRIPTION
Using kinetic dragging in Navigation Control causes multiple requests and hangs an application.

If user start dragging the map and increase acceleration of dragging when multiple geo objects are loaded the map keep moving far away from start dragging location.
In addition, such behaviour causes multiple(in our experiments: 1000+) requests, which hang the application for a long time.
Seems the map control requests tiles and objects for all bounds which are intersected during dragging.
It extremely degrades application performance in case high density of geo objects.

Here is an example, drag the map within area with markers and progressively increase acceleration:
http://jsfiddle.net/easyalgo/eUDNe/2/embedded/result/
