### PR TITLE
Fix label position in IE SVG renderer

### DIFF
--- a/lib/OpenLayers/Renderer/SVG.js
+++ b/lib/OpenLayers/Renderer/SVG.js
@@ -735,6 +735,9 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
                      vfactor = -.5;
                 }
                 tspan.setAttribute("dy", (vfactor*(numRows-1)) + "em");
+                if (OpenLayers.BROWSER_NAME === "msie") {
+                    tspan.setAttribute("dy", ".35em");
+                }
             } else {
                 tspan.setAttribute("dy", "1em");
             }


### PR DESCRIPTION
Label position in OL SVG renderer is set using the 'baseline-shift' property but this property does not work in IE as can be check here: 
http://www.w3.org/Graphics/SVG/Test/20061213/htmlObjectHarness/full-text-align-02-b.html
As a workaround, the 'dy' property can be used to get a similar result. Explained here: http://nelsonslog.wordpress.com/2011/09/12/svgtext-baseline-considered-harmful/
