### PR TITLE
Update Vector.js to support setOpacity for vector layers within RootContainer

### DIFF
--- a/lib/OpenLayers/Layer/Vector.js
+++ b/lib/OpenLayers/Layer/Vector.js
@@ -1010,7 +1010,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      * Parameters:
      * opacity - {Float}
      */
-    function(opacity) {
+    setOpacity: function(opacity) {
         if (opacity != this.opacity) {
             this.opacity = opacity;
             var element = this.renderer.root;


### PR DESCRIPTION
There's forgotten simple patch in trac http://trac.osgeo.org/openlayers/ticket/3608 by Christopher Schmidt, which I'm using for over year and Heron community uses it too https://code.google.com/p/geoext-viewer/source/browse/trunk/heron/lib/override-openlayers.js. It would be fine to merge it.
