### PR TITLE
ModifyFeature control: Allows use delkey on IE8

### DIFF
--- a/lib/OpenLayers/Control/ModifyFeature.js
+++ b/lib/OpenLayers/Control/ModifyFeature.js
@@ -312,6 +312,7 @@ OpenLayers.Control.ModifyFeature = OpenLayers.Class(OpenLayers.Control, {
                 "changelayer": this.handleMapEvents,
                 scope: this
             });
+            this._lastVertex = null;
             return this.handlers.keyboard.activate() &&
                     this.handlers.drag.activate();
         }


### PR DESCRIPTION
See the conversation on the DEV list: [OL 2.13 Modify Feature Example IE8/IE7 : Can't remove vertex](http://osgeo-org.1560.x6.nabble.com/OL-2-13-Modify-Feature-Example-IE8-IE7-Can-t-remove-vertex-td5072314.html)
