### PR TITLE
Update Graticule.js

### DIFF
--- a/lib/OpenLayers/Control/Graticule.js
+++ b/lib/OpenLayers/Control/Graticule.js
@@ -15,6 +15,11 @@
  * Class: OpenLayers.Control.Graticule
  * The Graticule displays a grid of latitude/longitude lines reprojected on
  * the map.  
+ * The grid is specified by a list of widths in degrees (with height the same as the width).
+ * The grid height can be specified as a multiple of the width.
+ * This allows making the grid more regular in specific regions of some projections.
+ * The grid can also be specified by lists of both widths and heights.
+ * This allows matching externally-defined grid systems.
  * 
  * Inherits from:
  *  - <OpenLayers.Control>
@@ -36,6 +41,23 @@ OpenLayers.Control.Graticule = OpenLayers.Class(OpenLayers.Control, {
     intervals: [ 45, 30, 20, 10, 5, 2, 1,
                  0.5, 0.2, 0.1, 0.05, 0.01, 
                  0.005, 0.002, 0.001 ],
+
+    /**
+    * APIProperty: intervalHeights
+    * {Array(Float)} A list of possible graticule heights in degrees.
+    * Length must match intervals array.  
+    * Default is null (same as widths).
+    */
+    intervalHeights: null,
+    
+    /**
+     * Property: intervalHeightFactor
+     * {Number} Factor to compute graticule height from the width.  
+     * Can be used to match existing grid systems, or improve regularity of grid.
+     * Default is 1.
+     * Ignored if intervalHeights are set explicitly.
+     */
+    intervalHeightFactor: 1,
 
     /**
      * APIProperty: displayInLayerSwitcher
@@ -233,12 +255,15 @@ OpenLayers.Control.Graticule = OpenLayers.Class(OpenLayers.Control, {
         //find lat/lon interval that results in a grid of less than the target size
         var testSq = this.targetSize*mapRes;
         testSq *= testSq;   //compare squares rather than doing a square root to save time
-        var llInterval;
         for (var i=0; i<this.intervals.length; ++i) {
-            llInterval = this.intervals[i];   //could do this for both x and y??
-            var delta = llInterval/2;  
-            var p1 = mapCenterLL.offset({x: -delta, y: -delta});  //test coords in EPSG:4326 space
-            var p2 = mapCenterLL.offset({x: delta, y: delta});
+            var intervalX = this.intervals[i];  
+            // use explicit widths or factor if not present
+            var intervalY = (this.intervalHeights) ? this.intervalHeights[i] : this.intervalHeightFactor * intervalX;
+            
+            var deltaX = intervalX/2;  
+            var deltaY = intervalY/2;  
+            var p1 = mapCenterLL.offset({x: -deltaX, y: -deltaY});  //test coords in EPSG:4326 space
+            var p2 = mapCenterLL.offset({x: deltaX, y: deltaY});
             OpenLayers.Projection.transform(p1, llProj, mapProj); // convert them back to map projection
             OpenLayers.Projection.transform(p2, llProj, mapProj);
             var distSq = (p1.x-p2.x)*(p1.x-p2.x) + (p1.y-p2.y)*(p1.y-p2.y);
@@ -249,8 +274,8 @@ OpenLayers.Control.Graticule = OpenLayers.Class(OpenLayers.Control, {
         //alert(llInterval);
         
         //round the LL center to an even number based on the interval
-        mapCenterLL.x = Math.floor(mapCenterLL.x/llInterval)*llInterval;
-        mapCenterLL.y = Math.floor(mapCenterLL.y/llInterval)*llInterval;
+        mapCenterLL.x = Math.floor(mapCenterLL.x/intervalX)*intervalX;
+        mapCenterLL.y = Math.floor(mapCenterLL.y/intervalY)*intervalY;
         //TODO adjust for minutses/seconds?
         
         /* The following 2 blocks calculate the nodes of the grid along a 
@@ -264,13 +289,13 @@ OpenLayers.Control.Graticule = OpenLayers.Class(OpenLayers.Control, {
         var newPoint = mapCenterLL.clone();
         var mapXY;
         do {
-            newPoint = newPoint.offset({x: 0, y: llInterval});
+            newPoint = newPoint.offset({x: 0, y: intervalY});
             mapXY = OpenLayers.Projection.transform(newPoint.clone(), llProj, mapProj);
             centerLonPoints.unshift(newPoint);
         } while (mapBounds.containsPixel(mapXY) && ++iter<1000);
         newPoint = mapCenterLL.clone();
         do {          
-            newPoint = newPoint.offset({x: 0, y: -llInterval});
+            newPoint = newPoint.offset({x: 0, y: -intervalY});
             mapXY = OpenLayers.Projection.transform(newPoint.clone(), llProj, mapProj);
             centerLonPoints.push(newPoint);
         } while (mapBounds.containsPixel(mapXY) && ++iter<1000);
@@ -280,13 +305,13 @@ OpenLayers.Control.Graticule = OpenLayers.Class(OpenLayers.Control, {
         var centerLatPoints = [mapCenterLL.clone()];
         newPoint = mapCenterLL.clone();
         do {
-            newPoint = newPoint.offset({x: -llInterval, y: 0});
+            newPoint = newPoint.offset({x: -intervalX, y: 0});
             mapXY = OpenLayers.Projection.transform(newPoint.clone(), llProj, mapProj);
             centerLatPoints.unshift(newPoint);
         } while (mapBounds.containsPixel(mapXY) && ++iter<1000);
         newPoint = mapCenterLL.clone();
         do {          
-            newPoint = newPoint.offset({x: llInterval, y: 0});
+            newPoint = newPoint.offset({x: intervalX, y: 0});
             mapXY = OpenLayers.Projection.transform(newPoint.clone(), llProj, mapProj);
             centerLatPoints.push(newPoint);
         } while (mapBounds.containsPixel(mapXY) && ++iter<1000);


### PR DESCRIPTION
Add support for computing the height as a factor of the width.  This allows making the grid more regular in specific regions of some projections.  Also, add ability to specify grid widths and heights independently.   This allows matching externally-defined grid systems.
