### PR TITLE
useTiltImages property to control Google's use of 45° images

### DIFF
--- a/lib/OpenLayers/Layer/Google.js
+++ b/lib/OpenLayers/Layer/Google.js
@@ -92,8 +92,8 @@ OpenLayers.Layer.Google = OpenLayers.Class(
      *     other maps, etc. 
      */
     sphericalMercator: false, 
-	
-	/**
+    
+    /**
      * APIProperty: useTiltImages
      * {Boolean} Should Google use 45° (tilt) imagery when available or 
      *     should it stick to the 0° overhead view? While tilt images look

--- a/lib/OpenLayers/Layer/Google/v3.js
+++ b/lib/OpenLayers/Layer/Google/v3.js
@@ -92,7 +92,7 @@ OpenLayers.Layer.Google.v3 = {
                 disableDoubleClickZoom: true,
                 scrollwheel: false,
                 streetViewControl: false,
-				tilt: (this.useTiltImages ? 45: 0)
+                tilt: (this.useTiltImages ? 45: 0)
             });
             var googleControl = document.createElement('div');
             googleControl.style.width = '100%';


### PR DESCRIPTION
refers to issue #1264
