### PR TITLE
Set the feature.type on GetFeatureInfo request on QGIS mapserver.

### DIFF
--- a/lib/OpenLayers/Format/GML.js
+++ b/lib/OpenLayers/Format/GML.js
@@ -187,11 +187,13 @@ OpenLayers.Format.GML = OpenLayers.Class(OpenLayers.Format.XML, {
         var feature = new OpenLayers.Feature.Vector(geometry, attributes);
         feature.bounds = bounds;
         
+        var firstChild = this.getFirstElementChild(node)
         feature.gml = {
-            featureType: node.firstChild.nodeName.split(":")[1],
-            featureNS: node.firstChild.namespaceURI,
-            featureNSPrefix: node.firstChild.prefix
+            featureType: firstChild.nodeName.split(":")[1],
+            featureNS: firstChild.namespaceURI,
+            featureNSPrefix: firstChild.prefix
         };
+        feature.type = feature.gml.featureType;
                 
         // assign fid - this can come from a "fid" or "id" attribute
         var childNode = node.firstChild;

--- a/lib/OpenLayers/Format/XML.js
+++ b/lib/OpenLayers/Format/XML.js
@@ -588,6 +588,27 @@ OpenLayers.Format.XML = OpenLayers.Class(OpenLayers.Format, {
     },
 
     /**
+     * Method: getFirstElementChild
+     * Implementation of firstElementChild attribute that works on ie7 and ie8.
+     *
+     * Parameters:
+     * node - {DOMElement} The parent node (required).
+     *
+     * Returns:
+     * {DOMElement} The first child element.
+     */
+    getFirstElementChild: function(node) {
+        if (node.firstElementChild) {
+            return node.firstElementChild;
+        }
+        else {
+            var child = node.firstChild;
+            while (child.nodeType != 1 && (child = child.nextSibling)) {}
+            return child;
+        }
+    },
+
+    /**
      * Method: readNode
      * Shorthand for applying one of the named readers given the node
      *     namespace and local name.  Readers take two args (node, obj) and

--- a/tests/Format/WMSGetFeatureInfo.html
+++ b/tests/Format/WMSGetFeatureInfo.html
@@ -321,7 +321,7 @@
         var parser = new OpenLayers.Format.WMSGetFeatureInfo();
 
         // read empty attribute
-        text =
+        var text =
             '<?xml version="1.0" encoding="UTF-8"?>' +
             '<msGMLOutput ' +
             '     xmlns:gml="http://www.opengis.net/gml"' +
@@ -344,7 +344,7 @@
             '    </name_layer>' +
             '</msGMLOutput>';
 
-        features = parser.read(text);
+        var features = parser.read(text);
 
         t.eq(features.length, 1,
              "Parsed 1 feature in total");
@@ -352,6 +352,34 @@
              "Attribute html exists");
         t.eq(features[0].attributes.html.length, 7000,
              "Attribute html have the right length");
+    }
+
+
+    function test_read_QGISOutput(t) {
+        t.plan(4);
+
+        var parser = new OpenLayers.Format.WMSGetFeatureInfo();
+
+        var text =
+            '<wfs:FeatureCollection xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:wfs="http://www.opengis.net/wfs" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:qgs="http://www.qgis.org/gml">' +
+            ' <gml:featureMember>' +
+            '  <qgs:camera fid="camera.15">' +
+            '   <qgs:gid>15</qgs:gid>' +
+            '   <qgs:id>i15</qgs:id>' +
+            '  </qgs:camera>' +
+            ' </gml:featureMember>' +
+            '</wfs:FeatureCollection>';
+
+        var features = parser.read(text);
+
+        t.eq(features.length, 1,
+             "Parsed 1 feature in total");
+        t.eq(features[0].type, 'camera',
+             "Attribute type contains the right value");
+        t.eq(features[0].attributes.gid, '15',
+             "Attribute gid contains the right value");
+        t.eq(features[0].attributes.id, 'i15',
+             "Attribute id contains the right value");
     }
     </script>
 </head>


### PR DESCRIPTION
Accentually the node.firstChild returns a text element with spaces ...
And the feature.type is not set (is the case fort MapServer and in WFS/GetFeature ! )
