### PR TITLE
Layer Null issue

### DIFF
--- a/lib/OpenLayers/TileManager.js
+++ b/lib/OpenLayers/TileManager.js
@@ -394,8 +394,13 @@ OpenLayers.TileManager = OpenLayers.Class({
         var tileQueue = this.tileQueue[map.id];
         var limit = this.tilesPerFrame;
         var animating = map.zoomTween && map.zoomTween.playing;
+        var tile;
         while (!animating && tileQueue.length && limit) {
-            tileQueue.shift().draw(true);
+            tile = tileQueue.shift();
+            if (tile.events) {
+                // Only draw tile if it is not destroyed
+                tile.draw(true);
+            }
             --limit;
         }
     },


### PR DESCRIPTION
Hi,

I have downloaded Openlayer version 2.13.1 for using Open Street Map. I was getting following errors in different browsers:

1) In IE after zooming in for one level I was getting this error "Unable to get property 'maxExtent' of undefined or null reference"
2) In FF after zooming in for one level I was getting this error "TypeError: this.layer is null"

And after that zooming in had stopped working it and it was not zooming in properly.

Then I downloaded Openlayer Version 2.12 and this issue was gone.

Kindly check this in 2.13.1 and provide your feedback.

Thanks,
Harshil Shukla
