### PR TITLE
use button elements instead of anchor elements and add tooltips to zoomcontrol

### DIFF
--- a/lib/OpenLayers/Control/Zoom.js
+++ b/lib/OpenLayers/Control/Zoom.js
@@ -88,21 +88,23 @@ OpenLayers.Control.Zoom = OpenLayers.Class(OpenLayers.Control, {
         var zoomIn = document.getElementById(this.zoomInId),
             zoomOut = document.getElementById(this.zoomOutId);
         if (!zoomIn) {
-            zoomIn = document.createElement("a");
-            zoomIn.href = "#zoomIn";
-            zoomIn.appendChild(document.createTextNode(this.zoomInText));
-            zoomIn.className = "olControlZoomIn";
+            zoomIn = document.createElement("button");
+            zoomIn.name = "ZoomIn";
+            zoomIn.type = "button";
+            zoomIn.insertAdjacentHTML("afterbegin", '<span role="tooltip">' 
+                        + OpenLayers.i18n("Zoom in") + '</span>' + this.zoomInText);
             el.appendChild(zoomIn);
         }
-        OpenLayers.Element.addClass(zoomIn, "olButton");
+        OpenLayers.Element.addClass(zoomIn, "olControlZoomIn olButton olHasToolTip");
         if (!zoomOut) {
-            zoomOut = document.createElement("a");
-            zoomOut.href = "#zoomOut";
-            zoomOut.appendChild(document.createTextNode(this.zoomOutText));
-            zoomOut.className = "olControlZoomOut";
+            zoomOut = document.createElement("button");
+            zoomOut.name = "ZoomOut";
+            zoomOut.type = "button";
+            zoomOut.insertAdjacentHTML("afterbegin", '<span role="tooltip">' 
+                        + OpenLayers.i18n("Zoom out") + '</span>' + this.zoomOutText);
             el.appendChild(zoomOut);
         }
-        OpenLayers.Element.addClass(zoomOut, "olButton");
+        OpenLayers.Element.addClass(zoomOut, "olControlZoomOut olButton olHasToolTip");
         return {
             zoomIn: zoomIn, zoomOut: zoomOut
         };

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -444,14 +444,14 @@ div.olControlZoom, div.olControlTextButtonPanel {
     border-radius: 4px;
     padding: 2px;
 }
-div.olControlZoom a {
+div.olControlZoom button {
     font-size: 18px;
     line-height: 19px;
     height: 22px;
     width:22px;
     padding: 0;
 }
-div.olControlZoom a, div.olControlTextButtonPanel .olButton {
+div.olControlZoom button, div.olControlTextButtonPanel .olButton {
     display: block;
     margin: 1px;
     color: white;
@@ -463,20 +463,23 @@ div.olControlZoom a, div.olControlTextButtonPanel .olButton {
     background: rgba(0, 60, 136, 0.5);
     filter: alpha(opacity=80);
 }
-div.olControlZoom a:hover, div.olControlTextButtonPanel .olButton:hover {
+div.olControlZoom button {
+    border: 0;
+}
+div.olControlZoom button:hover, div.olControlZoom button:focus, div.olControlTextButtonPanel .olButton:hover {
     background: #130085; /* fallback for IE */
     background: rgba(0, 60, 136, 0.7);
     filter: alpha(opacity=100);
 }
 @media only screen and (max-width: 600px) {
-    div.olControlZoom a:hover, div.olControlTextButtonPanel .olButton:hover {
+    div.olControlZoom button:hover, div.olControlZoom button:focus, div.olControlTextButtonPanel .olButton:hover {
         background: rgba(0, 60, 136, 0.5);
     }
 }
-a.olControlZoomIn {
+button.olControlZoomIn {
     border-radius: 4px 4px 0 0;
 }
-a.olControlZoomOut {
+button.olControlZoomOut {
     border-radius: 0 0 4px 4px;
 }
 
@@ -542,4 +545,44 @@ div.olControlTextButtonPanel.vertical .olButton:last-child {
 /* override any max-width image settings (e.g. bootstrap.css) */
 img.olTileImage {
     max-width: none;
+}
+
+/* invisible but not hidden */
+.olHasToolTip span, .olHasToolTip_b_r span {
+    position: absolute;
+    clip: rect(1px 1px 1px 1px); /* < IE8 */
+    clip: rect(1px, 1px, 1px, 1px);
+    padding: 0;
+    border: 0;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    font-weight: normal;
+    font-size: 16px;
+}
+
+/* show a tooltip offset to below and right */
+.olHasToolTip:hover span, .olHasToolTip:focus span ,
+.olHasToolTip_b_r:hover span , .olHasToolTip_b_r:focus span  {
+    clip: auto;
+    padding: 3px;
+    height: auto;
+    width: auto;
+    z-index: 1100;
+    max-height: 100px;
+    white-space: nowrap;
+    display: inline-block;
+    background-color: #eee;
+    color: #000;
+    border: 1px solid #333;
+    -webkit-border-radius: 5px; 
+    -moz-border-radius: 5px; 
+    -ms-border-radius: 5px; 
+    -o-border-radius: 5px; 
+    border-radius: 5px; 
+    -webkit-box-shadow: 2px 2px 2px #333; 
+    -moz-box-shadow: 2px 2px 2px #333; 
+    box-shadow: 2px 2px 2px #333; 
+    bottom: -2em;
+    left: 1em;
 }


### PR DESCRIPTION
TL;DR: if it is a button it should be a button.

Using the correct semantics serves accessiblity and adding a tooltip (which is screen reader accessible) makes the button easier to understand for everyone. Also proper focus handling is important for keyboard users since the have no `:hover` event

the tooltip can be easily disabled by removing the `:focus` and `:hover` pseudo classes or  using some simple css to override those.

more background in: http://www.geodienstencentrum.nl/blog/accessibility/webmapping/2014-02-14/enhancing-openlayers-controls.html

