### PR TITLE
Example for WFS DescribeFeatureType parser

### DIFF
--- a/examples/wfs-describefeaturetype.html
+++ b/examples/wfs-describefeaturetype.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <title>OpenLayers WFSDescribeFeatureType Parser Example</title>
+    <link rel="stylesheet" href="style.css" type="text/css">
+    <script src="../OpenLayers.js"></script>
+    <script type="text/javascript">
+        function parseData(req) {
+            format = new OpenLayers.Format.WFSDescribeFeatureType();
+            html = "<br>";
+            resp = format.read(req.responseText);
+            var featureTypes = resp.featureTypes;
+            for (var i = 0; i < featureTypes.length; i++) {
+                html += "typeName: " + featureTypes[i].typeName;
+                for (var j = 0; j < featureTypes[i].properties.length; j++) {
+                    html += "<ul>";
+                    html += "<li>name: " + featureTypes[i].properties[j].name + "</li>";
+                    html += "<li>localType: " + featureTypes[i].properties[j].localType + "</li>";
+                    html += "<li>nillable: " + featureTypes[i].properties[j].nillable + "</li>";
+                    html += "</ul>"
+                }
+            }
+            document.getElementById('output').innerHTML = html;
+        }
+        function load() {
+            OpenLayers.Request.GET({
+                url: "xml/wfsdescribefeaturetype.xml",
+                success: parseData
+            });
+        }
+    </script>
+</head>
+<body onload="load()">
+<h1 id="title">WFSDescribeFeatureType Parser Example</h1>
+
+<div id="tags">
+    wfsdescribefeaturetype, parser, cleanup
+</div>
+
+<p id="shortdesc">
+    Demonstrate the operation of the WFSDescribeFeatureType parser.
+</p>
+
+<div id="output"></div>
+
+<div id="docs">
+    <p>This script reads data from a file and parses out attributes on a typeName,
+        appending them to a HTML string with markup tags. This markup is
+        dumped to an element in the page.</p>
+</div>
+</body>
+</html>

--- a/examples/xml/wfsdescribefeaturetype.xml
+++ b/examples/xml/wfsdescribefeaturetype.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:samplews="http://www.samplews.org/" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" targetNamespace="http://www.samplews.org/">
+    <xsd:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+    <xsd:complexType name="sample-layer">
+        <xsd:complexContent>
+            <xsd:extension base="gml:AbstractFeatureType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="the_geom" nillable="true" type="gml:PointPropertyType"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="AREA" nillable="true" type="xsd:double"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="PERIMETER" nillable="true" type="xsd:double"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="ID" nillable="true" type="xsd:long"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="LAT" nillable="true" type="xsd:double"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="LONG" nillable="true" type="xsd:double"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="DATE" nillable="true" type="xsd:dateTime"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="JULIAN" nillable="true" type="xsd:int"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="GMT" nillable="true" type="xsd:int"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="TEMP" nillable="true" type="xsd:double"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="SRC" nillable="true" type="xsd:string"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="CONF" nillable="true" type="xsd:int"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:element name="sample-layer" substitutionGroup="gml:_Feature" type="samplews:sample-layer"/>
+</xsd:schema>


### PR DESCRIPTION
There was no existing example for how to use the OpenLayers.Format.WFSDescribeFeatureType class, so I created the following HTML and supporting XML.  I thought this would be useful to others needing to take advantage of that OpenLayer parser's functionality.
