### PR TITLE
Explicitly access rbush on window

### DIFF
--- a/lib/OpenLayers/Control/ModifyFeature/BySegment.js
+++ b/lib/OpenLayers/Control/ModifyFeature/BySegment.js
@@ -209,7 +209,7 @@ OpenLayers.Control.ModifyFeature.BySegment = {
             }
         }
         collectComponentVertices.call(this, feature.geometry);
-        this.tree = rbush();
+        this.tree = window.rbush();
         this.tree.load(data);
         this.handlers.hover.activate();
     },


### PR DESCRIPTION
Without this, building with closure fails (see #1080).
