### PR TITLE
BBOX strategy doesn't allow projectionless layers

### DIFF
--- a/lib/OpenLayers/Strategy/BBOX.js
+++ b/lib/OpenLayers/Strategy/BBOX.js
@@ -144,7 +144,7 @@ OpenLayers.Strategy.BBOX = OpenLayers.Class(OpenLayers.Strategy, {
             return null;
         }
         var bounds = this.layer.map.getExtent();
-        if(bounds && !this.layer.projection.equals(
+        if (bounds && this.layer.projection && !this.layer.projection.equals(
                 this.layer.map.getProjectionObject())) {
             bounds = bounds.clone().transform(
                 this.layer.map.getProjectionObject(), this.layer.projection
@@ -268,7 +268,7 @@ OpenLayers.Strategy.BBOX = OpenLayers.Class(OpenLayers.Strategy, {
             if(features && features.length > 0) {
                 var remote = this.layer.projection;
                 var local = this.layer.map.getProjectionObject();
-                if(!local.equals(remote)) {
+                if(remote && local && !local.equals(remote))
                     var geom;
                     for(var i=0, len=features.length; i<len; ++i) {
                         geom = features[i].geometry;


### PR DESCRIPTION
this patch adds support for them by safeguarding calls to `this.layer.projection`
