### PR TITLE
Promote several properties to API properties.

### DIFF
--- a/lib/OpenLayers/Control/SelectFeature.js
+++ b/lib/OpenLayers/Control/SelectFeature.js
@@ -40,14 +40,14 @@ OpenLayers.Control.SelectFeature = OpenLayers.Class(OpenLayers.Control, {
      */
 
     /**
-     * Property: multipleKey
+     * APIProperty: multipleKey
      * {String} An event modifier ('altKey' or 'shiftKey') that temporarily sets
      *     the <multiple> property to true.  Default is null.
      */
     multipleKey: null,
 
     /**
-     * Property: toggleKey
+     * APIProperty: toggleKey
      * {String} An event modifier ('altKey' or 'shiftKey') that temporarily sets
      *     the <toggle> property to true.  Default is null.
      */
@@ -95,7 +95,7 @@ OpenLayers.Control.SelectFeature = OpenLayers.Class(OpenLayers.Control, {
     box: false,
 
     /**
-     * Property: onBeforeSelect
+     * APIProperty: onBeforeSelect
      * {Function} Optional function to be called before a feature is selected.
      *     The function should expect to be called with a feature.
      */
@@ -116,7 +116,7 @@ OpenLayers.Control.SelectFeature = OpenLayers.Class(OpenLayers.Control, {
     onUnselect: function() {},
 
     /**
-     * Property: scope
+     * APIProperty: scope
      * {Object} The scope to use with the onBeforeSelect, onSelect, onUnselect
      *     callbacks. If null the scope will be this control.
      */
@@ -158,7 +158,7 @@ OpenLayers.Control.SelectFeature = OpenLayers.Class(OpenLayers.Control, {
     selectStyle: null,
 
     /**
-     * Property: renderIntent
+     * APIProperty: renderIntent
      * {String} key used to retrieve the select style from the layer's
      * style map.
      */


### PR DESCRIPTION
The properties `multipleKey` and `toggleKey` are used inside the examples
and therefore publicly known anyhow. The properties `onBeforeSelect` and
`scope` are changed to be part of the API for consistency (e.g. `onUnselect`
is part of the API already) and usefullness (we allow the `scope` to be
defined elsewhere in the library as well). The property `renderIntent` is
being promoted as it is very useful and a nice complimentary of the already
public `selectStyle`.
