### PR TITLE
Don't be able to double activate ModifyFeature Control

### DIFF
--- a/lib/OpenLayers/Control/ModifyFeature.js
+++ b/lib/OpenLayers/Control/ModifyFeature.js
@@ -297,15 +297,17 @@ OpenLayers.Control.ModifyFeature = OpenLayers.Class(OpenLayers.Control, {
      * {Boolean} Successfully activated the control.
      */
     activate: function() {
-        this.moveLayerToTop();
-        this.map.events.on({
-            "removelayer": this.handleMapEvents,
-            "changelayer": this.handleMapEvents,
-            scope: this
-        });
-        return (this.handlers.keyboard.activate() &&
-                this.handlers.drag.activate() &&
-                OpenLayers.Control.prototype.activate.apply(this, arguments));
+        if (OpenLayers.Control.prototype.activate.apply(this, arguments)) {
+            this.moveLayerToTop();
+            this.map.events.on({
+                "removelayer": this.handleMapEvents,
+                "changelayer": this.handleMapEvents,
+                scope: this
+            });
+            return this.handlers.keyboard.activate() &&
+                    this.handlers.drag.activate();
+        }
+        return false;
     },
 
     /**


### PR DESCRIPTION
If we use this control with GeoExt Action when we activate the Control the Action call the activate a second time than the layer is raised up a second time (moveLayerToTop)

And when we deactivate the Control the second time who the deactivate method is called the moveLayerBack method isn't call (in case of the if) than the layer steal be in Z_INDEX_BASE['Feature'] position :(
