### PR TITLE
Fixing typos in control/panel

### DIFF
--- a/lib/OpenLayers/Control/Panel.js
+++ b/lib/OpenLayers/Control/Panel.js
@@ -274,7 +274,7 @@ OpenLayers.Control.Panel = OpenLayers.Class(OpenLayers.Control, {
      * (code)
      * var panel = new OpenLayers.Control.Panel({
      *     defaultControl: control,
-     *     // ovverride createControlMarkup to create actual buttons
+     *     // override createControlMarkup to create actual buttons
      *     // including texts wrapped into span elements.
      *     createControlMarkup: function(control) {
      *         var button = document.createElement('button'),
@@ -369,7 +369,7 @@ OpenLayers.Control.Panel = OpenLayers.Class(OpenLayers.Control, {
      * property - {String} A control property to be matched.
      * match - {String | Object} A string to match.  Can also be a regular
      *     expression literal or object.  In addition, it can be any object
-     *     with a method named test.  For reqular expressions or other, if
+     *     with a method named test.  For regular expressions or other, if
      *     match.test(control[property]) evaluates to true, the control will be
      *     included in the array returned.  If no controls are found, an empty
      *     array is returned.
@@ -388,12 +388,12 @@ OpenLayers.Control.Panel = OpenLayers.Class(OpenLayers.Control, {
 
     /**
      * APIMethod: getControlsByName
-     * Get a list of contorls with names matching the given name.
+     * Get a list of controls with names matching the given name.
      *
      * Parameters:
      * match - {String | Object} A control name.  The name can also be a regular
      *     expression literal or object.  In addition, it can be any object
-     *     with a method named test.  For reqular expressions or other, if
+     *     with a method named test.  For regular expressions or other, if
      *     name.test(control.name) evaluates to true, the control will be included
      *     in the list of controls returned.  If no controls are found, an empty
      *     array is returned.
@@ -413,7 +413,7 @@ OpenLayers.Control.Panel = OpenLayers.Class(OpenLayers.Control, {
      * Parameters:
      * match - {String | Object} A control class name.  The type can also be a
      *     regular expression literal or object.  In addition, it can be any
-     *     object with a method named test.  For reqular expressions or other,
+     *     object with a method named test.  For regular expressions or other,
      *     if type.test(control.CLASS_NAME) evaluates to true, the control will
      *     be included in the list of controls returned.  If no controls are
      *     found, an empty array is returned.


### PR DESCRIPTION
Found a few distracting typos in control/panel.js.
Did a quick search of surrounding code to make sure no others.
