### PR TITLE
Fixing dependencies

### DIFF
--- a/build/mobile.cfg
+++ b/build/mobile.cfg
@@ -29,6 +29,7 @@ OpenLayers/Protocol/HTTP.js
 OpenLayers/Protocol/WFS.js
 OpenLayers/Protocol/WFS/v1_0_0.js
 OpenLayers/Strategy/Fixed.js
+OpenLayers/TileManager.js
 
 [exclude]
 

--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -614,9 +614,8 @@ OpenLayers.Map = OpenLayers.Class({
             {includeXY: true}
         );
         
-        if (this.tileManager !== null) {
-            if (OpenLayers.TileManager &&
-                  !(this.tileManager instanceof OpenLayers.TileManager)) {
+        if (OpenLayers.TileManager && this.tileManager !== null) {
+            if (!(this.tileManager instanceof OpenLayers.TileManager)) {
                 this.tileManager = new OpenLayers.TileManager(this.tileManager);
             }
             this.tileManager.addMap(this);


### PR DESCRIPTION
This avoids undefined this.tileManager.addMap, and re-adds the TileManager
to the mobile build profile.

It also fixes the mobile examples on http://openlayers.org/dev/examples.
