### PR TITLE
Enable feature_count parameter in WMTS GetFeatureInfo requests

### DIFF
--- a/lib/OpenLayers/Control/WMTSGetFeatureInfo.js
+++ b/lib/OpenLayers/Control/WMTSGetFeatureInfo.js
@@ -293,6 +293,7 @@ OpenLayers.Control.WMTSGetFeatureInfo = OpenLayers.Class(OpenLayers.Control, {
             version: layer.version,
             request: "GetFeatureInfo",
             infoFormat: this.infoFormat,
+            feature_count: this.maxFeatures,
             i: tileInfo.i,
             j: tileInfo.j
         });


### PR DESCRIPTION
WMTS GetFeatureInfo Control was ignoring the feature_count parameter in the requests, even though WMS GetFeatureInfo Control implements it (https://github.com/openlayers/openlayers/blob/master/lib/OpenLayers/Control/WMSGetFeatureInfo.js#L349)
