### PR TITLE
Canvas: Avoid flicker using externalGraphic

### DIFF
--- a/lib/OpenLayers/Renderer/Canvas.js
+++ b/lib/OpenLayers/Renderer/Canvas.js
@@ -290,6 +290,10 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
         };
         img.onload = OpenLayers.Function.bind(onLoad, this);
         img.src = style.externalGraphic;
+        if (img.complete) {
+            img.onload();
+            img.onload = null;
+        }
     },
 
     /**


### PR DESCRIPTION
Flicker is best seen dragging a point using a style with externalGraphic.

Although the externalGraphic is in cache by dragging/selecting a point then momentarily the vector layer shown empty until the point appear again.

Observed using browsers Chrome, FF and Opera but not in IE9.
