### PR TITLE
Throw an exception if xmldom is null

### DIFF
--- a/lib/OpenLayers/Format/XML.js
+++ b/lib/OpenLayers/Format/XML.js
@@ -142,8 +142,12 @@ OpenLayers.Format.XML = OpenLayers.Class(OpenLayers.Format, {
                         xmldom = new ActiveXObject("Microsoft.XMLDOM");
                     } else {
                         xmldom = this.xmldom;
-                        
                     }
+                    if(!xmldom)
+                    {
+                        throw "xmldom is null";
+                    }
+                    
                     xmldom.loadXML(text);
                     return xmldom;
                 }


### PR DESCRIPTION
This can happen if using the wrong parser to parse, say, an incorrect response from an ESRI WxS server.
