### PR TITLE
Update TileManager.js to fix multiple resize issue (drawing destroyed Tiles)

### DIFF
--- a/lib/OpenLayers/TileManager.js
+++ b/lib/OpenLayers/TileManager.js
@@ -394,8 +394,12 @@ OpenLayers.TileManager = OpenLayers.Class({
         var tileQueue = this.tileQueue[map.id];
         var limit = this.tilesPerFrame;
         var animating = map.zoomTween && map.zoomTween.playing;
+        var tile;
         while (!animating && tileQueue.length && limit) {
-            tileQueue.shift().draw(true);
+            tile = tileQueue.shift();
+            if (tile.layer !== null){
+                tile.draw(true);
+            }
             --limit;
         }
     },


### PR DESCRIPTION
This should fix comment #1302 , as the Tile has been destroyed by a previous resize event, the error is produced by that "destroyed" Tile that is still in the tileQueue
