### PR TITLE
UTFGrid examples broken because of TileManager

### DIFF
--- a/lib/OpenLayers/TileManager.js
+++ b/lib/OpenLayers/TileManager.js
@@ -310,6 +310,9 @@ OpenLayers.TileManager = OpenLayers.Class({
                 unload: this.unloadTile,
                 scope: this
             });        
+        } else {
+            // Layer has the wrong tile type, so don't handle it any longer
+            this.removeLayer({layer: evt.tile.layer});
         }
     },
     


### PR DESCRIPTION
This change modifies the TileManger so it does not cache e.g. UTFGrid tiles, which are not represented by a DOM element and break css classes management as a consequence of this.
