### PR TITLE
Mention uglifyjs compiler option in build options and README

### DIFF
--- a/build/README.txt
+++ b/build/README.txt
@@ -30,6 +30,11 @@ The options available for compression are:
    for files source Javascript files which are under 1MB. (Note that
    the default OpenLayers full build is not under 1MB.)
 
+ * uglify-js
+   This uses the uglify-js compiler.  You will need the uglifyjs tool
+   in your PATH; this can be installed using npm (the node.js package
+   manager).
+
  * jsmin
    jsmin is the default compiler, and uses the Python-based
    jsmin script to compress the Javascript. 

--- a/build/build.py
+++ b/build/build.py
@@ -143,7 +143,7 @@ def build(config_file = None, output_file = None, options = None):
 
 if __name__ == '__main__':
   opt = optparse.OptionParser(usage="%s [options] [config_file] [output_file]\n  Default config_file is 'full.cfg', Default output_file is 'OpenLayers.js'")
-  opt.add_option("-c", "--compressor", dest="compressor", help="compression method: one of 'jsmin' (default), 'minimize', 'closure_ws', 'closure', or 'none'", default="jsmin")
+  opt.add_option("-c", "--compressor", dest="compressor", help="compression method: one of 'jsmin' (default), 'minimize', 'closure_ws', 'closure', 'uglify-js', or 'none'", default="jsmin")
   opt.add_option("-s", "--status", dest="status", help="name of a file whose contents will be added as a comment at the front of the output file. For example, when building from a git repo, you can save the output of 'git describe --tags' in this file. Default is no file.", default=False)
   opt.add_option("--amd", dest="amd", help="output should be AMD module; wrap merged files in define function; can be either 'pre' (before compilation) or 'post' (after compilation). Wrapping the OpenLayers var in a function means the filesize can be reduced by the closure compiler using 'pre', but be aware that a few functions depend on the OpenLayers variable being present. Either option can be used with jsmin or minimize compression. Default false, not AMD.", default=False)
   opt.add_option("--amdname", dest="amdname", help="only useful with amd option. Name of AMD module. Default no name, anonymous module.", default=False)


### PR DESCRIPTION
Just a quick tidy-up of the build docs, mentioning uglify-js.
