### PR TITLE
XML serialisation fails in IE11

### DIFF
--- a/lib/OpenLayers/Format/CSWGetRecords/v2_0_2.js
+++ b/lib/OpenLayers/Format/CSWGetRecords/v2_0_2.js
@@ -35,7 +35,8 @@ OpenLayers.Format.CSWGetRecords.v2_0_2 = OpenLayers.Class(OpenLayers.Format.XML,
         ogc: "http://www.opengis.net/ogc",
         ows: "http://www.opengis.net/ows",
         xlink: "http://www.w3.org/1999/xlink",
-        xsi: "http://www.w3.org/2001/XMLSchema-instance"
+        xsi: "http://www.w3.org/2001/XMLSchema-instance",
+        xmlns: "http://www.w3.org/2000/xmlns/"
     },
     
     /**
@@ -310,7 +311,10 @@ OpenLayers.Format.CSWGetRecords.v2_0_2 = OpenLayers.Class(OpenLayers.Format.XML,
      */
     write: function(options) {
         var node = this.writeNode("csw:GetRecords", options);
-        node.setAttribute("xmlns:gmd", this.namespaces.gmd);
+        this.setAttributeNS(
+            node, this.namespaces.xmlns,
+            "xmlns:gmd", this.namespaces.gmd
+        );
         return OpenLayers.Format.XML.prototype.write.apply(this, [node]);
     },
 

