### PR TITLE
Explicitly bind xmlns-namespaced attributes.

### DIFF
--- a/lib/OpenLayers/Format/SLD/v1.js
+++ b/lib/OpenLayers/Format/SLD/v1.js
@@ -33,7 +33,8 @@ OpenLayers.Format.SLD.v1 = OpenLayers.Class(OpenLayers.Format.Filter.v1_0_0, {
         ogc: "http://www.opengis.net/ogc",
         gml: "http://www.opengis.net/gml",
         xlink: "http://www.w3.org/1999/xlink",
-        xsi: "http://www.w3.org/2001/XMLSchema-instance"
+        xsi: "http://www.w3.org/2001/XMLSchema-instance",
+        xmlns: "http://www.w3.org/2000/xmlns/"
     },
     
     /**
@@ -654,8 +655,14 @@ OpenLayers.Format.SLD.v1 = OpenLayers.Class(OpenLayers.Format.Filter.v1_0_0, {
 
                 // For ArcGIS Server it is necessary to define this
                 // at the root level (see ticket:2166).
-                root.setAttribute("xmlns:ogc", this.namespaces.ogc);
-                root.setAttribute("xmlns:gml", this.namespaces.gml);
+                this.setAttributeNS(
+                    root, this.namespaces.xmlns,
+                    "xmlns:ogc", this.namespaces.ogc
+                );
+                this.setAttributeNS(
+                    root, this.namespaces.xmlns,
+                    "xmlns:gml", this.namespaces.gml
+                );
 
                 // add in optional name
                 if(sld.name) {


### PR DESCRIPTION
This fixes XML serialization in IE11. See also #1220 and #1238.
