### PR TITLE
Ensure SelectFeature option accessors always return booleans

### DIFF
--- a/lib/OpenLayers/Control/SelectFeature.js
+++ b/lib/OpenLayers/Control/SelectFeature.js
@@ -358,7 +358,8 @@ OpenLayers.Control.SelectFeature = OpenLayers.Class(OpenLayers.Control, {
      */
     multipleSelect: function() {
         return this.multiple || (this.handlers.feature.evt &&
-                                 (typeof this.handlers.feature.evt[this.multipleKey] != 'undefined'));
+                                    (typeof this.handlers.feature.evt[this.multipleKey] != 'undefined') &&
+                                    this.handlers.feature.evt[this.multipleKey]);
     },
     
     /**
@@ -371,7 +372,8 @@ OpenLayers.Control.SelectFeature = OpenLayers.Class(OpenLayers.Control, {
      */
     toggleSelect: function() {
         return this.toggle || (this.handlers.feature.evt &&
-                               (typeof this.handlers.feature.evt[this.toggleKey] != 'undefined'));
+                                (typeof this.handlers.feature.evt[this.toggleKey] != 'undefined')) &&
+                                this.handlers.feature.evt[this.toggleKey]);
     },
 
     /**

--- a/lib/OpenLayers/Control/SelectFeature.js
+++ b/lib/OpenLayers/Control/SelectFeature.js
@@ -358,7 +358,7 @@ OpenLayers.Control.SelectFeature = OpenLayers.Class(OpenLayers.Control, {
      */
     multipleSelect: function() {
         return this.multiple || (this.handlers.feature.evt &&
-                                 this.handlers.feature.evt[this.multipleKey]);
+                                 (typeof this.handlers.feature.evt[this.multipleKey] != 'undefined'));
     },
     
     /**
@@ -371,7 +371,7 @@ OpenLayers.Control.SelectFeature = OpenLayers.Class(OpenLayers.Control, {
      */
     toggleSelect: function() {
         return this.toggle || (this.handlers.feature.evt &&
-                               this.handlers.feature.evt[this.toggleKey]);
+                               (typeof this.handlers.feature.evt[this.toggleKey] != 'undefined'));
     },
 
     /**


### PR DESCRIPTION
Ensure that option accessors for toggle and multiple always return boolean values rather than undefined.

Currently, when the multipleKey and/or toggleKey options are not set, the comparisons will return undefined rather than false.  This pull request uses typeof  to ensure the existence of the specified modifier keys in the event object.
