### PR TITLE
Tiles are calculated from tileOrigin, not from layer extent

### DIFF
--- a/lib/OpenLayers/Layer/XYZ.js
+++ b/lib/OpenLayers/Layer/XYZ.js
@@ -139,9 +139,9 @@ OpenLayers.Layer.XYZ = OpenLayers.Class(OpenLayers.Layer.Grid, {
      */
     getXYZ: function(bounds) {
         var res = this.getServerResolution();
-        var x = Math.round((bounds.left - this.maxExtent.left) /
+        var x = Math.round((bounds.left - this.tileOrigin.lon) /
             (res * this.tileSize.w));
-        var y = Math.round((this.maxExtent.top - bounds.top) /
+        var y = Math.round((this.tileOrigin.lat - bounds.top) /
             (res * this.tileSize.h));
         var z = this.getServerZoom();
 
@@ -164,7 +164,7 @@ OpenLayers.Layer.XYZ = OpenLayers.Class(OpenLayers.Layer.Grid, {
         OpenLayers.Layer.Grid.prototype.setMap.apply(this, arguments);
         if (!this.tileOrigin) { 
             this.tileOrigin = new OpenLayers.LonLat(this.maxExtent.left,
-                                                this.maxExtent.bottom);
+                                                this.maxExtent.top);
         }                                       
     },
 


### PR DESCRIPTION
It allows to add local XYZ layers with small maxExtent on the world map
