### PR TITLE
Don't reload all the overlays if the resolution don't change

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -1284,6 +1284,7 @@ OpenLayers.Map = OpenLayers.Class({
 
                 // preserve center and scale when changing base layers
                 var center = this.getCachedCenter();
+                var oldResolution = this.getResolution();
                 var newResolution = OpenLayers.Util.getResolutionFromScale(
                     this.getScale(), newBaseLayer.units
                 );
@@ -1312,7 +1313,7 @@ OpenLayers.Map = OpenLayers.Class({
                         newResolution || this.resolution, true
                     );
                     // zoom and force zoom change
-                    this.setCenter(center, newZoom, false, true);
+                    this.setCenter(center, newZoom, false, oldResolution != newResolution);
                 }
 
                 this.events.triggerEvent("changebaselayer", {


### PR DESCRIPTION
Actually each time we change the base layer all the overlays will
be reloaded ...
