### PR TITLE
Fix shouldDraw in case tile was destroyed (null layer)

### DIFF
--- a/lib/OpenLayers/Tile.js
+++ b/lib/OpenLayers/Tile.js
@@ -225,7 +225,7 @@ OpenLayers.Tile = OpenLayers.Class({
      */
     shouldDraw: function() {        
         var withinMaxExtent = false,
-            maxExtent = this.layer.maxExtent;
+            maxExtent = this.layer && this.layer.maxExtent;
         if (maxExtent) {
             var map = this.layer.map;
             var worldBounds = map.baseLayer.wrapDateLine && map.getMaxExtent();
@@ -234,7 +234,7 @@ OpenLayers.Tile = OpenLayers.Class({
             }
         }
         
-        return withinMaxExtent || this.layer.displayOutsideMaxExtent;
+        return withinMaxExtent || (this.layer && this.layer.displayOutsideMaxExtent);
     },
     
     /**


### PR DESCRIPTION
In some cases an tiles seem to still be queued in the tile manager after they have been destroyed.

I've not been able to work out exactly the circumstances (although I can reproduce them), but this pull request is a band-aid to prevent an error in the case that shouldDraw() is called on a Tile which has a null layer (e.g. after being destroyed).
