### PR TITLE
Change supportedFormat to supportedFormats for better compatibility

### DIFF
--- a/lib/OpenLayers/Format/WCSCapabilities/v1_1_0.js
+++ b/lib/OpenLayers/Format/WCSCapabilities/v1_1_0.js
@@ -94,10 +94,10 @@ OpenLayers.Format.WCSCapabilities.v1_1_0 = OpenLayers.Class(
             "SupportedFormat": function(node, coverageSummary) {
                 var format = this.getChildValue(node);
                 if(format) {
-                    if(!coverageSummary.supportedFormat) { 
-                        coverageSummary.supportedFormat = [];
+                    if(!coverageSummary.supportedFormats) { 
+                        coverageSummary.supportedFormats = [];
                     }
-                    coverageSummary.supportedFormat.push(format);
+                    coverageSummary.supportedFormats.push(format);
                 }
             }
         }, OpenLayers.Format.WCSCapabilities.v1.prototype.readers["wcs"]),

--- a/tests/Format/WCSCapabilities/v1.html
+++ b/tests/Format/WCSCapabilities/v1.html
@@ -82,8 +82,8 @@
         t.eq(metadata.identifier, "ro_dsm", "correct identifier");
         t.eq(metadata.title, "Rotterdam DSM", "correct title");
         t.eq(metadata.abstract, "Digital Surface Model (DSM) raster data set of inner city Rotterdam", "correct abstract");
-        t.eq(metadata.supportedFormat.length, 1, "correct number of supported formats");
-        t.eq(metadata.supportedFormat[0], "image/tiff", "correct format");
+        t.eq(metadata.supportedFormats.length, 1, "correct number of supported formats");
+        t.eq(metadata.supportedFormats[0], "image/tiff", "correct format");
         t.eq(metadata.supportedCRS.length, 4, "correct number of CRS records");
         t.eq(metadata.supportedCRS[2], "urn:ogc:def:crs:EPSG::3857", "correct CRS");
 


### PR DESCRIPTION
Change supportedFormat to supportedFormats for better compatibility between DescribeCoverage and GetCapabilities.  The XML is itself inconsistent, which was probably why this problem went unnoticed.  

It makes sense to use the same internal identifier for the same information to simplify parsing the resulting OpenLayers objects.  That way, if the user is trying to extract the supportedFormats data, they can do it with either a DescribeCoverage or a GetCapabilities object.
