### PR TITLE
Change to center of bounds from geometry centroid

### DIFF
--- a/lib/OpenLayers/Renderer.js
+++ b/lib/OpenLayers/Renderer.js
@@ -209,8 +209,10 @@ OpenLayers.Renderer = OpenLayers.Class({
                 }
                 var rendered = this.drawGeometry(feature.geometry, style, feature.id);
                 if(style.display != "none" && style.label && rendered !== false) {
-
-                    var location = feature.geometry.getCentroid(); 
+                    var center = bounds.getCenterLonLat();
+                    var location = new OpenLayers.Geometry.Point(
+                        center.lon, center.lat
+                    );
                     if(style.labelXOffset || style.labelYOffset) {
                         var xOffset = isNaN(style.labelXOffset) ? 0 : style.labelXOffset;
                         var yOffset = isNaN(style.labelYOffset) ? 0 : style.labelYOffset;


### PR DESCRIPTION
Centering of the label is applied to the last feature at the time of the multi-polygon.
For this reason, I have to make use of the center of the bounds.
