### PR TITLE
Fix typos in comments

### DIFF
--- a/build/lite.cfg
+++ b/build/lite.cfg
@@ -1,6 +1,6 @@
 # This file includes a small subset of OpenLayers code, designed to be
 # integrated into another application. It includes only the Layer types
-# neccesary to create tiled or untiled WMS, and does not include any Controls.
+# necessary to create tiled or untiled WMS, and does not include any Controls.
 # This is the result of what was at the time called "Webmap.js" at the FOSS4G
 # Web Mapping BOF.
 

--- a/examples/clientzoom.html
+++ b/examples/clientzoom.html
@@ -54,7 +54,7 @@
             <code>fractionalZoom</code> set to true. So "client zoom" also
             applies if you choose arbitrary zoom levels using the slider of the
             zoom bar, or shift-drag boxes to zoom to arbitrary extents.
-            "client zoom" therefore allows continous zooming for tiled layers.
+            "client zoom" therefore allows continuous zooming for tiled layers.
 
             </p>
 

--- a/examples/example-list.html
+++ b/examples/example-list.html
@@ -7,7 +7,7 @@
         <!-- This is the example list source: if you are trying to look at the 
         source of an example, YOU ARE IN THE WRONG PLACE. If you want to view
         the source of just one example, you can typically choose 
-        "This Frame -> View source" when right clicking on the exmaple. If not,
+        "This Frame -> View source" when right clicking on the example. If not,
         choose to open the example in a new window (via the context menu 
         click on the link), and view source from there. -->  
         <title>OpenLayers Examples</title>

--- a/examples/markersTextLayer.html
+++ b/examples/markersTextLayer.html
@@ -33,7 +33,7 @@
         textlayer, csv, tsv, basic, popup
     </div>
     <p id="shortdesc">
-      The Layer.Text class reads a Tab seperated values file and displays it as markers on
+      The Layer.Text class reads a Tab separated values file and displays it as markers on
       the map.
     </p>  
     <div id="map" class="smallmap"></div>

--- a/examples/ordering.html
+++ b/examples/ordering.html
@@ -192,7 +192,7 @@
                 </td>
                 <td>
                     <div class="docs">
-                        In this map, the gold features all have the same z-index, and the red features have alternating z-indeces. The gold features' z-index is greater than the red features' z-indeces, which is why gold features look to be drawn on top of the red features. Since each gold feature has the same z-index, gold features succomb to y-ordering: this is where features that seem closest to the viewer (lower lattitude) show up above those that seem farther away (higher lattitude).
+                        In this map, the gold features all have the same z-index, and the red features have alternating z-indeces. The gold features' z-index is greater than the red features' z-indeces, which is why gold features look to be drawn on top of the red features. Since each gold feature has the same z-index, gold features succomb to y-ordering: this is where features that seem closest to the viewer (lower latitude) show up above those that seem farther away (higher latitude).
                         <br><br>
                         You can enable y-ordering by passing the parameter <i>yOrdering: true</i> in the vector layer's options hash. For all configurations (with yOrdering or zIndexing set to true), if features have the same z-index -- and if y-ordering is enabled: the same latitude -- those features will succomb to drawing order, where the last feature to be drawn will appear above the rest.
                     </div>

--- a/examples/overviewmap.html
+++ b/examples/overviewmap.html
@@ -62,7 +62,7 @@
         // getting these settings initialized from map1.
         var jplOverview = jpl.clone();
         
