### PR TITLE
Add version and requestType to WPSDescribeProcess

### DIFF
--- a/lib/OpenLayers/Format/WPSDescribeProcess.js
+++ b/lib/OpenLayers/Format/WPSDescribeProcess.js
@@ -83,6 +83,10 @@ OpenLayers.Format.WPSDescribeProcess = OpenLayers.Class(
         }
         var info = {};
         this.readNode(data, info);
+        
+        info.version = this.VERSION;
+        info.requestType = this.CLASS_NAME.split('.',3)[2];
+        
         return info;
     },
 


### PR DESCRIPTION
Most similar requests (WxSGetCapabilities, WCSDescribeCoverage, WFSDescribeFeature, etc.) have version and requestType properties available as top level identifiers (which they get from OpenLayers.Format.XML.VersionedOGC).  For some reason, WPSDescribeProcess inherits from OpenLayers.Format.XML instead, and thus does not get access to version and requestType.  This makes it difficult to process data from WPSDescribeProcess using standardized methods that work with the other objects.

Because I do not understand the design logic that dictated implementing this class differently than the others, I do not want to change it.  But since the version and requestType are needed, I am adding them to the class directly.  It seems the least intrusive way at this point.
