### PR TITLE
Documentation change for Bounds.toBBOX()

### DIFF
--- a/lib/OpenLayers/BaseTypes/Bounds.js
+++ b/lib/OpenLayers/BaseTypes/Bounds.js
@@ -164,7 +164,7 @@ OpenLayers.Bounds = OpenLayers.Class({
      * Returns a boundingbox-string representation of the bounds object.
      * 
      * Parameters:
-     * decimal - {Integer} How many significant digits in the bbox coords?
+     * decimal - {Integer} How many decimal places in the bbox coords?
      *                     Default is 6
      * reverseAxisOrder - {Boolean} Should we reverse the axis order?
      * 


### PR DESCRIPTION
Changed documentation of OpenLayers.Bounds.toBBOX from Significant Figures to Decimal Places as this is what the method actually does.

@hocevar This is the first change from the earlier pull request #1042 as mentioned. Once merged the second changes can be considered in the original request.

Regards
