### PR TITLE
Prevent requests for "negative" wmts tiles

### DIFF
--- a/lib/OpenLayers/Layer/WMTS.js
+++ b/lib/OpenLayers/Layer/WMTS.js
@@ -416,6 +416,10 @@ OpenLayers.Layer.WMTS = OpenLayers.Class(OpenLayers.Layer.Grid, {
             var info = this.getTileInfo(center);
             var matrixId = this.matrix.identifier;
             var dimensions = this.dimensions, params;
+            //prevent the request of negative tiles or those that exceed the given matrixWidth/matrixHeight
+            if (info.row < 0 || info.col < 0 || info.row > matrixSet.matrixWidth || info.col > matrixSet.matrixHeight){
+                return url
+            }
 
             if (OpenLayers.Util.isArray(this.url)) {
                 url = this.selectUrl([


### PR DESCRIPTION
Prevent requests for tiles with negative row/col indices or those that exceed matrixWidth or matrixHeight. Motivation: WMTS spec doesn't allow negative row/col indices and the current bounds checks in .getUrl don't prevent requests for such tiles.
