### PR TITLE
Update Events.js

### DIFF
--- a/lib/OpenLayers/Events.js
+++ b/lib/OpenLayers/Events.js
@@ -1090,17 +1090,34 @@ OpenLayers.Events = OpenLayers.Class({
 
         OpenLayers.Event.observe(element, 'MSPointerDown', cb);
 
+        // MSPointerUp event was observed by addMsTouchListenerEnd function, so there is no needed.
+        //// Need to also listen for end events to keep the _msTouches list
+        //// accurate
+        //var internalCb = function(e) {
+        //    for (var i=0, ii=touches.length; i<ii; ++i) {
+        //        if (touches[i].pointerId == e.pointerId) {
+        //            touches.splice(i, 1);
+        //            break;
+        //        }
+        //    }
+        //};
+        //OpenLayers.Event.observe(element, 'MSPointerUp', internalCb);
+        
         // Need to also listen for end events to keep the _msTouches list
         // accurate
-        var internalCb = function(e) {
-            for (var i=0, ii=touches.length; i<ii; ++i) {
-                if (touches[i].pointerId == e.pointerId) {
-                    touches.splice(i, 1);
-                    break;
-                }
-            }
-        };
-        OpenLayers.Event.observe(element, 'MSPointerUp', internalCb);
+        var internalCb = function (e) {
+		    for (var i = 0, ii = touches.length; i < ii; ++i) {
+    			if (touches[i].pointerId == e.pointerId) {
+    				if (this.clientWidth != 0 && this.clientHeight != 0) {
+    					if ((Math.ceil(e.clientX) >= this.clientWidth || Math.ceil(e.clientY) >= this.clientHeight)) {
+    						touches.splice(i, 1);
+    					}
+    				}
+    				break;
+        		}
+        	}
+    	};
+    	OpenLayers.Event.observe(element, 'MSPointerOut', internalCb);
     },
 
     /**


### PR DESCRIPTION
fix map freezes when dragging the map event the finger moves outside of the map in IE10 on Win8. #1290
