### PR TITLE
OpenLayer.Filter.Function support for WFS

### DIFF
--- a/lib/OpenLayers/Format/Filter/v1.js
+++ b/lib/OpenLayers/Format/Filter/v1.js
@@ -452,6 +452,15 @@ OpenLayers.Format.Filter.v1 = OpenLayers.Class(OpenLayers.Format.XML, {
                 for(var i=0, len=params.length; i<len; i++){
                     this.writeOgcExpression(params[i], node);
                 }
+                var properties = filter.properties;
+                if(properties != null) {
+                    for(var i=0, len=properties.length; i<len; i++){
+                        var propNode = this.createElementNSPlus("ogc:PropertyName", {
+							value: properties[i] 
+						});
+                        node.appendChild(propNode);
+                    }
+                }
                 return node;
             },
             "PropertyIsNull": function(filter) {
@@ -496,7 +505,8 @@ OpenLayers.Format.Filter.v1 = OpenLayers.Class(OpenLayers.Format.XML, {
         "WITHIN": "WITHIN",
         "CONTAINS": "CONTAINS",
         "INTERSECTS": "INTERSECTS",
-        "FID": "_featureIds"
+        "FID": "_featureIds",
+		"FUNCTION": "Function"
     },
 
     CLASS_NAME: "OpenLayers.Format.Filter.v1" 

--- a/lib/OpenLayers/Format/Filter/v1.js
+++ b/lib/OpenLayers/Format/Filter/v1.js
@@ -454,12 +454,12 @@ OpenLayers.Format.Filter.v1 = OpenLayers.Class(OpenLayers.Format.XML, {
                 }
                 var properties = filter.properties;
                 if(properties != null) {
-                    for(var i=0, len=properties.length; i<len; i++){
-                        var propNode = this.createElementNSPlus("ogc:PropertyName", {
-							value: properties[i] 
-						});
-                        node.appendChild(propNode);
-                    }
+										for(var i=0, len=properties.length; i<len; i++){
+											var propNode = this.createElementNSPlus("ogc:PropertyName", {
+												value: properties[i] 
+											});
+											node.appendChild(propNode);
+										}
                 }
                 return node;
             },
@@ -506,7 +506,7 @@ OpenLayers.Format.Filter.v1 = OpenLayers.Class(OpenLayers.Format.XML, {
         "CONTAINS": "CONTAINS",
         "INTERSECTS": "INTERSECTS",
         "FID": "_featureIds",
-		"FUNCTION": "Function"
+				"FUNCTION": "Function"
     },
 
     CLASS_NAME: "OpenLayers.Format.Filter.v1" 

--- a/lib/OpenLayers/Format/Filter/v1_0_0.js
+++ b/lib/OpenLayers/Format/Filter/v1_0_0.js
@@ -97,7 +97,10 @@ OpenLayers.Format.Filter.v1_0_0 = OpenLayers.Class(
             "PropertyIsEqualTo": function(filter) {
                 var node = this.createElementNSPlus("ogc:PropertyIsEqualTo");
                 // no ogc:expression handling for PropertyName for now
-                this.writeNode("PropertyName", filter, node);
+                if(filter.property != null)
+                    this.writeNode("PropertyName", filter, node);
+                else if(filter.functionFilter != null)
+                    this.writeNode("Function", filter.functionFilter , node);
                 // handle Literals or Functions for now
                 this.writeOgcExpression(filter.value, node);
                 return node;

--- a/lib/OpenLayers/Format/Filter/v1_1_0.js
+++ b/lib/OpenLayers/Format/Filter/v1_1_0.js
@@ -110,7 +110,10 @@ OpenLayers.Format.Filter.v1_1_0 = OpenLayers.Class(
                     attributes: {matchCase: filter.matchCase}
                 });
                 // no ogc:expression handling for PropertyName for now
-                this.writeNode("PropertyName", filter, node);
+                if(filter.property != null)
+                    this.writeNode("PropertyName", filter, node);
+                else if(filter.functionFilter != null)
+                    this.writeNode("Function", filter.functionFilter , node);
                 // handle Literals or Functions for now
                 this.writeOgcExpression(filter.value, node);
                 return node;

--- a/lib/OpenLayers/Format/Filter/v1_1_0.js
+++ b/lib/OpenLayers/Format/Filter/v1_1_0.js
@@ -107,8 +107,10 @@ OpenLayers.Format.Filter.v1_1_0 = OpenLayers.Class(
         "ogc": OpenLayers.Util.applyDefaults({
             "PropertyIsEqualTo": function(filter) {
                 var node = this.createElementNSPlus("ogc:PropertyIsEqualTo", {
-                    attributes: {matchCase: filter.matchCase}
                 });
+								if(filter.matchcase != null) {	
+									node.attributes = {matchCase: filter.matchCase};
+								}
                 // no ogc:expression handling for PropertyName for now
                 if(filter.property != null)
                     this.writeNode("PropertyName", filter, node);


### PR DESCRIPTION
Hello, Bart asked me to generate a pull request for this based on this thread:
http://osgeo-org.1560.x6.nabble.com/Problems-with-Openlayers-Filter-Function-in-WFS-td5066248.html

The changes fix issues trying to use a Function filter as a Logical filter argument. Also added support for PropertyName arguments to Function filters. First timer here, so hopefully I've done this correctly. Comments welcome.
