### PR TITLE
LONLAT Convenience method.

### DIFF
--- a/lib/OpenLayers/BaseTypes/LonLat.js
+++ b/lib/OpenLayers/BaseTypes/LonLat.js
@@ -73,6 +73,17 @@ OpenLayers.LonLat = OpenLayers.Class({
         return (this.lon + ", " + this.lat);
     },
 
+    /**
+     * Method : toPoint
+     *
+     * Returns:
+     * {<OpenLayers.Geometry.Point>} New OpenLayers.Geometry.Point object with the same corresponding coordinates, x = lon, y = lat.
+     *
+     */
+    toPoint : function(){
+        return new OpenLayers.Geometry.Point(this.lon, this.lat);
+    },
+
     /** 
      * APIMethod: clone
      * 

--- a/tests/BaseTypes/LonLat.html
+++ b/tests/BaseTypes/LonLat.html
@@ -46,6 +46,15 @@
         t.eq( lonlat.toShortString(), "5, 6", "lonlat.toShortString() returns correctly");
     }
 
+    function test_LonLat_toPoint(t){
+        t.plan( 3 );
+        lonlat = new OpenLayers.LonLat(5,6);
+        var point = lonlat.toPoint();
+        t.ok(point instanceof OpenLayers.Geometry.Point, "lonlat.toPoint() returns point object");
+        t.eq(point.x, 5, 'x is set correctly');
+        t.eq(point.y, 6, 'x is set correctly');
+    }
+
     function test_LonLat_clone(t) {
         t.plan( 3 );
         oldLonLat = new OpenLayers.LonLat(5,6);


### PR DESCRIPTION
Convenience method for createing OpenLayers.Geometry.Point object
directly from OpenLayers.LonLat.
