### PR TITLE
LayerSwitcher doesnt switch layer entry correctly if Layer is not visible

### DIFF
--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -743,6 +743,12 @@ OpenLayers.Layer = OpenLayers.Class({
             this.visibility = visibility;
             this.display(visibility);
             this.redraw();
+            if (this.map != null) {
+                this.map.events.triggerEvent("changelayer", {
+                    layer: this,
+                    property: "visibility"
+                });
+            }
             this.events.triggerEvent("visibilitychanged");
         }
     },
@@ -759,11 +765,6 @@ OpenLayers.Layer = OpenLayers.Class({
     display: function(display) {
         if (display != (this.div.style.display != "none")) {
             this.div.style.display = (display && this.calculateInRange()) ? "block" : "none";
-            if(this.map){
-                this.map.events.triggerEvent("changelayer", {
-                    layer: this, property: "visibility"
-                });
-            }
         }
     },
 

--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -2038,7 +2038,9 @@ OpenLayers.Map = OpenLayers.Class({
                         if (!inRange) {
                             layer.display(false);
                         }
-
+                        this.events.triggerEvent("changelayer", {
+                            layer: layer, property: "visibility"
+                        });
                     }
                     if (inRange && layer.visibility) {
                         layer.moveTo(bounds, zoomChanged, options.dragging);

--- a/tests/Layer.html
+++ b/tests/Layer.html
@@ -858,44 +858,6 @@
              "setOpacity() does not trigger changelayer if the opacity value is the same");
     }
 
-    function test_display(t) {
-        t.plan(9);
-
-        var map, layer, log;
-
-        map = new OpenLayers.Map("map");
-        layer = new OpenLayers.Layer("", {
-            alwaysInRange: true,
-            visibility: true
-        });
-        map.addLayer(layer);
-
-        log = [];
-        map.events.register('changelayer', t, function(event) {
-            log.push({
-                layer: event.layer,
-                property: event.property
-            });
-        });
-        layer.display(false);
-        t.eq(layer.div.style.display, "none", "display() set layer's display style to correct value");
-        t.eq(layer.getVisibility(), true, "display() does not affect layer's visibility state");
-        t.eq(log.length, 1, "display() triggers changelayer once");
-        t.ok(log[0].layer == layer, "changelayer listener called with expected layer");
-        t.eq(log[0].property, "visibility", "changelayer listener called with expected property");
-        layer.visibility = false;
-        layer.display(true);
-        t.eq(layer.div.style.display, "block", "display() set layer's display style to correct value");
-        t.eq(layer.getVisibility(), false, "display() does not affect layer's visibility state");
-        layer.setVisibility(true);
-
-        // This call must not trig the event because the opacity value is the same.
-        log = [];
-        layer.display(true);
-        t.eq(log.length, 0, "display() does not trigger changelayer if the display value is the same");
-        layer.setVisibility(false);
-        t.eq(log.length, 1, "changelayer event called only once. setVisibility doesn't fire any extra changelayer events");
-    }
 
 /******
  * 

--- a/tests/Map.html
+++ b/tests/Map.html
@@ -984,22 +984,14 @@
     }
 
     function test_Map_moveTo(t) {
-        t.plan(12);
+        t.plan(2);
 
         map = new OpenLayers.Map('map');
         var baseLayer = new OpenLayers.Layer.WMS("Test Layer", 
             "http://octo.metacarta.com/cgi-bin/mapserv?",
             {map: "/mapdata/vmap_wms.map", layers: "basic"},
             {maxResolution: 'auto', maxExtent: new OpenLayers.Bounds(-10,-10,10,10)});
-        var testLayer = new OpenLayers.Layer("",{maxResolution: 0.1, minResolution: 0.03, isBaseLayer: false, visibility: true});
-        var log = [];
-        map.events.register('changelayer', t, function(event) {
-            log.push({
-                layer: event.layer,
-                property: event.property
-            });
-        });
-        map.events.on({
+        baseLayer.events.on({
             move: function() {
                 t.ok(true, "move listener called");
             },
@@ -1013,20 +1005,10 @@
             }
         });
         map.addLayer(baseLayer);
-        map.addLayer(testLayer);
-        log = [];
         var ll = new OpenLayers.LonLat(-100,-150);
         map.moveTo(ll, 2);
-        
         t.ok(map.getCenter().equals(new OpenLayers.LonLat(0,0)), "safely sets out-of-bounds lonlat");
-        t.eq(testLayer.div.style.display, "none", "moveTo out of resolution range set layer's display style to correct value");
-        t.eq(log.length, 1, "Map.moveTo out of resolution range triggers changelayer once");
-        t.ok(log[0].layer == testLayer, "changelayer listener called with expected layer");
-        t.eq(log[0].property, "visibility", "changelayer listener called with expected property");
 
-        map.moveTo(new OpenLayers.LonLat(0,0), 0);
-        t.eq(testLayer.div.style.display, "block", "moveTo in to resolution range set layer's display style to correct value");
-        
         map.destroy();
     }
 


### PR DESCRIPTION
map.moveTo() change the property layer.inRange without triggering event changelayer
Issue is new in version 2.13
