### PR TITLE
ZoomBox sprite positions not defined for EditingToolbar

### DIFF
--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -409,10 +409,12 @@ span.olGoogleAttribution.hybrid a, span.olGoogleAttribution.satellite a {
 .olControlEditingToolbar .olControlNavigationItemActive  {
     background-position: -103px -24px;
 }
-.olControlNavToolbar .olControlZoomBoxItemInactive {
+.olControlNavToolbar .olControlZoomBoxItemInactive,
+.olControlEditingToolbar .olControlZoomBoxItemInactive  {
     background-position: -128px -1px;
 }
-.olControlNavToolbar .olControlZoomBoxItemActive  {
+.olControlNavToolbar .olControlZoomBoxItemActive,  
+.olControlEditingToolbar .olControlZoomBoxItemActive  {
     background-position: -128px -24px;
 }
 .olControlEditingToolbar .olControlDrawFeaturePointItemInactive {


### PR DESCRIPTION
.olEditingToolbar class was not assigned to the olControlZoomBoxItem classes, which resulted in incorrect buttons.
