### PR TITLE
Patch to move ExtendedData block in OpenLayers.Format.KML to pass Schema Validation

### DIFF
--- a/lib/OpenLayers/Format/KML.js
+++ b/lib/OpenLayers/Format/KML.js
@@ -1228,10 +1228,6 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
         placemarkNode.appendChild(placemarkName);
         placemarkNode.appendChild(placemarkDesc);
 
-        // Geometry node (Point, LineString, etc. nodes)
-        var geometryNode = this.buildGeometryNode(feature.geometry);
-        placemarkNode.appendChild(geometryNode);        
-        
         // output attributes as extendedData
         if (feature.attributes) {
             var edNode = this.buildExtendedData(feature.attributes);
@@ -1239,6 +1235,10 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
                 placemarkNode.appendChild(edNode);
             }
         }
+        
+        // Geometry node (Point, LineString, etc. nodes)
+        var geometryNode = this.buildGeometryNode(feature.geometry);
+        placemarkNode.appendChild(geometryNode);        
         
         return placemarkNode;
     },    


### PR DESCRIPTION
OpenLayers.Format.KML currently writes the ExtendedData block below the geometry block e.g:

&lt;kml xmlns=&quot;http://www.opengis.net/kml/2.2&quot;&gt;
  &lt;Folder&gt;
    &lt;name&gt;KML Test&lt;/name&gt;
    &lt;Placemark&gt;
      &lt;name&gt;OpenLayers_Feature_Vector_491&lt;/name&gt;
      &lt;description /&gt;
      &lt;Polygon&gt;
        &lt;outerBoundaryIs&gt;
          &lt;LinearRing&gt;
            &lt;coordinates&gt;276941.5,189961 277145.5,189944 277088.5,189710 276941.5,189961&lt;/coordinates&gt;
          &lt;/LinearRing&gt;
        &lt;/outerBoundaryIs&gt;
      &lt;/Polygon&gt;
      &lt;ExtendedData&gt;
        &lt;Data name=&quot;type&quot;&gt;
          &lt;value&gt;polygon&lt;/value&gt;
        &lt;/Data&gt;
      &lt;/ExtendedData&gt;
    &lt;/Placemark&gt;
  &lt;/Folder&gt;
&lt;/kml&gt;

This causes validation against the schema to fail e.g. using xmllint:

xmllint -schema http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd test.kml

returns an error:

test.kml:14: element ExtendedData: Schemas validity error : Element '{http://www.opengis.net/kml/2.2}ExtendedData': This element is not expected.
test.kml fails to validate

This patch generates the ExtendedData block above the geometry block, allowing the generated KML to validate against the schema.
