### PR TITLE
A cluster with only one feaure inherits the attributes of the feature

### DIFF
--- a/lib/OpenLayers/Strategy/Cluster.js
+++ b/lib/OpenLayers/Strategy/Cluster.js
@@ -190,6 +190,15 @@ OpenLayers.Strategy.Cluster = OpenLayers.Class(OpenLayers.Strategy, {
                             }
                         }
                     }
+                    // if cluster has only one feature it inherits the attributes of the feature
+                     for(var i=0, len=clusters.length; i<len; ++i) {
+                         cluster = clusters[i];
+                         if(cluster.attributes.count === 1) {
+                             feature = cluster.cluster[0].clone();
+                             cluster.attributes = feature.attributes;
+                             cluster.attributes.count = 1;
+                         }
+                     }
                     this.clustering = true;
                     // A legitimate feature addition could occur during this
                     // addFeatures call.  For clustering to behave well, features


### PR DESCRIPTION
If a cluster has only one feature it inherits the attributes of the feature so that if the StyleMap of the feature defines an  externalGraphic based on an atttribute of the feature a correct tooltip is displayed.
