### PR TITLE
Do not removeText if no textRoot.childNodes exist

### DIFF
--- a/lib/OpenLayers/Renderer/Elements.js
+++ b/lib/OpenLayers/Renderer/Elements.js
@@ -878,13 +878,15 @@ OpenLayers.Renderer.Elements = OpenLayers.Class(OpenLayers.Renderer, {
      * featureId - {String}
      */
     removeText: function(featureId) {
-        var label = document.getElementById(featureId + this.LABEL_ID_SUFFIX);
-        if (label) {
-            this.textRoot.removeChild(label);
-        }
-        var outline = document.getElementById(featureId + this.LABEL_OUTLINE_SUFFIX);
-        if (outline) {
-            this.textRoot.removeChild(outline);
+        if (this.TextRoot.childNodes.length > 0) {
+            var label = document.getElementById(featureId + this.LABEL_ID_SUFFIX);
+            if (label) {
+                this.textRoot.removeChild(label);
+            }
+            var outline = document.getElementById(featureId + this.LABEL_OUTLINE_SUFFIX);
+            if (outline) {
+                this.textRoot.removeChild(outline);
+            }
         }
     },
 


### PR DESCRIPTION
Add of check to see if any textRoot.childNodes exist before removing a
label and/or label outline
