### PR TITLE
Use protocol relative URL for OSM tiles

### DIFF
--- a/lib/OpenLayers/Layer/OSM.js
+++ b/lib/OpenLayers/Layer/OSM.js
@@ -35,8 +35,8 @@ OpenLayers.Layer.OSM = OpenLayers.Class(OpenLayers.Layer.XYZ, {
 
     /**
      * APIProperty: url
-     * {String} The tileset URL scheme. Defaults to
-     * : http://[a|b|c].tile.openstreetmap.org/${z}/${x}/${y}.png
+     * {String} The tileset URL scheme. Defaults to (protocol relative url):
+     *  //[a|b|c].tile.openstreetmap.org/${z}/${x}/${y}.png 
      * (the official OSM tileset) if the second argument to the constructor
      * is null or undefined. To use another tileset you can have something
      * like this:
@@ -48,16 +48,16 @@ OpenLayers.Layer.OSM = OpenLayers.Class(OpenLayers.Layer.XYZ, {
      * (end)
      */
     url: [
-        'http://a.tile.openstreetmap.org/${z}/${x}/${y}.png',
-        'http://b.tile.openstreetmap.org/${z}/${x}/${y}.png',
-        'http://c.tile.openstreetmap.org/${z}/${x}/${y}.png'
+        '//a.tile.openstreetmap.org/${z}/${x}/${y}.png',
+        '//b.tile.openstreetmap.org/${z}/${x}/${y}.png',
+        '//c.tile.openstreetmap.org/${z}/${x}/${y}.png'
     ],
 
     /**
      * Property: attribution
      * {String} The layer attribution.
      */
-    attribution: "&copy; <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors",
+    attribution: "&copy; <a href='//www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors",
 
     /**
      * Property: sphericalMercator


### PR DESCRIPTION
OpenStreetMap have enabled SSL on their services and website. Using protocol relative URLs for the tiles takes advantage of this work out of the box.

see: 
- OSM blog: http://blog.openstreetmap.org/2014/02/11/osm-enhances-user-privacy/
- specification: [IETF RFC 3986](http://www.ietf.org/rfc/rfc3986.txt) section 4.2
