### PR TITLE
SingleTile WMS layer requests an image with a wrong width to server

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -838,6 +838,9 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
                                   center.lat - (tileHeight/2),
                                   center.lon + (tileWidth/2),
                                   center.lat + (tileHeight/2));
+
+        // store the resolution of the grid
+        this.gridResolution = this.getServerResolution();
   
         // same logic as OpenLayers.Tile#shouldDraw
         var maxExtent = this.maxExtent;
@@ -870,9 +873,6 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
         
         //remove all but our single tile
         this.removeExcessTiles(1,1);
-
-        // store the resolution of the grid
-        this.gridResolution = this.getServerResolution();
     },
 
     /** 


### PR DESCRIPTION
This PR addresses a regression introduced by 6ab0f32 (Override getImageSize function to take clipped images into account) (Sorry, I did mess up the original PR and recreated a new one.)

There are two issues when adding a new WMS layer in singleTile mode to a map:

1/ When adding, the `gridResolution` which is null by default is not initailized, as a result, the `getImageSize` function returns an image size with a width = 'Infinity'.
2/ When zooming in/out the `gridResolution` is not updated, resulting in an image of the wrong size, either too small when zooming in or to large when zooming out. The image height is correct in all case.

Comment from @ahocevar on original PR:
`this.gridResolution` is set at the bottom of `initSingleTile()`. Wouldn't it be sufficient to move that to the top of `initSingleTile()`?
