### PR TITLE
Added lazy update of SVG properties 

### DIFF
--- a/lib/OpenLayers/Renderer/SVG.js
+++ b/lib/OpenLayers/Renderer/SVG.js
@@ -128,7 +128,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
             // Set the viewbox
             var extentString = "0 0 " + this.size.w + " " + this.size.h;
 
-            this.rendererRoot.setAttributeNS(null, "viewBox", extentString);
+			lazyUpdate(this.renderRoot, null, "viewBox", extentString);
             this.translate(this.xOffset, 0);
             return true;
         } else {
@@ -161,7 +161,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
             if (x || y) {
                 transformString = "translate(" + x + "," + y + ")";
             }
-            this.root.setAttributeNS(null, "transform", transformString);
+            lazyUpate(this.root, null, "transform", transformString);
             this.translationParameters = {x: x, y: y};
             return true;
         }
@@ -177,8 +177,8 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
     setSize: function(size) {
         OpenLayers.Renderer.prototype.setSize.apply(this, arguments);
         
-        this.rendererRoot.setAttributeNS(null, "width", this.size.w);
-        this.rendererRoot.setAttributeNS(null, "height", this.size.h);
+        lazyUpdate(this.rendererRoot, null, "width", this.size.w);
+        lazyUpdate(this.rendererRoot, null, "height", this.size.h);
     },
 
     /** 
@@ -222,6 +222,24 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         return nodeType;
     },
 
+	 /** 
+     * Method: lazyUpdate
+     * Only update the SVG attributes of a node if they are different     * 
+     *
+     * Parameters:
+     * node - {SVGDomElement} An SVG element to decorate
+	 * ns- {SVGDomNamespace} The namespace of the attribute, null is
+	  *  an acceptable input if there is no namespace 
+     * variable - {String} Attribute name
+     * newVal - {Object} The new value to set the attribute to
+     */
+
+	lazyUpdate: function(node, ns, variable, newVal) {
+	   if (node.getAttributeNS(ns, variable) != newVal) {
+		  lazyUpdate(node, ns, variable, newVal);
+	   }
+	},
+	
     /** 
      * Method: setStyle
      * Use to set all the style attributes to a SVG node.
@@ -242,7 +260,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
 
         var title = style.title || style.graphicTitle;
         if (title) {
-            node.setAttributeNS(null, "title", title);
+            lazyUpdate(node, null, "title", title);
             //Standards-conformant SVG
             // Prevent duplicate nodes. See issue https://github.com/openlayers/openlayers/issues/92 
             var titleNode = node.getElementsByTagName("title");
@@ -265,7 +283,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
             } else if (style.externalGraphic) {
                 pos = this.getPosition(node);
                 if (style.graphicWidth && style.graphicHeight) {
-                  node.setAttributeNS(null, "preserveAspectRatio", "none");
+                   lazyUpdate(node, null, "preserveAspectRatio", "none");
                 }
                 var width = style.graphicWidth || style.graphicHeight;
                 var height = style.graphicHeight || style.graphicWidth;
@@ -278,12 +296,12 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
 
                 var opacity = style.graphicOpacity || style.fillOpacity;
                 
-                node.setAttributeNS(null, "x", (pos.x + xOffset).toFixed());
-                node.setAttributeNS(null, "y", (pos.y + yOffset).toFixed());
-                node.setAttributeNS(null, "width", width);
-                node.setAttributeNS(null, "height", height);
-                node.setAttributeNS(this.xlinkns, "xlink:href", style.externalGraphic);
-                node.setAttributeNS(null, "style", "opacity: "+opacity);
+                lazyUpdate(node, null, "x", (pos.x + xOffset).toFixed());
+                lazyUpdate(node, null, "y", (pos.y + yOffset).toFixed());
+                lazyUpdate(node, null, "width", width);
+                lazyUpdate(node, null, "height", height);
+                lazyUpdate(node, this.xlinkns, "xlink:href", style.externalGraphic);
+                lazyUpdate(node, null, "style", "opacity: "+opacity);
                 node.onclick = OpenLayers.Event.preventDefault;
             } else if (this.isComplexSymbol(style.graphicName)) {
                 // the symbol viewBox is three times as large as the symbol
@@ -309,12 +327,12 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
                 // http://osgeo-org.1803224.n2.nabble.com/Select-Control-Ctrl-click-on-Feature-with-a-graphicName-opens-new-browser-window-tc5846039.html
                 node.firstChild && node.removeChild(node.firstChild);
                 node.appendChild(src.firstChild.cloneNode(true));
-                node.setAttributeNS(null, "viewBox", src.getAttributeNS(null, "viewBox"));
+                lazyUpdate(node, null, "viewBox", src.getAttributeNS(null, "viewBox"));
                 
-                node.setAttributeNS(null, "width", size);
-                node.setAttributeNS(null, "height", size);
-                node.setAttributeNS(null, "x", pos.x - offset);
-                node.setAttributeNS(null, "y", pos.y - offset);
+                lazyUpdate(node, null, "width", size);
+                lazyUpdate(node, null, "height", size);
+                lazyUpdate(node, null, "x", pos.x - offset);
+                lazyUpdate(node, null, "y", pos.y - offset);
                 
                 // now that the node has all its new properties, insert it
                 // back into the dom where it was
@@ -324,7 +342,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
                     parent.appendChild(node);
                 }
             } else {
-                node.setAttributeNS(null, "r", style.pointRadius);
+                lazyUpdate(node, null, "r", style.pointRadius);
             }
 
             var rotation = style.rotation;
@@ -333,12 +351,12 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
                 node._rotation = rotation;
                 rotation |= 0;
                 if (node.nodeName !== "svg") { 
-                    node.setAttributeNS(null, "transform", 
+                    lazyUpdate(node, null, "transform", 
                         "rotate(" + rotation + " " + pos.x + " " + 
                         pos.y + ")"); 
                 } else {
                     var metrics = this.symbolMetrics[src.id];
-                    node.firstChild.setAttributeNS(null, "transform", "rotate(" 
+                    lazyUpdate(node.firstChild, null, "transform", "rotate(" 
                         + rotation + " " 
                         + metrics[1] + " "
                         + metrics[2] + ")");
@@ -347,32 +365,32 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         }
         
         if (options.isFilled) {
-            node.setAttributeNS(null, "fill", style.fillColor);
-            node.setAttributeNS(null, "fill-opacity", style.fillOpacity);
+            lazyUpdate(node, null, "fill", style.fillColor);
+            lazyUpdate(node, null, "fill-opacity", style.fillOpacity);
         } else {
-            node.setAttributeNS(null, "fill", "none");
+            lazyUpdate(node, null, "fill", "none");
         }
 
         if (options.isStroked) {
-            node.setAttributeNS(null, "stroke", style.strokeColor);
-            node.setAttributeNS(null, "stroke-opacity", style.strokeOpacity);
-            node.setAttributeNS(null, "stroke-width", style.strokeWidth * widthFactor);
-            node.setAttributeNS(null, "stroke-linecap", style.strokeLinecap || "round");
+            lazyUpdate(node, null, "stroke", style.strokeColor);
+            lazyUpdate(node, null, "stroke-opacity", style.strokeOpacity);
+            lazyUpdate(node, null, "stroke-width", style.strokeWidth * widthFactor);
+            lazyUpdate(node, null, "stroke-linecap", style.strokeLinecap || "round");
             // Hard-coded linejoin for now, to make it look the same as in VML.
             // There is no strokeLinejoin property yet for symbolizers.
-            node.setAttributeNS(null, "stroke-linejoin", "round");
-            style.strokeDashstyle && node.setAttributeNS(null,
+            lazyUpdate(node, null, "stroke-linejoin", "round");
+            style.strokeDashstyle && lazyUpdate(node, null,
                 "stroke-dasharray", this.dashStyle(style, widthFactor));
         } else {
-            node.setAttributeNS(null, "stroke", "none");
+            lazyUpdate(node, null, "stroke", "none");
         }
         
         if (style.pointerEvents) {
-            node.setAttributeNS(null, "pointer-events", style.pointerEvents);
+            lazyUpdate(node, null, "pointer-events", style.pointerEvents);
         }
                 
         if (style.cursor != null) {
-            node.setAttributeNS(null, "cursor", style.cursor);
+            lazyUpdate(node, null, "cursor", style.cursor);
         }
         
         return node;
@@ -422,7 +440,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
     createNode: function(type, id) {
         var node = document.createElementNS(this.xmlns, type);
         if (id) {
-            node.setAttributeNS(null, "id", id);
+            lazyUpdate(node, null, "id", id);
         }
         return node;    
     },
@@ -517,9 +535,9 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         var y = (this.top - geometry.y / resolution);
 
         if (this.inValidRange(x, y)) { 
-            node.setAttributeNS(null, "cx", x);
-            node.setAttributeNS(null, "cy", y);
-            node.setAttributeNS(null, "r", radius);
+            lazyUpdate(node, null, "cx", x);
+            lazyUpdate(node, null, "cy", y);
+            lazyUpdate(node, null, "r", radius);
             return node;
         } else {
             return false;
@@ -542,7 +560,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
     drawLineString: function(node, geometry) {
         var componentsResult = this.getComponentsString(geometry.components);
         if (componentsResult.path) {
-            node.setAttributeNS(null, "points", componentsResult.path);
+            lazyUpdate(node, null, "points", componentsResult.path);
             return (componentsResult.complete ? node : null);  
         } else {
             return false;
@@ -564,7 +582,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
     drawLinearRing: function(node, geometry) {
         var componentsResult = this.getComponentsString(geometry.components);
         if (componentsResult.path) {
-            node.setAttributeNS(null, "points", componentsResult.path);
+            lazyUpdate(node, null, "points", componentsResult.path);
             return (componentsResult.complete ? node : null);  
         } else {
             return false;
@@ -602,8 +620,8 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         }
         d += " z";
         if (draw) {
-            node.setAttributeNS(null, "d", d);
-            node.setAttributeNS(null, "fill-rule", "evenodd");
+            lazyUpdate(node, null, "d", d);
+            lazyUpdate(node, null, "fill-rule", "evenodd");
             return complete ? node : null;
         } else {
             return false;
@@ -627,10 +645,10 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         var y = (this.top - geometry.y / resolution);
 
         if (this.inValidRange(x, y)) { 
-            node.setAttributeNS(null, "x", x);
-            node.setAttributeNS(null, "y", y);
-            node.setAttributeNS(null, "width", geometry.width / resolution);
-            node.setAttributeNS(null, "height", geometry.height / resolution);
+            lazyUpdate(node, null, "x", x);
+            lazyUpdate(node, null, "y", y);
+            lazyUpdate(node, null, "width", geometry.width / resolution);
+            lazyUpdate(node, null, "height", geometry.height / resolution);
             return node;
         } else {
             return false;
@@ -670,45 +688,45 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         var suffix = (drawOutline)?this.LABEL_OUTLINE_SUFFIX:this.LABEL_ID_SUFFIX;
         var label = this.nodeFactory(featureId + suffix, "text");
 
-        label.setAttributeNS(null, "x", x);
-        label.setAttributeNS(null, "y", -y);
+        lazyUpdate(label, null, "x", x);
+        lazyUpdate(label, null, "y", -y);
 
         if (style.fontColor) {
-            label.setAttributeNS(null, "fill", style.fontColor);
+            lazyUpdate(label, null, "fill", style.fontColor);
         }
         if (style.fontStrokeColor) {
-            label.setAttributeNS(null, "stroke", style.fontStrokeColor);
+            lazyUpdate(label, null, "stroke", style.fontStrokeColor);
         }
         if (style.fontStrokeWidth) {
-            label.setAttributeNS(null, "stroke-width", style.fontStrokeWidth);
+            lazyUpdate(label, null, "stroke-width", style.fontStrokeWidth);
         }
         if (style.fontOpacity) {
-            label.setAttributeNS(null, "opacity", style.fontOpacity);
+            lazyUpdate(label, null, "opacity", style.fontOpacity);
         }
         if (style.fontFamily) {
-            label.setAttributeNS(null, "font-family", style.fontFamily);
+            lazyUpdate(label, null, "font-family", style.fontFamily);
         }
         if (style.fontSize) {
-            label.setAttributeNS(null, "font-size", style.fontSize);
+            lazyUpdate(label, null, "font-size", style.fontSize);
         }
         if (style.fontWeight) {
-            label.setAttributeNS(null, "font-weight", style.fontWeight);
+            lazyUpdate(label, null, "font-weight", style.fontWeight);
         }
         if (style.fontStyle) {
-            label.setAttributeNS(null, "font-style", style.fontStyle);
+            lazyUpdate(label, null, "font-style", style.fontStyle);
         }
         if (style.labelSelect === true) {
-            label.setAttributeNS(null, "pointer-events", "visible");
+            lazyUpdate(label, null, "pointer-events", "visible");
             label._featureId = featureId;
         } else {
-            label.setAttributeNS(null, "pointer-events", "none");
+            lazyUpdate(label, null, "pointer-events", "none");
         }
         var align = style.labelAlign || OpenLayers.Renderer.defaultSymbolizer.labelAlign;
-        label.setAttributeNS(null, "text-anchor",
+        lazyUpdate(label, null, "text-anchor",
             OpenLayers.Renderer.SVG.LABEL_ALIGN[align[0]] || "middle");
 
         if (OpenLayers.IS_GECKO === true) {
-            label.setAttributeNS(null, "dominant-baseline",
+            lazyUpdate(label, null, "dominant-baseline",
                 OpenLayers.Renderer.SVG.LABEL_ALIGN[align[1]] || "central");
         }
 
@@ -725,7 +743,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
                 tspan._geometryClass = location.CLASS_NAME;
             }
             if (OpenLayers.IS_GECKO === false) {
-                tspan.setAttributeNS(null, "baseline-shift",
+                lazyUpdate(tspan, null, "baseline-shift",
                     OpenLayers.Renderer.SVG.LABEL_VSHIFT[align[1]] || "-35%");
             }
             tspan.setAttribute("x", x);
@@ -926,7 +944,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
             points.push(x, ",", y);
         }
         
-        node.setAttributeNS(null, "points", points.join(" "));
+        lazyUpdate(node, null, "points", points.join(" "));
         
         var width = symbolExtent.getWidth();
         var height = symbolExtent.getHeight();
@@ -934,7 +952,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         // to allow for strokeWidth being displayed correctly at the corners.
         var viewBox = [symbolExtent.left - width,
                         symbolExtent.bottom - height, width * 3, height * 3];
-        symbolNode.setAttributeNS(null, "viewBox", viewBox.join(" "));
+        symbollazyUpdate(node, null, "viewBox", viewBox.join(" "));
         this.symbolMetrics[id] = [
             Math.max(width, height),
             symbolExtent.getCenterLonLat().lon,


### PR DESCRIPTION
Lazily update SVG properties to increase render speed of large numbers of moving objects.  The setAttributeNS function profiled to be exceptionally slow in firefox, chrome and IE, this mitigates the poor performance dramatically since many attributes are not actually changed on a frame by frame basis.
