### PR TITLE
Fix to the calculation of linear rings over the 180 line

### DIFF
--- a/lib/OpenLayers/Geometry/LinearRing.js
+++ b/lib/OpenLayers/Geometry/LinearRing.js
@@ -282,7 +282,15 @@ OpenLayers.Geometry.LinearRing = OpenLayers.Class(
             for(var i=0; i<len-1; i++) {
                 p1 = ring.components[i];
                 p2 = ring.components[i+1];
-                area += OpenLayers.Util.rad(p2.x - p1.x) *
+                var d = p2.x - p1.x;
+                if (Math.abs(d) > 180) {
+                    if (d > 0) {
+                        d += -360;
+                    } else {
+                        d += 360;
+                    }
+                }
+                area += OpenLayers.Util.rad(d) *
                         (2 + Math.sin(OpenLayers.Util.rad(p1.y)) +
                         Math.sin(OpenLayers.Util.rad(p2.y)));
             }


### PR DESCRIPTION
There was an issue when trying to use a linear ring to calculate distance or area over the 180 line.  This fixes those calculations
