### PR TITLE
Fix dependencies for WFS v2

### DIFF
--- a/lib/OpenLayers/Format/WFST/v2_0_0.js
+++ b/lib/OpenLayers/Format/WFST/v2_0_0.js
@@ -6,6 +6,7 @@
 /**
  * @requires OpenLayers/Format/WFST/v1.js
  * @requires OpenLayers/Format/Filter/v2_0_0.js
+ * @requires OpenLayers/Format/OWSCommon/v1_0_0.js
  */
 
 /**

--- a/lib/OpenLayers/Protocol/WFS/v2_0_0.js
+++ b/lib/OpenLayers/Protocol/WFS/v2_0_0.js
@@ -5,7 +5,7 @@
 
 /**
  * @requires OpenLayers/Protocol/WFS/v1.js
- * @requires OpenLayers/Format/WFST/v1_1_0.js
+ * @requires OpenLayers/Format/WFST/v2_0_0.js
  */
 
 /**


### PR DESCRIPTION
In `OpenLayers.Format.WFST.v2_0_0`, OWSCommon v1_0_0 prototype is used to import the ows readers but it is not declared as a requirement.

Furthermore, the WFS v2 protocol still references the v1.1.0 format.