--- a/lib/OpenLayers/Format/SOSGetObservation.js
+++ b/lib/OpenLayers/Format/SOSGetObservation.js
@@ -30,7 +30,8 @@ OpenLayers.Format.SOSGetObservation = OpenLayers.Class(OpenLayers.Format.XML, {
         om: "http://www.opengis.net/om/1.0",
         sa: "http://www.opengis.net/sampling/1.0",
         xlink: "http://www.w3.org/1999/xlink",
-        xsi: "http://www.w3.org/2001/XMLSchema-instance"
+        xsi: "http://www.w3.org/2001/XMLSchema-instance",
+        xmlns: "http://www.w3.org/2000/xmlns/"
     },
 
     /**
@@ -101,8 +102,14 @@ OpenLayers.Format.SOSGetObservation = OpenLayers.Class(OpenLayers.Format.XML, {
      */
     write: function(options) {
         var node = this.writeNode("sos:GetObservation", options);
-        node.setAttribute("xmlns:om", this.namespaces.om);
-        node.setAttribute("xmlns:ogc", this.namespaces.ogc);
+        this.setAttributeNS(
+            node, this.namespaces.xmlns,
+            "xmlns:om", this.namespaces.om
+        );
+        this.setAttributeNS(
+            node, this.namespaces.xmlns,
+            "xmlns:ogc", this.namespaces.ogc
+        );
         this.setAttributeNS(
             node, this.namespaces.xsi,
             "xsi:schemaLocation", this.schemaLocation

--- a/lib/OpenLayers/Format/WFST/v1.js
+++ b/lib/OpenLayers/Format/WFST/v1.js
@@ -29,7 +29,8 @@ OpenLayers.Format.WFST.v1 = OpenLayers.Class(OpenLayers.Format.XML, {
         wfs: "http://www.opengis.net/wfs",
         gml: "http://www.opengis.net/gml",
         ogc: "http://www.opengis.net/ogc",
-        ows: "http://www.opengis.net/ows"
+        ows: "http://www.opengis.net/ows",
+        xmlns: "http://www.w3.org/2000/xmlns/"
     },
     
     /**
@@ -320,7 +321,10 @@ OpenLayers.Format.WFST.v1 = OpenLayers.Class(OpenLayers.Format.XML, {
                     }
                 });
                 if(this.featureNS) {
-                    node.setAttribute("xmlns:" + this.featurePrefix, this.featureNS);
+                    this.setAttributeNS(
+                        node, this.namespaces.xmlns,
+                        "xmlns:" + this.featurePrefix, this.featureNS
+                    );
                 }
                 
                 // add in geometry
@@ -383,7 +387,10 @@ OpenLayers.Format.WFST.v1 = OpenLayers.Class(OpenLayers.Format.XML, {
                     }
                 });
                 if(this.featureNS) {
-                    node.setAttribute("xmlns:" + this.featurePrefix, this.featureNS);
+                    this.setAttributeNS(
+                        node, this.namespaces.xmlns,
+                        "xmlns:" + this.featurePrefix, this.featureNS
+                    );
                 }
                 this.writeNode("ogc:Filter", new OpenLayers.Filter.FeatureId({
                     fids: [feature.fid]

--- a/lib/OpenLayers/Format/WFST/v1_0_0.js
+++ b/lib/OpenLayers/Format/WFST/v1_0_0.js
@@ -147,7 +147,10 @@ OpenLayers.Format.WFST.v1_0_0 = OpenLayers.Class(
                     node.setAttribute("srsName", options.srsName);
                 }
                 if(options.featureNS) {
-                    node.setAttribute("xmlns:" + prefix, options.featureNS);
+                    this.setAttributeNS(
+                        node, this.namespaces.xmlns,
+                        "xmlns:" + prefix, options.featureNS
+                    );
                 }
                 if(options.propertyNames) {
                     for(var i=0,len = options.propertyNames.length; i<len; i++) {

--- a/lib/OpenLayers/Format/WFST/v1_1_0.js
+++ b/lib/OpenLayers/Format/WFST/v1_1_0.js
@@ -157,7 +157,8 @@ OpenLayers.Format.WFST.v1_1_0 = OpenLayers.Class(
                     }
                 });
                 if(options.featureNS) {
-                    node.setAttribute("xmlns:" + prefix, options.featureNS);
+                    this.setAttributeNS(node, this.namespaces.xmlns,
+                        "xmlns:" + prefix, options.featureNS);
                 }
                 if(options.propertyNames) {
                     for(var i=0,len = options.propertyNames.length; i<len; i++) {

--- a/lib/OpenLayers/Format/WFST/v2_0_0.js
+++ b/lib/OpenLayers/Format/WFST/v2_0_0.js
@@ -30,7 +30,8 @@ OpenLayers.Format.WFST.v2_0_0 = OpenLayers.Class(
         xsi: "http://www.w3.org/2001/XMLSchema-instance",
         wfs: "http://www.opengis.net/wfs/2.0",
         gml: "http://www.opengis.net/gml/3.2",
-        fes: "http://www.opengis.net/fes/2.0"
+        fes: "http://www.opengis.net/fes/2.0",
+        xmlns: "http://www.w3.org/2000/xmlns/"
     },
         
     /**
@@ -175,7 +176,10 @@ OpenLayers.Format.WFST.v2_0_0 = OpenLayers.Class(
                     }
                 });
                 if(options.featureNS) {
-                    node.setAttribute("xmlns:" + prefix, options.featureNS);
+                    this.setAttributeNS(
+                        node, this.namespaces.xmlns,
+                        "xmlns:" + prefix, options.featureNS
+                    );
                 }
                 if(options.propertyNames) {
                     for(var i=0,len = options.propertyNames.length; i<len; i++) {
@@ -203,7 +207,10 @@ OpenLayers.Format.WFST.v2_0_0 = OpenLayers.Class(
                     }
                 });
                 if(this.featureNS) {
-                    node.setAttribute("xmlns:" + this.featurePrefix, this.featureNS);
+                    this.setAttributeNS(
+                        node, this.namespaces.xmlns,
+                        "xmlns:" + this.featurePrefix, this.featureNS
+                    );
                 }
                 
                 // add in geometry
@@ -260,7 +267,10 @@ OpenLayers.Format.WFST.v2_0_0 = OpenLayers.Class(
                     }
                 });
                 if(this.featureNS) {
-                    node.setAttribute("xmlns:" + this.featurePrefix, this.featureNS);
+                    this.setAttributeNS(
+                        node, this.namespaces.xmlns,
+                        "xmlns:" + this.featurePrefix, this.featureNS
+                    );
                 }
                 this.writeNode("fes:Filter", new OpenLayers.Filter.FeatureId({
                     fids: [feature.fid]


### PR DESCRIPTION
See this thread:

http://lists.osgeo.org/pipermail/openlayers-dev/2013-December/009137.html

This helped me fix it: http://stackoverflow.com/questions/19610089/unwanted-namespaces-on-svg-markup-when-using-xmlserializer-in-javascript-with-ie
