### PR TITLE
Added a fix for geometry collections which cross the 180

### DIFF
--- a/lib/OpenLayers/Renderer/Canvas.js
+++ b/lib/OpenLayers/Renderer/Canvas.js
@@ -209,7 +209,7 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
             (className == "OpenLayers.Geometry.MultiPolygon")) {
             var worldBounds = (this.map.baseLayer && this.map.baseLayer.wrapDateLine) && this.map.getMaxExtent();
             for (var i = 0; i < geometry.components.length; i++) {
-				this.calculateFeatureDx(geometry.components[i].getBounds(), worldBounds);
+                this.calculateFeatureDx(geometry.components[i].getBounds(), worldBounds);
                 this.drawGeometry(geometry.components[i], style, featureId);
             }
             return;


### PR DESCRIPTION
When a geometry collection crossed the 180, featureDx was not being recalculated which meant all parts weren't being drawn correctly.
