### PR TITLE
Added additional capabilities to Format.WKT.write. When writing to WKT t...

### DIFF
--- a/lib/OpenLayers/Format/WKT.js
+++ b/lib/OpenLayers/Format/WKT.js
@@ -96,11 +96,16 @@ OpenLayers.Format.WKT = OpenLayers.Class(OpenLayers.Format, {
      * Parameters:
      * features - {<OpenLayers.Feature.Vector>|Array} A feature or array of
      *            features
+     * places - {Number} Optional. The number of places to print out to the WKT representation
+     * source - {String} Optional. The source projection to be transformed from.
+     * destination - {String} Optional. The destination projection to be transformed to.
+     *             If source is specified but destination is not, destination is assumed to be
+     *             "EPSG:4326"
      *
      * Returns:
      * {String} The WKT string representation of the input geometries
      */
-    write: function(features) {
+    write: function(features, places, source, destination) {
         var collection, geometry, isCollection;
         if (features.constructor == Array) {
             collection = features;
@@ -118,7 +123,7 @@ OpenLayers.Format.WKT = OpenLayers.Class(OpenLayers.Format, {
                 pieces.push(',');
             }
             geometry = collection[i].geometry;
-            pieces.push(this.extractGeometry(geometry));
+            pieces.push(this.extractGeometry(geometry, places, source, destination));
         }
         if (isCollection) {
             pieces.push(')');
@@ -132,11 +137,16 @@ OpenLayers.Format.WKT = OpenLayers.Class(OpenLayers.Format, {
      *
      * Parameters:
      * geometry - {<OpenLayers.Geometry.Geometry>}
+     * places - {Number} Optional. The number of places to print out to the WKT representation
+     * source - {String} Optional. The source projection to be transformed from.
+     * destination - {String} Optional. The destination projection to be transformed to.
+     *             If source is specified but destination is not, destination is assumed to be
+     *             "EPSG:4326"
      *
      * Returns:
      * {String} A WKT string of representing the geometry
      */
-    extractGeometry: function(geometry) {
+    extractGeometry: function(geometry, places, source, destination) {
         var type = geometry.CLASS_NAME.split('.')[2].toLowerCase();
         if (!this.extract[type]) {
             return null;
@@ -146,7 +156,7 @@ OpenLayers.Format.WKT = OpenLayers.Class(OpenLayers.Format, {
             geometry.transform(this.internalProjection, this.externalProjection);
         }                       
         var wktType = type == 'collection' ? 'GEOMETRYCOLLECTION' : type.toUpperCase();
-        var data = wktType + '(' + this.extract[type].apply(this, [geometry]) + ')';
+        var data = wktType + '(' + this.extract[type].apply(this, [geometry, places, source, destination]) + ')';
         return data;
     },
     
@@ -158,23 +168,41 @@ OpenLayers.Format.WKT = OpenLayers.Class(OpenLayers.Format, {
         /**
          * Return a space delimited string of point coordinates.
          * @param {OpenLayers.Geometry.Point} point
+         * @param {Number} places - Optional. The number of places to print out to the WKT representation
+         * @param {String} source - Optional. The source projection to be transformed from.
+         * @param {String} destination - Optional. The destination projection to be transformed to.
+         *             If source is specified but destination is not, destination is assumed to be
+         *             "EPSG:4326"
          * @returns {String} A string of coordinates representing the point
          */
-        'point': function(point) {
+        'point': function(point, places, source, destination) {
+            if (source) {
+                if (!destination)
+                    destination = "EPSG:4326";
+                point = point.clone();
+                new OpenLayers.Projection.transform(point, source, destination);
+            }
+            if (typeof (places) === 'number')
+                return point.x.toFixed(places) + ' ' + point.y.toFixed(places);
             return point.x + ' ' + point.y;
         },
 
         /**
          * Return a comma delimited string of point coordinates from a multipoint.
          * @param {OpenLayers.Geometry.MultiPoint} multipoint
+         * @param {Number} places - Optional. The number of places to print out to the WKT representation
+         * @param {String} source - Optional. The source projection to be transformed from.
+         * @param {String} destination - Optional. The destination projection to be transformed to.
+         *             If source is specified but destination is not, destination is assumed to be
+         *             "EPSG:4326"
          * @returns {String} A string of point coordinate strings representing
          *                  the multipoint
          */
-        'multipoint': function(multipoint) {
+        'multipoint': function(multipoint, places, source, destination) {
             var array = [];
             for(var i=0, len=multipoint.components.length; i<len; ++i) {
                 array.push('(' +
-                           this.extract.point.apply(this, [multipoint.components[i]]) +
+                           this.extract.point.apply(this, [multipoint.components[i], places, source, destination]) +
                            ')');
             }
             return array.join(',');
@@ -183,13 +211,18 @@ OpenLayers.Format.WKT = OpenLayers.Class(OpenLayers.Format, {
         /**
          * Return a comma delimited string of point coordinates from a line.
          * @param {OpenLayers.Geometry.LineString} linestring
+         * @param {Number} places - Optional. The number of places to print out to the WKT representation
+         * @param {String} source - Optional. The source projection to be transformed from.
+         * @param {String} destination - Optional. The destination projection to be transformed to.
+         *             If source is specified but destination is not, destination is assumed to be
+         *             "EPSG:4326"
          * @returns {String} A string of point coordinate strings representing
          *                  the linestring
          */
-        'linestring': function(linestring) {
+        'linestring': function(linestring, places, source, destination) {
             var array = [];
             for(var i=0, len=linestring.components.length; i<len; ++i) {
-                array.push(this.extract.point.apply(this, [linestring.components[i]]));
+                array.push(this.extract.point.apply(this, [linestring.components[i], places, source, destination]));
             }
             return array.join(',');
         },
@@ -197,14 +230,19 @@ OpenLayers.Format.WKT = OpenLayers.Class(OpenLayers.Format, {
         /**
          * Return a comma delimited string of linestring strings from a multilinestring.
          * @param {OpenLayers.Geometry.MultiLineString} multilinestring
+         * @param {Number} places - Optional. The number of places to print out to the WKT representation
+         * @param {String} source - Optional. The source projection to be transformed from.
+         * @param {String} destination - Optional. The destination projection to be transformed to.
+         *             If source is specified but destination is not, destination is assumed to be
+         *             "EPSG:4326"
          * @returns {String} A string of of linestring strings representing
          *                  the multilinestring
          */
-        'multilinestring': function(multilinestring) {
+        'multilinestring': function(multilinestring, places, source, destination) {
             var array = [];
             for(var i=0, len=multilinestring.components.length; i<len; ++i) {
                 array.push('(' +
-                           this.extract.linestring.apply(this, [multilinestring.components[i]]) +
+                           this.extract.linestring.apply(this, [multilinestring.components[i], places, source, destination]) +
                            ')');
             }
             return array.join(',');
@@ -213,13 +251,18 @@ OpenLayers.Format.WKT = OpenLayers.Class(OpenLayers.Format, {
         /**
          * Return a comma delimited string of linear ring arrays from a polygon.
          * @param {OpenLayers.Geometry.Polygon} polygon
+         * @param {Number} places - Optional. The number of places to print out to the WKT representation
+         * @param {String} source - Optional. The source projection to be transformed from.
+         * @param {String} destination - Optional. The destination projection to be transformed to.
+         *             If source is specified but destination is not, destination is assumed to be
+         *             "EPSG:4326"
          * @returns {String} An array of linear ring arrays representing the polygon
          */
-        'polygon': function(polygon) {
+        'polygon': function(polygon, places, source, destination) {
             var array = [];
             for(var i=0, len=polygon.components.length; i<len; ++i) {
                 array.push('(' +
-                           this.extract.linestring.apply(this, [polygon.components[i]]) +
+                           this.extract.linestring.apply(this, [polygon.components[i], places, source, destination]) +
                            ')');
             }
             return array.join(',');
@@ -228,14 +271,19 @@ OpenLayers.Format.WKT = OpenLayers.Class(OpenLayers.Format, {
         /**
          * Return an array of polygon arrays from a multipolygon.
          * @param {OpenLayers.Geometry.MultiPolygon} multipolygon
+         * @param {Number} places - Optional. The number of places to print out to the WKT representation
+         * @param {String} source - Optional. The source projection to be transformed from.
+         * @param {String} destination - Optional. The destination projection to be transformed to.
+         *             If source is specified but destination is not, destination is assumed to be
+         *             "EPSG:4326"
          * @returns {String} An array of polygon arrays representing
          *                  the multipolygon
          */
-        'multipolygon': function(multipolygon) {
+        'multipolygon': function(multipolygon, places, source, destination) {
             var array = [];
             for(var i=0, len=multipolygon.components.length; i<len; ++i) {
                 array.push('(' +
-                           this.extract.polygon.apply(this, [multipolygon.components[i]]) +
+                           this.extract.polygon.apply(this, [multipolygon.components[i], places, source, destination]) +
                            ')');
             }
             return array.join(',');
@@ -244,12 +292,17 @@ OpenLayers.Format.WKT = OpenLayers.Class(OpenLayers.Format, {
         /**
          * Return the WKT portion between 'GEOMETRYCOLLECTION(' and ')' for an <OpenLayers.Geometry.Collection>
          * @param {OpenLayers.Geometry.Collection} collection
+         * @param {Number} places - Optional. The number of places to print out to the WKT representation
+         * @param {String} source - Optional. The source projection to be transformed from.
+         * @param {String} destination - Optional. The destination projection to be transformed to.
+         *             If source is specified but destination is not, destination is assumed to be
+         *             "EPSG:4326"
          * @returns {String} internal WKT representation of the collection
          */
-        'collection': function(collection) {
+        'collection': function(collection, places, source, destination) {
             var array = [];
             for(var i=0, len=collection.components.length; i<len; ++i) {
-                array.push(this.extractGeometry.apply(this, [collection.components[i]]));
+                array.push(this.extractGeometry.apply(this, [collection.components[i], places, source, destination]));
             }
             return array.join(',');
         }


### PR DESCRIPTION
...he user now has the ability to specify the number of decimal places to include in the output and the option of specifying the projection of the output geometry.

Three optional parameters where added: places, source, and destination. If source is provided but destination is not, destination is assumed to be "EPSG:4326". Reprojection is limited to the transformations available to OpenLayers.
