### PR TITLE
Added missing requires to WCSDescribeCoverage/v1.js

### DIFF
--- a/lib/OpenLayers/Format/WCSDescribeCoverage/v1.js
+++ b/lib/OpenLayers/Format/WCSDescribeCoverage/v1.js
@@ -5,6 +5,7 @@
 
 /**
  * @requires OpenLayers/Format/WCSCapabilities.js
+ * @requires OpenLayers/Format/WCSDescribeCoverage.js
  * @requires OpenLayers/Format/XML.js
  */
 


### PR DESCRIPTION
Fixes broken build #1184
