### PR TITLE
Make parser name available in the document object

### DIFF
--- a/lib/OpenLayers/Format/XML/VersionedOGC.js
+++ b/lib/OpenLayers/Format/XML/VersionedOGC.js
@@ -205,6 +205,7 @@ OpenLayers.Format.XML.VersionedOGC = OpenLayers.Class(OpenLayers.Format.XML, {
             obj.error = format.read(data);
         }
         obj.version = version;
+        obj.requestType = this.name;
         return obj;
     },
 


### PR DESCRIPTION
This helps when you are not quite sure what sort of object you are getting back; such as when an ESRI server returns a WFS response to a WCS GetCapabilities request, which I have seen on servers in the wild.
