### PR TITLE
Correct @requires and API-documentation...

### DIFF
--- a/lib/OpenLayers/Format/WFST/v2_0_0.js
+++ b/lib/OpenLayers/Format/WFST/v2_0_0.js
@@ -5,16 +5,16 @@
 
 /**
  * @requires OpenLayers/Format/WFST/v1.js
- * @requires OpenLayers/Format/Filter/v1_0_0.js
+ * @requires OpenLayers/Format/Filter/v2_0_0.js
  */
 
 /**
- * Class: OpenLayers.Format.WFST.v1_0_0
- * A format for creating WFS v1.0.0 transactions.  Create a new instance with the
- *     <OpenLayers.Format.WFST.v1_0_0> constructor.
+ * Class: OpenLayers.Format.WFST.v2_0_0
+ * A format for creating WFS v2.0.0 transactions.  Create a new instance with the
+ *     <OpenLayers.Format.WFST.v2_0_0> constructor.
  *
  * Inherits from:
- *  - <OpenLayers.Format.Filter.v1_0_0>
+ *  - <OpenLayers.Format.Filter.v2_0_0>
  *  - <OpenLayers.Format.WFST.v1>
  */
 OpenLayers.Format.WFST.v2_0_0 = OpenLayers.Class(


### PR DESCRIPTION
... of `Format/WFST/v2_0_0_0.js`.

This might lead to our examples being functional again.

See also #1075.
