### PR TITLE
Update Events.js

### DIFF
--- a/lib/OpenLayers/Events.js
+++ b/lib/OpenLayers/Events.js
@@ -1089,18 +1089,23 @@ OpenLayers.Events = OpenLayers.Class({
         };
 
         OpenLayers.Event.observe(element, 'MSPointerDown', cb);
-
-        // Need to also listen for end events to keep the _msTouches list
-        // accurate
-        var internalCb = function(e) {
-            for (var i=0, ii=touches.length; i<ii; ++i) {
+        
+        // the pointerId only needs to be removed from the _msTouches array
+        // when the pointer has left its element
+        var internalCb = function (e) {
+            var up = false;
+            for (var i = 0, ii = touches.length; i < ii; ++i) {
                 if (touches[i].pointerId == e.pointerId) {
-                    touches.splice(i, 1);
+                    if (this.clientWidth != 0 && this.clientHeight != 0) {
+                        if ((Math.ceil(e.clientX) >= this.clientWidth || Math.ceil(e.clientY) >= this.clientHeight)) {
+                            touches.splice(i, 1);
+                        }
+                    }
                     break;
                 }
             }
         };
-        OpenLayers.Event.observe(element, 'MSPointerUp', internalCb);
+        OpenLayers.Event.observe(element, 'MSPointerOut', internalCb);
     },
 
     /**


### PR DESCRIPTION
fix map freezes when dragging the map event the finger moves outside of the map in IE10 on Win8. #1290
