### PR TITLE
Remove merge-markers from test.

### DIFF
--- a/tests/Filter/Comparison.html
+++ b/tests/Filter/Comparison.html
@@ -320,7 +320,6 @@
             expect: false
         }, {
             filter: new OpenLayers.Filter.Comparison({
-<<<<<<< HEAD
                 type: OpenLayers.Filter.Comparison.IS_NULL,
                 property: "prop"
             }),
@@ -347,7 +346,8 @@
             }),
             context: new OpenLayers.Feature.Vector(null, {prop: 0}),
             expect: false
-=======
+        }, {
+            filter: new OpenLayers.Filter.Comparison({
                 type: OpenLayers.Filter.Comparison.LIKE,
                 property: "prop",
                 value: ".+"
@@ -362,7 +362,6 @@
             }),
             context: new OpenLayers.Feature.Vector(null, {}),
             expect: false
->>>>>>> #2938: [patch] Comparason type like with null (property not present)
         }];
         
         t.plan(cases.length);


### PR DESCRIPTION
This removes a `SyntaxError` in `tests/Filter/Comparison.html`.

This test now passes for me again.

Please review. 
