### PR TITLE
Standalone ModifyFeature control allows dragging of unselected points

### DIFF
--- a/lib/OpenLayers/Control/ModifyFeature.js
+++ b/lib/OpenLayers/Control/ModifyFeature.js
@@ -441,7 +441,8 @@ OpenLayers.Control.ModifyFeature = OpenLayers.Class(OpenLayers.Control, {
             }
             this.selectFeature(feature);
         }
-        if (feature._sketch || isPoint) {
+        if (this.feature &&
+                (feature._sketch || isPoint && feature === this.feature)) {
             // feature is a drag or virtual handle or point
             this.vertex = feature;
             this.handlers.drag.stopDown = true;


### PR DESCRIPTION
I am doing something similar to the code in #972. I basically have a map with features that can be hovered over, selected, and moved (3 different renderings for default, hover, and selected.) I've created the following code with two `SelectFeature` controls and one `ModifyFeature` control.

``` coffeescript
  # Allow hovering over stuff
  hoverControl = new OpenLayers.Control.SelectFeature vectorLayer,
    hover: true
    highlightOnly: true
    renderIntent: "hover"
    eventListeners:
      featurehighlighted: (e) -> ... # doin some stuff

  # Select control that manually triggers updates
  selectControl = new OpenLayers.Control.SelectFeature vectorLayer,
    clickout: true
    toggle: true

  # Allow repositioning stuff
  modifyControl = new OpenLayers.Control.ModifyFeature vectorLayer,
    standalone: true

  # Hook up layer events
  vectorLayer.events.on
    featureselected: (e) -> modifyControl.selectFeature(e.feature)
    featureunselected: (e) -> modifyControl.unselectFeature(e.feature)    
    featuremodified: (e) ->
      point = e.feature.geometry
      Events.update { _id: e.feature.id },
        $set:
          location: [point.x, point.y]

  # Order of hover and select control matters
  map.addControl(hoverControl)
  hoverControl.activate()

  map.addControl(selectControl)
  selectControl.activate()

  map.addControl(modifyControl)
  modifyControl.activate()

```

I've played with the order of the controls and only one seems to work at all. Hovering, selecting, and moving a selected control all work. However, dragging an unselected feature results in 1 of 2 undesired behaviors:
1. (**Nothing** is selected) A ton of errors are thrown as the feature is dragged. It doesn't actually move. However, hovering over the feature's original location will cause it to jump to where the drag was released. Yet, the `featuremodified` event is not triggered, so it doesn't actually update on the server.

![image](https://f.cloud.github.com/assets/2080084/906567/13af9b58-fcb3-11e2-8a9a-353a93e122d4.png)
1. (Some **OTHER** feature is selected) The feature drags as normal, and its local position updates along with the drag (instead of "jumping" as before), but the `featuremodified` event is also not called.

I can demonstrate this in a live app if desired. In my case I am using `OpenLayers.Geometry.Point` with `externalGraphic`s and it seems like https://github.com/openlayers/openlayers/blob/master/lib/OpenLayers/Control/ModifyFeature.js is not properly accounting for the fact that it is standalone and attempting to allow any point to be dragged.
