### PR TITLE
SVG lazy update

### DIFF
--- a/lib/OpenLayers/Renderer/SVG.js
+++ b/lib/OpenLayers/Renderer/SVG.js
@@ -127,8 +127,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
             this.top = top;
             // Set the viewbox
             var extentString = "0 0 " + this.size.w + " " + this.size.h;
-
-			this.lazyUpdate(this.rendererRoot, null, "viewBox", extentString);
+            this.lazyUpdate(this.rendererRoot, null, "viewBox", extentString);
             this.translate(this.xOffset, 0);
             return true;
         } else {
@@ -222,35 +221,34 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         return nodeType;
     },
 
-	 /** 
+    /**
      * Method: lazyUpdate
-     * Only update the SVG attributes of a node if they are different     * 
+     * Only update the SVG attributes of a node if they are different
      *
      * Parameters:
      * node - {SVGDomElement} An SVG element to decorate
-	 * ns- {SVGDomNamespace} The namespace of the attribute, null is
-	  *  an acceptable input if there is no namespace 
+     * ns- {SVGDomNamespace} The namespace of the attribute, null is
+     *  an acceptable input if there is no namespace
      * variable - {String} Attribute name
      * newVal - {Object} The new value to set the attribute to
      */
+    lazyUpdate: function(node, ns, variable, newVal) {
+        if (node.getAttributeNS(ns, variable) != newVal) {
+            node.setAttributeNS(ns, variable, newVal);
+        }
+    },
 
-	lazyUpdate: function(node, ns, variable, newVal) {
-	   if (node.getAttributeNS(ns, variable) != newVal) {
-		  node.setAttributeNS(ns, variable, newVal);
-	   }
-	},
-	
-    /** 
+    /**
      * Method: setStyle
      * Use to set all the style attributes to a SVG node.
-     * 
+     *
      * Takes care to adjust stroke width and point radius to be
      * resolution-relative
      *
      * Parameters:
      * node - {SVGDomElement} An SVG element to decorate
      * style - {Object}
-     * options - {Object} Currently supported options include 
+     * options - {Object} Currently supported options include
      *                              'isFilled' {Boolean} and
      *                              'isStroked' {Boolean}
      */
@@ -283,7 +281,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
             } else if (style.externalGraphic) {
                 pos = this.getPosition(node);
                 if (style.graphicWidth && style.graphicHeight) {
-                   this.lazyUpdate(node, null, "preserveAspectRatio", "none");
+                    this.lazyUpdate(node, null, "preserveAspectRatio", "none");
                 }
                 var width = style.graphicWidth || style.graphicHeight;
                 var height = style.graphicHeight || style.graphicWidth;


### PR DESCRIPTION
SVG Lazy update for attributes.  Profiling showed setAttributeNS was a very slow operation on Firefox, Chrome Safari and IE.  Since most attributes don't change from frame to frame, on calling setAttributeNS for attributes that have changed speeds up rendering considerably.

This has passed the test suite (which is pretty cool by the way).
