### PR TITLE
Canvas: Prevent execute img.onload after a cleaning.

### DIFF
--- a/lib/OpenLayers/Renderer/Canvas.js
+++ b/lib/OpenLayers/Renderer/Canvas.js
@@ -69,6 +69,7 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
         this.root = document.createElement("canvas");
         this.container.appendChild(this.root);
         this.canvas = this.root.getContext("2d");
+        this._clearRectId = OpenLayers.Util.createUniqueID();
         this.features = {};
         if (this.hitDetection) {
             this.hitCanvas = document.createElement("canvas");
@@ -254,11 +255,13 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
            style.graphicXOffset : -(0.5 * width);
         var yOffset = (style.graphicYOffset != undefined) ?
            style.graphicYOffset : -(0.5 * height);
+        var _clearRectId = this._clearRectId;
 
         var opacity = style.graphicOpacity || style.fillOpacity;
         
         var onLoad = function() {
-            if(!this.features[featureId]) {
+            if(!this.features[featureId] ||
+                                     _clearRectId !== this._clearRectId) {
                 return;
             }
             var pt = this.getLocalXY(geometry);
@@ -285,7 +288,6 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
                 }
             }
         };
-
         img.onload = OpenLayers.Function.bind(onLoad, this);
         img.src = style.externalGraphic;
     },
@@ -767,10 +769,19 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
      * Clear all vectors from the renderer.
      */    
     clear: function() {
+        this.clearCanvas();
+        this.features = {};
+    },
+
+    /**
+     * Method: clearCanvas
+     * Clear the canvas element of the renderer.
+     */    
+    clearCanvas: function() {
         var height = this.root.height;
         var width = this.root.width;
         this.canvas.clearRect(0, 0, width, height);
-        this.features = {};
+        this._clearRectId = OpenLayers.Util.createUniqueID();
         if (this.hitDetection) {
             this.hitContext.clearRect(0, 0, width, height);
         }
@@ -844,12 +855,7 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
      */
     redraw: function() {
         if (!this.locked) {
-            var height = this.root.height;
-            var width = this.root.width;
-            this.canvas.clearRect(0, 0, width, height);
-            if (this.hitDetection) {
-                this.hitContext.clearRect(0, 0, width, height);
-            }
+            this.clearCanvas();
             var labelMap = [];
             var feature, geometry, style;
             var worldBounds = (this.map.baseLayer && this.map.baseLayer.wrapDateLine) && this.map.getMaxExtent();


### PR DESCRIPTION
See the conversation on the Users list: [Canvas issue when using externalGraphic](http://osgeo-org.1560.x6.nabble.com/Canvas-issue-when-using-externalGraphic-td5071099.html)
