### PR TITLE
Add cluster handling to filter

### DIFF
--- a/lib/OpenLayers/Strategy/Filter.js
+++ b/lib/OpenLayers/Strategy/Filter.js
@@ -101,15 +101,36 @@ OpenLayers.Strategy.Filter = OpenLayers.Class(OpenLayers.Strategy, {
             var feature;
             for (var i=0, ii=features.length; i<ii; ++i) {
                 feature = features[i];
-                if (this.filter.evaluate(feature)) {
-                    event.features.push(feature);
-                } else {
-                    this.cache.push(feature);
+                if(feature.cluster) {
+                    // This may have some weird effects with special clustering
+                    // rules, such as threshold.
+                    var cluster = feature.cluster;
+                    feature.cluster = [];
+                    for (var j=0, jj=cluster.length; j<jj; ++j) {
+                        declustered_feature = cluster[j];
+                        if (this.filter.evaluate(declustered_feature)) {
+                            // Put this feature back in his cluster.
+                            feature.cluster.push(declustered_feature);
+                        } else {
+                            this.cache.push(declustered_feature);
+                        }
+                    }
+                    // We may have filtered out all of the features from a cluster
+                    // It wouldn't do to add it back in.
+                    if(feature.cluster.length) {
+                        event.features.push(feature);
+                    }
+                 } else {
+                    if (this.filter.evaluate(feature)) {
+                        event.features.push(feature);
+                    } else {
+                        this.cache.push(feature);
+                    }
                 }
             }
         }
     },
-    
+
     /**
      * Method: handleRemove
      */


### PR DESCRIPTION
This filters the items in a cluster.  I wrote this because handleAdd
gets rerun when using filters before clusters.  Not having this
handling was causing the filter to fail (or succeed, depending on your
filter) on each clustered feature since it was inspecting the cluster
and not the features within the cluster.
