### PR TITLE
Add missing Text Symbolizer API properties

### DIFF
--- a/lib/OpenLayers/Symbolizer/Text.js
+++ b/lib/OpenLayers/Symbolizer/Text.js
@@ -42,8 +42,22 @@ OpenLayers.Symbolizer.Text = OpenLayers.Class(OpenLayers.Symbolizer, {
      */
     
     /**
-     * Property: fontStyle
+     * APIProperty: fontStyle
      * {String} The font style for the label.
+     * 
+     * No default set here.  Use OpenLayers.Renderer.defaultRenderer for defaults.
+     */
+
+    /**
+     * APIProperty: fontColor
+     * {String} The font color for the label.
+     * 
+     * No default set here.  Use OpenLayers.Renderer.defaultRenderer for defaults.
+     */
+
+    /**
+     * APIProperty: fontOpacity
+     * {String} The font opacity for the label.
      * 
      * No default set here.  Use OpenLayers.Renderer.defaultRenderer for defaults.
      */


### PR DESCRIPTION
The properties fontStyle, fontColor, fontOpacity are provided and probably should be in the documentation.