-        // A more detailled layer of Manhattan for map2
+        // A more detailed layer of Manhattan for map2
         var ny = new OpenLayers.Layer.WMS(
             "Manhattan", 
             "http://demo.opengeo.org/geoserver/wms",

--- a/examples/simplify-linestring.html
+++ b/examples/simplify-linestring.html
@@ -50,7 +50,7 @@
             <p>
                 Instances of OpenLayers.Geometry.LineString have a method simplify,
                 that can be used to simplify linestring geometries.
-                Simplification sometimes is useful to enhance the perfomance of 
+                Simplification sometimes is useful to enhance the performance of 
                 vector rendering or to reduce complexity of geometries. This 
                 might be especially handy when viewing geometries a small 
                 scales.  
@@ -83,7 +83,7 @@
                 example implementation of the algorithm in python</a>.
             </p>
             <p>
-                For a detailled explanation of the algorithm see 
+                For a detailed explanation of the algorithm see 
                 <a href="http://en.wikipedia.org/wiki/Douglas-Peucker_algorithm">the
                 Wikipedia article</a> or the original publication: David Douglas 
                 &amp; Thomas Peucker, "Algorithms for the reduction of the 

--- a/examples/simplify-linestring.js
+++ b/examples/simplify-linestring.js
@@ -1,7 +1,7 @@
 // global variables
 var map, map2;
 
-// wrap the instanciation code in an anonymous function that gets executed
+// wrap the instantiation code in an anonymous function that gets executed
 // immedeately
 (function(){
     // style the vectorlayer

--- a/examples/strategy-cluster-extended.html
+++ b/examples/strategy-cluster-extended.html
@@ -111,7 +111,7 @@
                 </li>
             </ul>
             <p>
-                Hover over the features to get a short infomation about the 
+                Hover over the features to get a short information about the 
                 feature or cluster of features. 
             </p>
         </div>

--- a/examples/strategy-cluster-extended.js
+++ b/examples/strategy-cluster-extended.js
@@ -67,7 +67,7 @@ OpenLayers.Strategy.RuleCluster = OpenLayers.Class(OpenLayers.Strategy.Cluster, 
 // global variables
 var map, vectorlayer, features, stylemap, select;
 
-// wrap the instanciation code in an anonymous function that gets executed
+// wrap the instantiation code in an anonymous function that gets executed
 // immeadeately
 (function(){
 

--- a/examples/styles-context.html
+++ b/examples/styles-context.html
@@ -108,7 +108,7 @@
         <p>Features in the northern hemisphere are styled according to their
         "type" attribute.  This is accomplished with a simple template that
         is evaluated with the feature attributes as context.</p>
-        <p>Features in the sourthern hemisphere are styled according to a
+        <p>Features in the southern hemisphere are styled according to a
         combination of their attributes and non-attribute properties.  This
         is accomplished using an advanced template that calls functions
         on the context object passed to the Style constructor.</p>

--- a/lib/OpenLayers/Console.js
+++ b/lib/OpenLayers/Console.js
@@ -16,7 +16,7 @@
  * cross-browser debugging Firebug style.
  *
  * Note:
- * Note that behavior will differ with the Firebug extention and Firebug Lite.
+ * Note that behavior will differ with the Firebug extension and Firebug Lite.
  * Most notably, the Firebug Lite console does not currently allow for
  * hyperlinks to code or for clicking on object to explore their properties.
  * 

--- a/lib/OpenLayers/Control/Geolocate.js
+++ b/lib/OpenLayers/Control/Geolocate.js
@@ -164,7 +164,7 @@ OpenLayers.Control.Geolocate = OpenLayers.Class(OpenLayers.Control, {
      * APIMethod: getCurrentLocation
      *
      * Returns:
-     * {Boolean} Returns true if a event will be fired (successfull
+     * {Boolean} Returns true if a event will be fired (successful
      * registration)
      */
     getCurrentLocation: function() {

--- a/lib/OpenLayers/Control/GetFeature.js
+++ b/lib/OpenLayers/Control/GetFeature.js
@@ -557,7 +557,7 @@ OpenLayers.Control.GetFeature = OpenLayers.Class(OpenLayers.Control, {
      * Unselect all selected features.
      */
     unselectAll: function() {
-        // we'll want an option to supress notification here
+        // we'll want an option to suppress notification here
         for(var fid in this.features) {
             this.unselect(this.features[fid]);
         }

--- a/lib/OpenLayers/Control/MousePosition.js
+++ b/lib/OpenLayers/Control/MousePosition.js
@@ -52,7 +52,7 @@ OpenLayers.Control.MousePosition = OpenLayers.Class(OpenLayers.Control, {
 
     /**
      * APIProperty: separator
-     * {String} A string to be used to seperate the two coordinates from each
+     * {String} A string to be used to separate the two coordinates from each
      *     other.  Defaults to the string ', ', which will result in a
      *     rendered coordinate of e.g. '42.12, 21.22'.
      */

--- a/lib/OpenLayers/Control/PinchZoom.js
+++ b/lib/OpenLayers/Control/PinchZoom.js
@@ -135,7 +135,7 @@ OpenLayers.Control.PinchZoom = OpenLayers.Class(OpenLayers.Control, {
             location.lat -= resolution * ((size.h / 2) - zoomPixel.y);
 
             // Force a reflow before calling setCenter. This is to work
-            // around an issue occuring in iOS.
+            // around an issue occurring in iOS.
             //
             // See https://github.com/openlayers/openlayers/pull/351.
             //

--- a/lib/OpenLayers/Control/SelectFeature.js
+++ b/lib/OpenLayers/Control/SelectFeature.js
@@ -299,7 +299,7 @@ OpenLayers.Control.SelectFeature = OpenLayers.Class(OpenLayers.Control, {
      * options - {Object} Optional configuration object.
      */
     unselectAll: function(options) {
-        // we'll want an option to supress notification here
+        // we'll want an option to suppress notification here
         var layers = this.layers || [this.layer],
             layer, feature, l, numExcept;
         for(l=0; l<layers.length; ++l) {

--- a/lib/OpenLayers/Control/TransformFeature.js
+++ b/lib/OpenLayers/Control/TransformFeature.js
@@ -179,7 +179,7 @@ OpenLayers.Control.TransformFeature = OpenLayers.Class(OpenLayers.Control, {
      * APIProperty: irregular
      * {Boolean} Make scaling/resizing work irregularly. If true then
      *     dragging a handle causes the feature to resize in the direction
-     *     of movement. If false then the feature resizes symetrically
+     *     of movement. If false then the feature resizes symmetrically
      *     about it's center.
      */
     irregular: false,

--- a/lib/OpenLayers/Control/ZoomPanel.js
+++ b/lib/OpenLayers/Control/ZoomPanel.js
@@ -12,7 +12,7 @@
 
 /**
  * Class: OpenLayers.Control.ZoomPanel
- * The ZoomPanel control is a compact collecton of 3 zoom controls: a 
+ * The ZoomPanel control is a compact collection of 3 zoom controls: a 
  * <OpenLayers.Control.ZoomIn>, a <OpenLayers.Control.ZoomToMaxExtent>, and a
  * <OpenLayers.Control.ZoomOut>. By default it is drawn in the upper left 
  * corner of the map.

--- a/lib/OpenLayers/Feature/Vector.js
+++ b/lib/OpenLayers/Feature/Vector.js
@@ -177,7 +177,7 @@ OpenLayers.Feature.Vector = OpenLayers.Class(OpenLayers.Feature, {
      * Method: onScreen
      * Determine whether the feature is within the map viewport.  This method
      *     tests for an intersection between the geometry and the viewport
-     *     bounds.  If a more effecient but less precise geometry bounds
+     *     bounds.  If a more efficient but less precise geometry bounds
      *     intersection is desired, call the method with the boundsOnly
      *     parameter true.
      *

--- a/lib/OpenLayers/Format/KML.js
+++ b/lib/OpenLayers/Format/KML.js
@@ -217,7 +217,7 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
             data = OpenLayers.Format.XML.prototype.read.apply(this, [data]);
         }
 
-        // Loop throught the following node types in this order and
+        // Loop through the following node types in this order and
         // process the nodes found 
         var types = ["Link", "NetworkLink", "Style", "StyleMap", "Placemark"];
         for(var i=0, len=types.length; i<len; ++i) {
@@ -335,7 +335,7 @@ OpenLayers.Format.KML = OpenLayers.Class(OpenLayers.Format.XML, {
      * color and opacity or null if the color is invalid.
      *
      * Parameters: 
-     * kmlColor - {String} a kml formated color
+     * kmlColor - {String} a kml formatted color
      *
      * Returns:
      * {Object}

--- a/lib/OpenLayers/Format/OSM.js
+++ b/lib/OpenLayers/Format/OSM.js
@@ -25,7 +25,7 @@ OpenLayers.Format.OSM = OpenLayers.Class(OpenLayers.Format.XML, {
     /**
      * APIProperty: checkTags
      * {Boolean} Should tags be checked to determine whether something
-     * should be treated as a seperate node. Will slow down parsing.
+     * should be treated as a separate node. Will slow down parsing.
      * Default is false.
      */
     checkTags: false,

--- a/lib/OpenLayers/Format/QueryStringFilter.js
+++ b/lib/OpenLayers/Format/QueryStringFilter.js
@@ -52,7 +52,7 @@ OpenLayers.Format.QueryStringFilter = (function() {
         // convert % to \%
         value = value.replace(/%/g, "\\%");
 
-        // convert \\. to \\_ (\\.* occurences converted later)
+        // convert \\. to \\_ (\\.* occurrences converted later)
         value = value.replace(/\\\\\.(\*)?/g, function($0, $1) {
             return $1 ? $0 : "\\\\_";
         });
@@ -60,7 +60,7 @@ OpenLayers.Format.QueryStringFilter = (function() {
         // convert \\.* to \\%
         value = value.replace(/\\\\\.\*/g, "\\\\%");
 
-        // convert . to _ (\. and .* occurences converted later)
+        // convert . to _ (\. and .* occurrences converted later)
         value = value.replace(/(\\)?\.(\*)?/g, function($0, $1, $2) {
             return $1 || $2 ? $0 : "_";
         });

--- a/lib/OpenLayers/Format/Text.js
+++ b/lib/OpenLayers/Format/Text.js
@@ -66,7 +66,7 @@ OpenLayers.Format.Text = OpenLayers.Class(OpenLayers.Format, {
 
     /**
      * APIMethod: read
-     * Return a list of features from a Tab Seperated Values text string.
+     * Return a list of features from a Tab Separated Values text string.
      * 
      * Parameters:
      * text - {String} 

--- a/lib/OpenLayers/Geometry/LineString.js
+++ b/lib/OpenLayers/Geometry/LineString.js
@@ -553,7 +553,7 @@ OpenLayers.Geometry.LineString = OpenLayers.Class(OpenLayers.Geometry.Curve, {
      *
      *
      * Parameters:
-     * tolerance - {number} threshhold for simplification in map units
+     * tolerance - {number} threshold for simplification in map units
      *
      * Returns:
      * {OpenLayers.Geometry.LineString} the simplified LineString

--- a/lib/OpenLayers/Handler/Click.js
+++ b/lib/OpenLayers/Handler/Click.js
@@ -134,7 +134,7 @@ OpenLayers.Handler.Click = OpenLayers.Class(OpenLayers.Handler, {
      *     the map.
      * callbacks - {Object} An object with keys corresponding to callbacks
      *     that will be called by the handler. The callbacks should
-     *     expect to recieve a single argument, the click event.
+     *     expect to receive a single argument, the click event.
      *     Callbacks for 'click' and 'dblclick' are supported.
      * options - {Object} Optional object whose properties will be set on the
      *     handler.

--- a/lib/OpenLayers/Handler/Drag.js
+++ b/lib/OpenLayers/Handler/Drag.js
@@ -117,7 +117,7 @@ OpenLayers.Handler.Drag = OpenLayers.Class(OpenLayers.Handler, {
      *     the map.
      * callbacks - {Object} An object containing a single function to be
      *     called when the drag operation is finished. The callback should
-     *     expect to recieve a single argument, the pixel location of the event.
+     *     expect to receive a single argument, the pixel location of the event.
      *     Callbacks for 'move' and 'done' are supported. You can also speficy
      *     callbacks for 'down', 'up', and 'out' to respond to those events.
      * options - {Object} 

--- a/lib/OpenLayers/Handler/Feature.js
+++ b/lib/OpenLayers/Handler/Feature.js
@@ -113,7 +113,7 @@ OpenLayers.Handler.Feature = OpenLayers.Class(OpenLayers.Handler, {
      * layer - {<OpenLayers.Layer.Vector>}
      * callbacks - {Object} An object with a 'over' property whos value is
      *     a function to be called when the mouse is over a feature. The 
-     *     callback should expect to recieve a single argument, the feature.
+     *     callback should expect to receive a single argument, the feature.
      * options - {Object} 
      */
     initialize: function(control, layer, callbacks, options) {

--- a/lib/OpenLayers/Handler/Keyboard.js
+++ b/lib/OpenLayers/Handler/Keyboard.js
@@ -51,7 +51,7 @@ OpenLayers.Handler.Keyboard = OpenLayers.Class(OpenLayers.Handler, {
      *     the map.
      * callbacks - {Object} An object containing a single function to be
      *     called when the drag operation is finished. The callback should
-     *     expect to recieve a single argument, the pixel location of the event.
+     *     expect to receive a single argument, the pixel location of the event.
      *     Callbacks for 'keydown', 'keypress', and 'keyup' are supported.
      * options - {Object} Optional object whose properties will be set on the
      *     handler.

--- a/lib/OpenLayers/Handler/MouseWheel.js
+++ b/lib/OpenLayers/Handler/MouseWheel.js
@@ -62,7 +62,7 @@ OpenLayers.Handler.MouseWheel = OpenLayers.Class(OpenLayers.Handler, {
      * control - {<OpenLayers.Control>} 
      * callbacks - {Object} An object containing a single function to be
      *                          called when the drag operation is finished.
-     *                          The callback should expect to recieve a single
+     *                          The callback should expect to receive a single
      *                          argument, the point geometry.
      * options - {Object} 
      */

--- a/lib/OpenLayers/Handler/Path.js
+++ b/lib/OpenLayers/Handler/Path.js
@@ -90,7 +90,7 @@ OpenLayers.Handler.Path = OpenLayers.Class(OpenLayers.Handler.Point, {
      *     geometry and the sketch feature.
      * point - Called as each point is added.  Receives the new point geometry.
      * done - Called when the point drawing is finished.  The callback will
-     *     recieve a single argument, the linestring geometry.
+     *     receive a single argument, the linestring geometry.
      * cancel - Called when the handler is deactivated while drawing.  The
      *     cancel callback will receive a geometry.
      */

--- a/lib/OpenLayers/Handler/Point.js
+++ b/lib/OpenLayers/Handler/Point.js
@@ -137,7 +137,7 @@ OpenLayers.Handler.Point = OpenLayers.Class(OpenLayers.Handler, {
      * modify - Called with each move of a vertex with the vertex (point)
      *     geometry and the sketch feature.
      * done - Called when the point drawing is finished.  The callback will
-     *     recieve a single argument, the point geometry.
+     *     receive a single argument, the point geometry.
      * cancel - Called when the handler is deactivated while drawing.  The
      *     cancel callback will receive a geometry.
      */

--- a/lib/OpenLayers/Handler/Polygon.js
+++ b/lib/OpenLayers/Handler/Polygon.js
@@ -58,7 +58,7 @@ OpenLayers.Handler.Polygon = OpenLayers.Class(OpenLayers.Handler.Path, {
      *     geometry and the sketch feature.
      * point - Called as each point is added.  Receives the new point geometry.
      * done - Called when the point drawing is finished.  The callback will
-     *     recieve a single argument, the polygon geometry.
+     *     receive a single argument, the polygon geometry.
      * cancel - Called when the handler is deactivated while drawing.  The
      *     cancel callback will receive a geometry.
      */

--- a/lib/OpenLayers/Handler/RegularPolygon.js
+++ b/lib/OpenLayers/Handler/RegularPolygon.js
@@ -139,7 +139,7 @@ OpenLayers.Handler.RegularPolygon = OpenLayers.Class(OpenLayers.Handler.Drag, {
      * create - Called when a sketch is first created.  Callback called with
      *     the creation point geometry and sketch feature.
      * done - Called when the sketch drawing is finished.  The callback will
-     *     recieve a single argument, the sketch geometry.
+     *     receive a single argument, the sketch geometry.
      * cancel - Called when the handler is deactivated while drawing.  The
      *     cancel callback will receive a geometry.
      */

--- a/lib/OpenLayers/Layer/ArcIMS.js
+++ b/lib/OpenLayers/Layer/ArcIMS.js
@@ -321,7 +321,7 @@ OpenLayers.Layer.ArcIMS = OpenLayers.Class(OpenLayers.Layer.Grid, {
      * options - {Object} Object with non-default properties to set on the layer.
      *     Supported properties are buffer, callback, scope, and any other
      *     properties applicable to the ArcXML format.  Set the 'callback' and
-     *     'scope' for an object and function to recieve the parsed features
+     *     'scope' for an object and function to receive the parsed features
      *     from ArcIMS.
      */
     getFeatureInfo: function(geometry, layer, options) {

--- a/lib/OpenLayers/Layer/Bing.js
+++ b/lib/OpenLayers/Layer/Bing.js
@@ -206,7 +206,7 @@ OpenLayers.Layer.Bing = OpenLayers.Class(OpenLayers.Layer.XYZ, {
     /**
      * Method: getURL
      *
-     * Paramters:
+     * Parameters:
      * bounds - {<OpenLayers.Bounds>}
      */
     getURL: function(bounds) {

--- a/lib/OpenLayers/Layer/Image.js
+++ b/lib/OpenLayers/Layer/Image.js
@@ -99,7 +99,7 @@ OpenLayers.Layer.Image = OpenLayers.Class(OpenLayers.Layer, {
      * Method: clone
      * Create a clone of this layer
      *
-     * Paramters:
+     * Parameters:
      * obj - {Object} An optional layer (is this ever used?)
      *
      * Returns:

--- a/lib/OpenLayers/Layer/MapGuide.js
+++ b/lib/OpenLayers/Layer/MapGuide.js
@@ -352,7 +352,7 @@ OpenLayers.Layer.MapGuide = OpenLayers.Class(OpenLayers.Layer.Grid, {
         }
         var paramsString = OpenLayers.Util.getParameterString(allParams);
         
-        /* MapGuide needs '+' seperating things like bounds/height/width.
+        /* MapGuide needs '+' separating things like bounds/height/width.
            Since typically this is URL encoded, we use a slight hack: we
            depend on the list-like functionality of getParameterString to
            leave ',' only in the case of list items (since otherwise it is

--- a/lib/OpenLayers/Layer/MapServer.js
+++ b/lib/OpenLayers/Layer/MapServer.js
@@ -151,7 +151,7 @@ OpenLayers.Layer.MapServer = OpenLayers.Class(OpenLayers.Layer.Grid, {
         // requestString always starts with url
         var requestString = url;        
 
-        // MapServer needs '+' seperating things like bounds/height/width.
+        // MapServer needs '+' separating things like bounds/height/width.
         //   Since typically this is URL encoded, we use a slight hack: we
         //  depend on the list-like functionality of getParameterString to
         //  leave ',' only in the case of list items (since otherwise it is

--- a/lib/OpenLayers/Layer/SphericalMercator.js
+++ b/lib/OpenLayers/Layer/SphericalMercator.js
@@ -10,7 +10,7 @@
 
 /**
  * Class: OpenLayers.Layer.SphericalMercator
- * A mixin for layers that wraps up the pieces neccesary to have a coordinate
+ * A mixin for layers that wraps up the pieces necessary to have a coordinate
  *     conversion for working with commercial APIs which use a spherical
  *     mercator projection.  Using this layer as a base layer, additional
  *     layers can be used as overlays if they are in the same projection.

--- a/lib/OpenLayers/Layer/Vector.js
+++ b/lib/OpenLayers/Layer/Vector.js
@@ -617,7 +617,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      *     removes them from the layer's control.  The beforefeatureremoved
      *     and featureremoved events will be triggered for each feature.  The
      *     featuresremoved event will be triggered after all features have
-     *     been removed.  To supress event triggering, use the silent option.
+     *     been removed.  To suppress event triggering, use the silent option.
      * 
      * Parameters:
      * features - {Array(<OpenLayers.Feature.Vector>)} List of features to be
@@ -626,7 +626,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      *     removal.
      *
      * Valid options:
-     * silent - {Boolean} Supress event triggering.  Default is false.
+     * silent - {Boolean} Suppress event triggering.  Default is false.
      */
     removeFeatures: function(features, options) {
         if(!features || features.length === 0) {
@@ -709,7 +709,7 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      *     removal.
      *
      * Valid options:
-     * silent - {Boolean} Supress event triggering.  Default is false.
+     * silent - {Boolean} Suppress event triggering.  Default is false.
      */
     removeAllFeatures: function(options) {
         var notify = !options || !options.silent;

--- a/lib/OpenLayers/Layer/Zoomify.js
+++ b/lib/OpenLayers/Layer/Zoomify.js
@@ -79,14 +79,14 @@ OpenLayers.Layer.Zoomify = OpenLayers.Class(OpenLayers.Layer.Grid, {
      * Parameters:
      * name - {String} A name for the layer.
      * url - {String} - Relative or absolute path to the image or more
-     *        precisly to the TileGroup[X] directories root.
+     *        precisely to the TileGroup[X] directories root.
      *        Flash plugin use the variable name "zoomifyImagePath" for this.
      * size - {<OpenLayers.Size>} The size (in pixels) of the image.
      * options - {Object} Hashtable of extra options to tag onto the layer
      */
     initialize: function(name, url, size, options) {
 
-        // initilize the Zoomify pyramid for given size
+        // initialize the Zoomify pyramid for given size
         this.initializeZoomify(size);
 
         OpenLayers.Layer.Grid.prototype.initialize.apply(this, [

--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -1977,7 +1977,7 @@ OpenLayers.Map = OpenLayers.Class({
 
             if (centerChanged) {
                 if (!zoomChanged && this.center) { 
-                    // if zoom hasnt changed, just slide layerContainer
+                    // if zoom hasn't changed, just slide layerContainer
                     //  (must be done before setting this.center to new value)
                     this.centerLayerContainer(lonlat);
                 }

--- a/lib/OpenLayers/Projection.js
+++ b/lib/OpenLayers/Projection.js
@@ -104,7 +104,7 @@ OpenLayers.Projection = OpenLayers.Class({
     /**
      * Method: equals
      * Test equality of two projection instances.  Determines equality based
-     *     soley on the projection code.
+     *     solely on the projection code.
      *
      * Returns:
      * {Boolean} The two projections are equivalent.

--- a/lib/OpenLayers/Renderer/Canvas.js
+++ b/lib/OpenLayers/Renderer/Canvas.js
@@ -650,7 +650,7 @@ OpenLayers.Renderer.Canvas = OpenLayers.Class(OpenLayers.Renderer, {
         // erase inner rings
         for (var i=1; i<len; ++i) {
             /** 
-             * Note that this is overly agressive.  Here we punch holes through 
+             * Note that this is overly aggressive.  Here we punch holes through 
              * all previously rendered features on the same canvas.  A better 
              * solution for polygons with interior rings would be to draw the 
              * polygon on a sketch canvas first.  We could erase all holes 

--- a/lib/OpenLayers/Rule.js
+++ b/lib/OpenLayers/Rule.js
@@ -180,7 +180,7 @@ OpenLayers.Rule = OpenLayers.Class({
      * Method: getContext
      * Gets the context for evaluating this rule
      * 
-     * Paramters:
+     * Parameters:
      * feature - {<OpenLayers.Feature>} feature to take the context from if
      *           none is specified.
      */

--- a/lib/OpenLayers/WPSClient.js
+++ b/lib/OpenLayers/WPSClient.js
@@ -68,7 +68,7 @@ OpenLayers.WPSClient = OpenLayers.Class({
      * Parameters:
      * options - {Object} Object whose properties will be set on the instance.
      *
-     * Avaliable options:
+     * Available options:
      * servers - {Object} Mandatory. Service metadata, keyed by a local
      *     identifier. Can either be a string with the service url or an
      *     object literal with additional metadata:

--- a/lib/OpenLayers/WPSProcess.js
+++ b/lib/OpenLayers/WPSProcess.js
@@ -86,7 +86,7 @@ OpenLayers.WPSProcess = OpenLayers.Class({
      * Parameters:
      * options - {Object} Object whose properties will be set on the instance.
      *
-     * Avaliable options:
+     * Available options:
      * client - {<OpenLayers.WPSClient>} Mandatory. Client that manages this
      *     process.
      * server - {String} Mandatory. Local client identifier of this process's

--- a/lib/deprecated.js
+++ b/lib/deprecated.js
@@ -2467,7 +2467,7 @@ OpenLayers.Layer.WFS = OpenLayers.Class(
         params = OpenLayers.Util.upperCaseObject(params);
 
         // Turn off error reporting, browsers like Safari may work
-        // depending on the setup, and we don't want an unneccesary alert.
+        // depending on the setup, and we don't want an unnecessary alert.
         OpenLayers.Util.extend(options, {'reportError': false});
         var newArguments = [];
         newArguments.push(name, options);
@@ -2627,7 +2627,7 @@ OpenLayers.Layer.WFS = OpenLayers.Class(
 
             var params = null;
 
-            // Cant combine "filter" and "BBOX". This is a cheap hack to help
+            // Can't combine "filter" and "BBOX". This is a cheap hack to help
             // people out who can't migrate to the WFS protocol immediately.
             var filter = this.params.filter || this.params.FILTER;
             if (filter) {
@@ -4177,7 +4177,7 @@ OpenLayers.Layer.Yahoo = OpenLayers.Class(
     /**
      * Method: fixYahooEventPane
      * The map has been centered, so the mysterious yahoo eventpane has been
-     *     added. we remove it so that it doesnt mess with *our* event pane.
+     *     added. we remove it so that it doesn't mess with *our* event pane.
      */
     fixYahooEventPane: function() {
         var yahooEventPane = OpenLayers.Util.getElement("ygddfdiv");
@@ -5794,7 +5794,7 @@ OpenLayers.Popup.AnchoredBubble = OpenLayers.Class(OpenLayers.Popup.Anchored, {
 
     /**
      * Method: setRicoCorners
-     * Update RICO corners according to the popup's current relative postion.
+     * Update RICO corners according to the popup's current relative position.
      */
     setRicoCorners:function() {
 

--- a/notes/2.13.md
+++ b/notes/2.13.md
@@ -48,7 +48,7 @@ The `enableKinetic` property for the DragPan control has been changed to true by
 
 ## Control.ModifyFeature: no more built-in SelectFeature control
 
-The ModifyFeature control is now much leaner, making it more reliable when combined with other controls. The most noticable change is that it has no
+The ModifyFeature control is now much leaner, making it more reliable when combined with other controls. The most noticeable change is that it has no
 `selectControl` member any more. Users who previously relied on this built-in SelectFeature control will now have to create both a SelectFeature and a ModifyFeature control and configure the ModifyFeature control with `standalone: true`. To get features selected, call the `selectFeature` method e.g. from a `featureselected` listener on the vector layer. Note that other than in the old implementation, calling `selectFeature` on an already selected feature will not do anything.
 
 ## Format.GPX: No more prefixes

--- a/tools/README.txt
+++ b/tools/README.txt
@@ -9,6 +9,6 @@ Javascript minimizing tools:
  * shrinksafe.py
    shrinksafe.py calls out to a third party javascript shrinking service. This 
    creates file sizes about 4% smaller (as of commit 501) of the OpenLayers 
-   code. However, this also has the side effect of making you dependant on the 
+   code. However, this also has the side effect of making you dependent on the 
    web service -- and since that service sometimes goes dead, it's risky to 
    depend on it.


### PR DESCRIPTION
I fixed some spelling errors using codespell.py from https://github.com/lucasdemarchi/codespell then I manually checked the modified files and committed only the changes inside comments (as you can see from the colored diff most lines have only one letter changed).

I excluded the following files because they had false positives, or they were data files, or they were created outside of OpenLayers:
examples/animator.js
examples/georss.xml
examples/kml/sundials.kml
examples/utfgrid/geography-class/2/1/1.grid.json
lib/OpenLayers/Format/GeoRSS.js
lib/OpenLayers/Lang/*
tools/BeautifulSoup.py

I also excluded the tests directory because I'm not familiar with the tests.
