### PR TITLE
Update Events.js

### DIFF
--- a/lib/OpenLayers/Events.js
+++ b/lib/OpenLayers/Events.js
@@ -1101,6 +1101,8 @@ OpenLayers.Events = OpenLayers.Class({
             }
         };
         OpenLayers.Event.observe(element, 'MSPointerUp', internalCb);
+        // observe MSPointerOut event for the cursor moves outside of the map container
+        OpenLayers.Event.observe(element, 'MSPointerOut', internalCb);
     },
 
     /**
@@ -1164,6 +1166,8 @@ OpenLayers.Events = OpenLayers.Class({
         };
 
         OpenLayers.Event.observe(element, 'MSPointerUp', cb);
+        // observe MSPointerOut event for the cursor moves outside of the map container
+        OpenLayers.Event.observe(element, 'MSPointerOut', cb);
     },
 
     CLASS_NAME: "OpenLayers.Events"


### PR DESCRIPTION
fix map freezes when dragging the map event the finger moves outside of the map in IE10 on Win8. #1290
