### PR TITLE
ignore textnodes when searching for a sibling containing geometry.

### DIFF
--- a/lib/OpenLayers/Format/GML.js
+++ b/lib/OpenLayers/Format/GML.js
@@ -187,11 +187,20 @@ OpenLayers.Format.GML = OpenLayers.Class(OpenLayers.Format.XML, {
         var feature = new OpenLayers.Feature.Vector(geometry, attributes);
         feature.bounds = bounds;
         
+        // All modern browsers, except for IE, will translate newlines & spaces into textnodes.
+        // Some engines will return a pretty-printed XML, thus creating textnodes (which is according to HTML spec)
+        var featureChild = node.firstChild;
+        while (featureChild && featureChild.nodeType != 1)
+        {
+            featureChild = featureChild.nextSibling;
+        }
+
         feature.gml = {
-            featureType: node.firstChild.nodeName.split(":")[1],
-            featureNS: node.firstChild.namespaceURI,
-            featureNSPrefix: node.firstChild.prefix
+            featureType: featureChild.nodeName.split(":")[1],
+            featureNS: featureChild.namespaceURI,
+            featureNSPrefix: featureChild.prefix
         };
+        
                 
         // assign fid - this can come from a "fid" or "id" attribute
         var childNode = node.firstChild;


### PR DESCRIPTION
Some WMS/WFS servers send a pretty-printed response to a WFS/Wms GetFeatureInfo request. Browsers like Mozilla and Chrome will create an empty textnode for each linebreak or whitespace.

I've added a piece of code that will ignore the textnodes when looking for feature.gml as it will crash on the textnodes.
