### PR TITLE
Multipolygon hole drawing

### DIFF
--- a/lib/OpenLayers/Handler/Polygon.js
+++ b/lib/OpenLayers/Handler/Polygon.js
@@ -115,7 +115,19 @@ OpenLayers.Handler.Polygon = OpenLayers.Class(OpenLayers.Handler.Path, {
                     this.control.layer.events.registerPriority(
                         "sketchmodified", this, this.enforceTopology
                     );
-                    polygon.geometry.addComponent(this.line.geometry);
+
+                    var geom = polygon.geometry;
+
+                    if(candidate instanceof OpenLayers.Geometry.MultiPolygon) {
+                        inner: for(var j = 0; j < candidate.components.length; ++j) {
+                            if(candidate.components[j].intersects(geometry)) {
+                                geom = candidate.components[j];
+                                break inner;
+                            }
+                        }
+                    }
+
+                    geom.addComponent(this.line.geometry);
                     this.polygon = polygon;
                     this.drawingHole = true;
                     break;


### PR DESCRIPTION
This fixes http://trac.osgeo.org/openlayers/ticket/3592 . In case the geometry is a multipolygon, the intersecting multipolygon component (ie. polygon) is used to draw the hole.
