### PR TITLE
LAYERS parameter cast to string

### DIFF
--- a/lib/OpenLayers/Control/WMSGetFeatureInfo.js
+++ b/lib/OpenLayers/Control/WMSGetFeatureInfo.js
@@ -403,8 +403,8 @@ OpenLayers.Control.WMSGetFeatureInfo = OpenLayers.Class(OpenLayers.Control, {
         } else {
             if (OpenLayers.Util.isArray(layer.params.LAYERS)) {
                 styleNames = new Array(layer.params.LAYERS.length);
-            } else { // Assume it's a String
-                styleNames = layer.params.LAYERS.replace(/[^,]/g, "");
+            } else {
+                styleNames = layer.params.LAYERS.toString().replace(/[^,]/g, "");
             }
         }
         return styleNames;


### PR DESCRIPTION
Code assumed a string type to make a replace operation. It failed
when LAYERS is a unique number (typical of layers from ArcGIS services).
