### PR TITLE
Refactor ElementsIndexer.getNextElement to not use recursion

### DIFF
--- a/lib/OpenLayers/Renderer/Elements.js
+++ b/lib/OpenLayers/Renderer/Elements.js
@@ -210,16 +210,13 @@ OpenLayers.ElementsIndexer = OpenLayers.Class({
      *     null.
      */
     getNextElement: function(index) {
-        var nextIndex = index + 1;
-        if (nextIndex < this.order.length) {
-            var nextElement = OpenLayers.Util.getElement(this.order[nextIndex]);
-            if (nextElement == undefined) {
-                nextElement = this.getNextElement(nextIndex);
-            }
-            return nextElement;
-        } else {
-            return null;
-        } 
+        for (var nextIndex = index + 1, nextElement = undefined;
+            (nextIndex < this.order.length) && (nextElement == undefined);
+            nextIndex++) {
+            nextElement = OpenLayers.Util.getElement(this.order[nextIndex]);
+        }
+        
+        return nextElement || null;
     },
     
     CLASS_NAME: "OpenLayers.ElementsIndexer"


### PR DESCRIPTION
# Problem

Exceeded maximum call stack in `ElementsIndexer.getNextElement`
# Solution

Since we are simply iterating over an array, we can save memory by storing and incrementing the current array index, using a traditional `for` loop.
