### PR TITLE
Map docs: remove non-existent extent option

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -508,10 +508,6 @@ OpenLayers.Map = OpenLayers.Class({
      *     Note that if an ArgParser/Permalink control is present,
      *     and the querystring contains a zoom level, zoom will be set
      *     by that, and this option will be ignored.
-     * extent - {<OpenLayers.Bounds>|Array} The initial extent of the map.
-     *     If provided as an array, the array should consist of
-     *     four values (left, bottom, right, top).
-     *     Only specify if <center> and <zoom> are not provided.
      * 
      * Examples:
      * (code)


### PR DESCRIPTION
I've been contacted by someone trying to use the extent option on the map and finding it doesn't work. Not surprising as AFAICS there's no code for it. I added this comment in #295 based on @ahocevar branch in #248 but I can't work out where this came from. Either way, if there is no such option, it should be removed from the api docs.

Is it possible to remove this from the 2.13 api docs as well, so people don't waste time on it?
