### PR TITLE
add new option hexZoom to ArcGISCache layer

### DIFF
--- a/lib/OpenLayers/Layer/ArcGISCache.js
+++ b/lib/OpenLayers/Layer/ArcGISCache.js
@@ -47,72 +47,79 @@ OpenLayers.Layer.ArcGISCache = OpenLayers.Class(OpenLayers.Layer.XYZ, {
      */
     url: null,
     
-   /**
-    * APIProperty: tileOrigin
-    * {<OpenLayers.LonLat>} The location of the tile origin for the cache.
-    *     An ArcGIS cache has it's origin at the upper-left (lowest x value
-    *     and highest y value of the coordinate system).  The units for the
-    *     tile origin should be the same as the units for the cached data.
-    */
+    /**
+     * APIProperty: tileOrigin
+     * {<OpenLayers.LonLat>} The location of the tile origin for the cache.
+     *     An ArcGIS cache has it's origin at the upper-left (lowest x value
+     *     and highest y value of the coordinate system).  The units for the
+     *     tile origin should be the same as the units for the cached data.
+     */
     tileOrigin: null, 
    
-   /**
-    * APIProperty: tileSize
-    * {<OpenLayers.Size>} This size of each tile. Defaults to 256 by 256 pixels.
-    */
+    /**
+     * APIProperty: tileSize
+     * {<OpenLayers.Size>} This size of each tile. Defaults to 256 by 256 pixels.
+     */
     tileSize: new OpenLayers.Size(256, 256),
     
-   /**
-    * APIProperty: useAGS
-    * {Boolean} Indicates if we are going to be accessing the ArcGIS Server (AGS)
-    *     cache via an AGS MapServer or directly through HTTP. When accessing via
-    *     AGS the path structure uses a standard z/y/x structure. But AGS actually
-    *     stores the tile images on disk using a hex based folder structure that looks
-    *     like "http://example.com/mylayer/L00/R00000000/C00000000.png".  Learn more
-    *     about this here:
-    *     http://blogs.esri.com/Support/blogs/mappingcenter/archive/2010/08/20/Checking-Your-Local-Cache-Folders.aspx
-    *     Defaults to true;
-    */    
+    /**
+     * APIProperty: useArcGISServer
+     * {Boolean} Indicates if we are going to be accessing the ArcGIS Server (AGS)
+     *     cache via an AGS MapServer or directly through HTTP. When accessing via
+     *     AGS the path structure uses a standard z/y/x structure. But AGS actually
+     *     stores the tile images on disk using a hex based folder structure that looks
+     *     like "http://example.com/mylayer/L00/R00000000/C00000000.png".  Learn more
+     *     about this here:
+     *     http://blogs.esri.com/Support/blogs/mappingcenter/archive/2010/08/20/Checking-Your-Local-Cache-Folders.aspx
+     *     Defaults to true;
+     */    
     useArcGISServer: true,
 
-   /**
-    * APIProperty: type
-    * {String} Image type for the layer.  This becomes the filename extension
-    *     in tile requests.  Default is "png" (generating a url like
-    *     "http://example.com/mylayer/L00/R00000000/C00000000.png").
-    */
+    /**
+     * APIProperty: type
+     * {String} Image type for the layer.  This becomes the filename extension
+     *     in tile requests.  Default is "png" (generating a url like
+     *     "http://example.com/mylayer/L00/R00000000/C00000000.png").
+     */
     type: 'png',
     
     /**
-    * APIProperty: useScales
-    * {Boolean} Optional override to indicate that the layer should use 'scale' information
-    *     returned from the server capabilities object instead of 'resolution' information.
-    *     This can be important if your tile server uses an unusual DPI for the tiles.
-    */
+     * APIProperty: useScales
+     * {Boolean} Optional override to indicate that the layer should use 'scale' information
+     *     returned from the server capabilities object instead of 'resolution' information.
+     *     This can be important if your tile server uses an unusual DPI for the tiles.
+     */
     useScales: false,
     
-   /**
-    * APIProperty: overrideDPI
-    * {Boolean} Optional override to change the OpenLayers.DOTS_PER_INCH setting based 
-    *     on the tile information in the server capabilities object.  This can be useful 
-    *     if your server has a non-standard DPI setting on its tiles, and you're only using 
-    *     tiles with that DPI.  This value is used while OpenLayers is calculating resolution
-    *     using scales, and is not necessary if you have resolution information. (This is
-    *     typically the case)  Regardless, this setting can be useful, but is dangerous
-    *     because it will impact other layers while calculating resolution.  Only use this
-    *     if you know what you are doing.  (See OpenLayers.Util.getResolutionFromScale)
-    */
+    /**
+     * APIProperty: overrideDPI
+     * {Boolean} Optional override to change the OpenLayers.DOTS_PER_INCH setting based 
+     *     on the tile information in the server capabilities object.  This can be useful 
+     *     if your server has a non-standard DPI setting on its tiles, and you're only using 
+     *     tiles with that DPI.  This value is used while OpenLayers is calculating resolution
+     *     using scales, and is not necessary if you have resolution information. (This is
+     *     typically the case)  Regardless, this setting can be useful, but is dangerous
+     *     because it will impact other layers while calculating resolution.  Only use this
+     *     if you know what you are doing.  (See OpenLayers.Util.getResolutionFromScale)
+     */
     overrideDPI: false,
+
+    /**
+     * APIProperty: hexZoom
+     * {Boolean} Should we hex encode the z values in the url?
+     * Default value is false.
+     */
+    hexZoom: false,
     
-   /**
-    * Constructor: OpenLayers.Layer.ArcGISCache 
-    * Creates a new instance of this class 
-    * 
-    * Parameters: 
-    * name - {String} 
-    * url - {String} 
-    * options - {Object} extra layer options
-    */ 
+    /**
+     * Constructor: OpenLayers.Layer.ArcGISCache 
+     * Creates a new instance of this class 
+     * 
+     * Parameters: 
+     * name - {String} 
+     * url - {String} 
+     * options - {Object} extra layer options
+     */ 
     initialize: function(name, url, options) { 
         OpenLayers.Layer.XYZ.prototype.initialize.apply(this, arguments);
 
@@ -206,19 +213,19 @@ OpenLayers.Layer.ArcGISCache = OpenLayers.Class(OpenLayers.Layer.XYZ, {
        }
     }, 
 
-   /** 
-    * Method: getContainingTileCoords
-    * Calculates the x/y pixel corresponding to the position of the tile
-    *     that contains the given point and for the for the given resolution.
-    * 
-    * Parameters:
-    * point - {<OpenLayers.Geometry.Point>} 
-    * res - {Float} The resolution for which to compute the extent.
-    * 
-    * Returns: 
-    * {<OpenLayers.Pixel>} The x/y pixel corresponding to the position 
-    * of the upper left tile for the given resolution.
-    */
+    /** 
+     * Method: getContainingTileCoords
+     * Calculates the x/y pixel corresponding to the position of the tile
+     *     that contains the given point and for the for the given resolution.
+     * 
+     * Parameters:
+     * point - {<OpenLayers.Geometry.Point>} 
+     * res - {Float} The resolution for which to compute the extent.
+     * 
+     * Returns: 
+     * {<OpenLayers.Pixel>} The x/y pixel corresponding to the position 
+     * of the upper left tile for the given resolution.
+     */
     getContainingTileCoords: function(point, res) {
         return new OpenLayers.Pixel(
            Math.max(Math.floor((point.x - this.tileOrigin.lon) / (this.tileSize.w * res)),0),
@@ -226,19 +233,19 @@ OpenLayers.Layer.ArcGISCache = OpenLayers.Class(OpenLayers.Layer.XYZ, {
         );
     },
     
-   /** 
-    * Method: calculateMaxExtentWithLOD
-    * Given a Level of Detail object from the server, this function
-    *     calculates the actual max extent
-    * 
-    * Parameters: 
-    * lod - {Object} a Level of Detail Object from the server capabilities object 
-            representing a particular zoom level
-    * 
-    * Returns: 
-    * {<OpenLayers.Bounds>} The actual extent of the tiles for the given zoom level
-    */
-   calculateMaxExtentWithLOD: function(lod) {
+    /** 
+     * Method: calculateMaxExtentWithLOD
+     * Given a Level of Detail object from the server, this function
+     *     calculates the actual max extent
+     * 
+     * Parameters: 
+     * lod - {Object} a Level of Detail Object from the server capabilities object 
+             representing a particular zoom level
+     * 
+     * Returns: 
+     * {<OpenLayers.Bounds>} The actual extent of the tiles for the given zoom level
+     */
+    calculateMaxExtentWithLOD: function(lod) {
         // the max extent we're provided with just overlaps some tiles
         // our real extent is the bounds of all the tiles we touch
 
@@ -251,22 +258,22 @@ OpenLayers.Layer.ArcGISCache = OpenLayers.Class(OpenLayers.Layer.XYZ, {
         var maxY = this.tileOrigin.lat - (lod.startTileRow * this.tileSize.h * lod.resolution);
         var minY = maxY - (numTileRows * this.tileSize.h * lod.resolution);
         return new OpenLayers.Bounds(minX, minY, maxX, maxY);
-   },
+    },
     
-   /** 
-    * Method: calculateMaxExtentWithExtent
-    * Given a 'suggested' max extent from the server, this function uses
-    *     information about the actual tile sizes to determine the actual
-    *     extent of the layer.
-    * 
-    * Parameters: 
-    * extent - {<OpenLayers.Bounds>} The 'suggested' extent for the layer
-    * res - {Float} The resolution for which to compute the extent.
-    * 
-    * Returns: 
-    * {<OpenLayers.Bounds>} The actual extent of the tiles for the given zoom level
-    */
-   calculateMaxExtentWithExtent: function(extent, res) {
+    /** 
+     * Method: calculateMaxExtentWithExtent
+     * Given a 'suggested' max extent from the server, this function uses
+     *     information about the actual tile sizes to determine the actual
+     *     extent of the layer.
+     * 
+     * Parameters: 
+     * extent - {<OpenLayers.Bounds>} The 'suggested' extent for the layer
+     * res - {Float} The resolution for which to compute the extent.
+     * 
+     * Returns: 
+     * {<OpenLayers.Bounds>} The actual extent of the tiles for the given zoom level
+     */
+    calculateMaxExtentWithExtent: function(extent, res) {
         var upperLeft = new OpenLayers.Geometry.Point(extent.left, extent.top);
         var bottomRight = new OpenLayers.Geometry.Point(extent.right, extent.bottom);
         var start = this.getContainingTileCoords(upperLeft, res);
@@ -279,20 +286,20 @@ OpenLayers.Layer.ArcGISCache = OpenLayers.Class(OpenLayers.Layer.XYZ, {
             endTileRow: end.y
         };
         return this.calculateMaxExtentWithLOD(lod);
-   },
+    },
     
     /** 
-    * Method: getUpperLeftTileCoord
-    * Calculates the x/y pixel corresponding to the position 
-    *     of the upper left tile for the given resolution.
-    * 
-    * Parameters: 
-    * res - {Float} The resolution for which to compute the extent.
-    * 
-    * Returns: 
-    * {<OpenLayers.Pixel>} The x/y pixel corresponding to the position 
-    * of the upper left tile for the given resolution.
-    */
+     * Method: getUpperLeftTileCoord
+     * Calculates the x/y pixel corresponding to the position 
+     *     of the upper left tile for the given resolution.
+     * 
+     * Parameters: 
+     * res - {Float} The resolution for which to compute the extent.
+     * 
+     * Returns: 
+     * {<OpenLayers.Pixel>} The x/y pixel corresponding to the position 
+     * of the upper left tile for the given resolution.
+     */
     getUpperLeftTileCoord: function(res) {
         var upperLeft = new OpenLayers.Geometry.Point(
             this.maxExtent.left,
@@ -301,17 +308,17 @@ OpenLayers.Layer.ArcGISCache = OpenLayers.Class(OpenLayers.Layer.XYZ, {
     },
 
     /** 
-    * Method: getLowerRightTileCoord
-    * Calculates the x/y pixel corresponding to the position 
-    *     of the lower right tile for the given resolution.
-    *  
-    * Parameters: 
-    * res - {Float} The resolution for which to compute the extent.
-    * 
-    * Returns: 
-    * {<OpenLayers.Pixel>} The x/y pixel corresponding to the position
-    * of the lower right tile for the given resolution.
-    */
+     * Method: getLowerRightTileCoord
+     * Calculates the x/y pixel corresponding to the position 
+     *     of the lower right tile for the given resolution.
+     *  
+     * Parameters: 
+     * res - {Float} The resolution for which to compute the extent.
+     * 
+     * Returns: 
+     * {<OpenLayers.Pixel>} The x/y pixel corresponding to the position
+     * of the lower right tile for the given resolution.
+     */
     getLowerRightTileCoord: function(res) {
         var bottomRight = new OpenLayers.Geometry.Point(
             this.maxExtent.right,
@@ -319,18 +326,18 @@ OpenLayers.Layer.ArcGISCache = OpenLayers.Class(OpenLayers.Layer.XYZ, {
         return this.getContainingTileCoords(bottomRight, res);
     },
     
-   /** 
-    * Method: getMaxExtentForResolution
-    * Since the max extent of a set of tiles can change from zoom level
-    *     to zoom level, we need to be able to calculate that max extent 
-    *     for a given resolution.
-    *
-    * Parameters: 
-    * res - {Float} The resolution for which to compute the extent.
-    * 
-    * Returns: 
-    * {<OpenLayers.Bounds>} The extent for this resolution
-    */ 
+    /** 
+     * Method: getMaxExtentForResolution
+     * Since the max extent of a set of tiles can change from zoom level
+     *     to zoom level, we need to be able to calculate that max extent 
+     *     for a given resolution.
+     *
+     * Parameters: 
+     * res - {Float} The resolution for which to compute the extent.
+     * 
+     * Returns: 
+     * {<OpenLayers.Bounds>} The extent for this resolution
+     */ 
     getMaxExtentForResolution: function(res) {
         var start = this.getUpperLeftTileCoord(res);
         var end = this.getLowerRightTileCoord(res);
@@ -346,16 +353,16 @@ OpenLayers.Layer.ArcGISCache = OpenLayers.Class(OpenLayers.Layer.XYZ, {
         return new OpenLayers.Bounds(minX, minY, maxX, maxY);
     },
     
-   /** 
-    * APIMethod: clone 
-    * Returns an exact clone of this OpenLayers.Layer.ArcGISCache
-    * 
-    * Parameters: 
-    * [obj] - {Object} optional object to assign the cloned instance to.
-    *  
-    * Returns: 
-    * {<OpenLayers.Layer.ArcGISCache>} clone of this instance 
-    */ 
+    /** 
+     * APIMethod: clone 
+     * Returns an exact clone of this OpenLayers.Layer.ArcGISCache
+     * 
+     * Parameters: 
+     * [obj] - {Object} optional object to assign the cloned instance to.
+     *  
+     * Returns: 
+     * {<OpenLayers.Layer.ArcGISCache>} clone of this instance 
+     */ 
     clone: function (obj) { 
         if (obj == null) { 
             obj = new OpenLayers.Layer.ArcGISCache(this.name, this.url, this.options);
@@ -402,21 +409,21 @@ OpenLayers.Layer.ArcGISCache = OpenLayers.Class(OpenLayers.Layer.XYZ, {
         return this._tileOrigin;
     },
 
-   /**
-    * Method: getURL
-    * Determine the URL for a tile given the tile bounds.  This is should support
-    *     urls that access tiles through an ArcGIS Server MapServer or directly through
-    *     the hex folder structure using HTTP.  Just be sure to set the useArcGISServer
-    *     property appropriately!  This is basically the same as 
-    *     'OpenLayers.Layer.TMS.getURL',  but with the addition of hex addressing,
-    *     and tile rounding.
-    *
-    * Parameters:
-    * bounds - {<OpenLayers.Bounds>}
-    *
-    * Returns:
-    * {String} The URL for a tile based on given bounds.
-    */
+    /**
+     * Method: getURL
+     * Determine the URL for a tile given the tile bounds.  This is should support
+     *     urls that access tiles through an ArcGIS Server MapServer or directly through
+     *     the hex folder structure using HTTP.  Just be sure to set the useArcGISServer
+     *     property appropriately!  This is basically the same as 
+     *     'OpenLayers.Layer.TMS.getURL',  but with the addition of hex addressing,
+     *     and tile rounding.
+     *
+     * Parameters:
+     * bounds - {<OpenLayers.Bounds>}
+     *
+     * Returns:
+     * {String} The URL for a tile based on given bounds.
+     */
     getURL: function (bounds) {
         var res = this.getResolution(); 
 
@@ -464,7 +471,7 @@ OpenLayers.Layer.ArcGISCache = OpenLayers.Class(OpenLayers.Layer.XYZ, {
             // The tile images are stored using hex values on disk.
             x = 'C' + OpenLayers.Number.zeroPad(x, 8, 16);
             y = 'R' + OpenLayers.Number.zeroPad(y, 8, 16);
-            z = 'L' + OpenLayers.Number.zeroPad(z, 2, 10);
+            z = 'L' + OpenLayers.Number.zeroPad(z, 2, this.hexZoom ? 16 : 10);
             url = url + '/${z}/${y}/${x}.' + this.type;
         }
 
@@ -477,4 +484,4 @@ OpenLayers.Layer.ArcGISCache = OpenLayers.Class(OpenLayers.Layer.XYZ, {
     },
 
     CLASS_NAME: 'OpenLayers.Layer.ArcGISCache' 
-}); 
+});

--- a/tests/Layer/ArcGISCache.html
+++ b/tests/Layer/ArcGISCache.html
@@ -56,6 +56,12 @@
             layerInfo: layerInfo,
             params: {foo: "bar"}
         });
+        var layer2 = new OpenLayers.Layer.ArcGISCache(name, url, {
+            layerInfo: layerInfo,
+            hexZoom: true,
+            useArcGISServer: false,
+            params: {foo: "bar"}
+        });
         var map = new OpenLayers.Map('map', { 
             maxExtent: layer.maxExtent,
             units: layer.units,
@@ -65,41 +71,48 @@
             projection: layer.displayProjection,
             StartBounds: layer.initialExtent    
         });
-        map.addLayers([layer]);
+        map.addLayers([layer, layer2]);
     
         //this set represents a few edge cases, and some more specific cases, it is by no means exhaustive,
         var urlSets = [
             { 
                 bounds: new OpenLayers.Bounds(-36787612.973083,-22463925.368666, 43362420.398053,17611091.316902),
-                url: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/0/0/0" 
+                url: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/0/0/0",
+                url2: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/L00/R00000000/C00000000.png"
             },            
             { 
                 bounds: new OpenLayers.Bounds(-31793889.951914,4589319.785415, 8281126.733654,24626828.128199),
-                url: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/1/0/0"
+                url: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/1/0/0",
+                url2: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/L01/R00000000/C00000000.png"
             },            
             { 
                 bounds: new OpenLayers.Bounds(-24639873.181971,12676071.933457, -4602364.839187,22694826.104849),
-                url: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/2/0/0" 
+                url: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/2/0/0",
+                url2: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/L02/R00000000/C00000000.png" 
             },
             { 
                 bounds: new OpenLayers.Bounds(-15521241.455665,11580270.695961, 4516266.887119,21599024.867353),
-                url: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/2/0/1" 
+                url: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/2/0/1",
+                url2: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/L02/R00000000/C00000001.png"
             },                    
             { 
                 bounds: new OpenLayers.Bounds(-9265879.5435993,2870892.9335638, -8639707.4078873,3183979.0014198) ,
-                url: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/7/54/35" 
+                url: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/7/54/35",
+                url2: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/L07/R00000036/C00000023.png"
             },
             { 
                 bounds: new OpenLayers.Bounds(-10741909.131798,4684560.1640365, -10585366.09787,4762831.6810005),
-                url: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/9/195/119" 
+                url: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/9/195/119",
+                url2: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/L09/R000000c3/C00000077.png"
             },
             { 
                 bounds: new OpenLayers.Bounds(-13668958.106938,4456961.2611504, -13512415.07301,4535232.7781144),
-                url: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/9/198/82" 
+                url: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/9/198/82",
+                url2: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/L09/R000000c6/C00000052.png"
             }
         ];
         
-        t.plan( urlSets.length );
+        t.plan( urlSets.length * 2 );
         for(var i=0;i<urlSets.length;i++) 
         {
             var o = urlSets[i];            
@@ -107,6 +120,7 @@
             
             var resultUrl = layer.getURL(o.bounds);            
             t.ok( resultUrl == o.url + "?foo=bar", "correct tile returned for " + o.bounds);        
+            t.ok(layer2.getURL(o.bounds) == o.url2 + "?foo=bar", "correct tile url returned if hexZoom is true for " + o.bounds);
         }
     }    
     


### PR DESCRIPTION
both options seem to be used, so people need to be able to configure whether or not the z-values should be hex-encoded or not.

see also #852
