### PR TITLE
WMTS capabilities reader: removed useless 'layers' property

### DIFF
--- a/lib/OpenLayers/Format/WMTSCapabilities/v1_0_0.js
+++ b/lib/OpenLayers/Format/WMTSCapabilities/v1_0_0.js
@@ -115,7 +115,6 @@ OpenLayers.Format.WMTSCapabilities.v1_0_0 = OpenLayers.Class(
                     dimensions: [],
                     tileMatrixSetLinks: []
                 };
-                layer.layers = [];
                 this.readChildNodes(node, layer);
                 obj.layers.push(layer);
             },


### PR DESCRIPTION
To my knowledge, there should not be such a "layers" property in the layer object
