### PR TITLE
Another proposed fix for #1302

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -866,6 +866,7 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
 
             this.addTileMonitoringHooks(tile);
             tile.draw();
+            tile.isLoading = true;
             this.grid[0][0] = tile;
         } else {
             tile.moveTo(tileBounds, px);


### PR DESCRIPTION
I believe the unload and destroy events are being called on the Tile, but it's not deleting itself when it's a singleTile. Adding this isLoading set, erases correctly the Tile on a singleTile case, without putting other flags in general code of Tile. Please @ahocevar review if you think this might be more cleaner. This way we still use the TileManager for singleTile layers.
