### PR TITLE
Google maps webkit svg bug

### DIFF
--- a/lib/OpenLayers/Renderer/SVG.js
+++ b/lib/OpenLayers/Renderer/SVG.js
@@ -450,10 +450,6 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
     createRenderRoot: function() {
         var svg = this.nodeFactory(this.container.id + "_svgRoot", "svg");
         svg.style.display = "block";
-
-        if (window.google && window.google.maps && window.google.maps.Map) {
-            svg.style['-webkit-transform'] = 'translateZ(0)';
-        }
         return svg;
     },
 

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -534,6 +534,11 @@ div.olControlTextButtonPanel.vertical .olButton:last-child {
     perspective: 1000;
 }
 
+/* Turn on GPU acceleration for webkit when Google Maps V3 base layer is present */
+.olForeignContainer svg {
+    -webkit-transform: translateZ(0);
+}
+
 /* when replacing tiles, do not show tile and backbuffer at the same time */
 .olTileReplacing {
     display: none;


### PR DESCRIPTION
This PR addresses the issue outlined in https://github.com/openlayers/openlayers/issues/1207.

I've added a manual test that demonstrates the issue as well as a fix. However, I'm not 100% sure the fix is in the right place. The problem is solved by turning on GPU acceleration when Google Maps V3 base layer is present. 

I could have put a style declaration in the default theme css but I guess not everyone will include it when using OL. So, I've put some logic in the SVG renderer. It checks for the presence of google.maps.Map and if present, adds the style declaration to turn on GPU acceleration. Part of me thinks it shouldn't be here - the render shouldn't need to know about any external global objects i.e. google, but couldn't think of a better place to put it.
