### PR TITLE
support for projectionless maps was broken

### DIFF
--- a/lib/OpenLayers/Layer.js
+++ b/lib/OpenLayers/Layer.js
@@ -636,8 +636,12 @@ OpenLayers.Layer = OpenLayers.Class({
 
             // Check the projection to see if we can get units -- if not, refer
             // to properties.
-            this.units = this.projection.getUnits() ||
-                         this.units || this.map.units;
+            if (this.projection && this.projection.getUnits()) {
+                this.units = this.projection.getUnits();
+            }
+            else {
+                this.units = this.units || this.map.units;
+            }
             
             this.initResolutions();
             


### PR DESCRIPTION
We had to monkey-patch Layer.setMap(), because we were using a projectionless layer {projection:null, units: 'm'}, where the map only knows the units of the layer. According to the docs, this should work, but we were getting a JS error in .setMap()/Line 639, because OpenLayers tries to extract the units from the projection object.
