### PR TITLE
Arcgiscache fix when using different resolutions then OpenLayers.Map resolutions

### DIFF
--- a/lib/OpenLayers/Layer/ArcGISCache.js
+++ b/lib/OpenLayers/Layer/ArcGISCache.js
@@ -395,6 +395,9 @@ OpenLayers.Layer.ArcGISCache = OpenLayers.Class(OpenLayers.Layer.XYZ, {
      * {<OpenLayers.LonLat>} The tile origin.
      */
     getTileOrigin: function() {
+		if (this.tileOrigin){
+			return this.tileOrigin;
+		}
         if (!this._tileOrigin) {
             var extent = this.getMaxExtent();
             this._tileOrigin = new OpenLayers.LonLat(extent.left, extent.top);


### PR DESCRIPTION
When using a different resolutions 'schema' for the OpenLayers.Map and the ArcGISCache layer, the url is not correct.
Made some fixes.

Example:

``` javascript
var proj='EPSG:28992';

var mapExtent = new OpenLayers.Bounds(102488,393587,121903,406954);

var map;
function init(){
    map = new OpenLayers.Map('map', {
        maxExtent:mapExtent,
        controls: [
            new OpenLayers.Control.Navigation(),
            new OpenLayers.Control.LayerSwitcher(), 
            new OpenLayers.Control.PanZoomBar(),
            new OpenLayers.Control.MousePosition()]
    });

    var baseLayer = new OpenLayers.Layer.TMS('tms', "http://www.openbasiskaart.nl/mapcache/tms/", {
        tileOrigin: new OpenLayers.LonLat(-285401.92,22598.08),
        serverResolutions: [3440.64,1720.32,860.16,430.08,215.04,107.52,53.76, 26.88, 13.44, 6.72, 3.36, 1.68, 0.84, 0.42, 0.21],
        maxExtent: new OpenLayers.Bounds(-285401.92,22598.08,595401.92,903401.92),
        maxResolution: 3440.64,
        opacity: 1,
        isBaseLayer: true,
        serviceVersion: "1.0.0",
        tileSize: new OpenLayers.Size(256,256),
        projection: proj,
        layername: "osm@rd",
    });
    var overlayLayer = new OpenLayers.Layer.ArcGISCache('arghh', "http://geoservices.breda.nl/ArcGIS/rest/services/extern_breda/luchtfoto/MapServer", {
        tileOrigin: new OpenLayers.LonLat(-10000,600000),
        resolutions: [33.8667344001355, 16.9333672000677, 8.46668360003387, 4.23334180001693, 2.11667090000847, 1.05833545000423, 0.529167725002117, 0.264583862501058, 0.198437896875794, 0.132291931250529, 0.0661459656252646],
        maxExtent: new OpenLayers.Bounds(-10000,387827.077534562,127222.154276999,600000),
        maxResolution: 33.8667344001355,
        opacity: 1,
        isBaseLayer: false,
        tileSize: new OpenLayers.Size(256,256),
        type: "png",
        projection: proj
    });
    map.addLayers([baseLayer, overlayLayer]);

    map.zoomToExtent(mapExtent);
}
```
