### PR TITLE
Conditionally add features to the selectedfeatures of a layer when using selectFeature of ModifyFeatureControl

### DIFF
--- a/lib/OpenLayers/Control/ModifyFeature.js
+++ b/lib/OpenLayers/Control/ModifyFeature.js
@@ -417,8 +417,10 @@ OpenLayers.Control.ModifyFeature = OpenLayers.Class(OpenLayers.Control, {
      * feature - {<OpenLayers.Feature.Vector>} the selected feature.
      */
     selectFeature: function(feature) {
+        var indexOf = OpenLayers.Util.indexOf;
+
         if (this.feature === feature ||
-           (this.geometryTypes && OpenLayers.Util.indexOf(this.geometryTypes,
+           (this.geometryTypes && indexOf(this.geometryTypes,
            feature.geometry.CLASS_NAME) == -1)) {
             return;
         }
@@ -427,7 +429,11 @@ OpenLayers.Control.ModifyFeature = OpenLayers.Class(OpenLayers.Control, {
                 this.unselectFeature(this.feature);
             }
             this.feature = feature;
-            this.layer.selectedFeatures.push(feature);
+
+            if(indexOf(this.layer.selectedFeatures, feature) == -1){
+                this.layer.selectedFeatures.push(feature);
+            }
+
             this.layer.drawFeature(feature, 'select');
             this.modified = false;
             this.resetVertices();


### PR DESCRIPTION
Previously everytime that `selectFeature()` was called (e.g. in standalone mode) it immediately added the passed feature to the `selectedFeatures` array of the configured layer. In our usecase we had a custom `SelectFeature` control, which also modifies that `selectedFeature` array, so that after calling `selectFeature()` of the `ModifyFeature` control we end up with duplicates.
