### PR TITLE
Update featureclick.js

### DIFF
--- a/lib/OpenLayers/Events/featureclick.js
+++ b/lib/OpenLayers/Events/featureclick.js
@@ -36,6 +36,9 @@ OpenLayers.Events.featureclick = OpenLayers.Class({
      */
     provides: ["featureclick", "nofeatureclick", "featureover", "featureout"],
     
+    lastClientX:0,
+
+    lastClientY:0,
     /**
      * Constructor: OpenLayers.Events.featureclick
      * Create a new featureclick event type.
@@ -147,6 +150,17 @@ OpenLayers.Events.featureclick = OpenLayers.Class({
      * evt - {<OpenLayers.Event>}
      */
     onMousemove: function(evt) {
+        var clientX=evt.clientX;
+        var clientY=evt.clientY;
+	
+	//this is a fix for Chrome 34, mousemove is triggered even cursor did not move. th
+        if(this.lastClientX==clientX && this.lastClientY==clientY){
+            return;
+        }
+        else{
+            this.lastClientX=clientX;
+            this.lastClientY=clientY;
+        }
         delete this.startEvt;
         var features = this.getFeatures(evt);
         var over = {}, newly = [], feature;


### PR DESCRIPTION
events/featureclick.js uses technique layer.div.style.display = "none" and layer.div.style.display = "block" to loop through layers to find all features that exists on certain screen x,y point;

However, currently, on Chrome 34.0.1847.131m and 35.0.1916.99 beta-m;
The hide and show technique triggers mousemove event, which causes the onMousemove method get called constantly, resulting a big performance impact. This won't happen on Internet Explorer and Firefox.
An test can be found http://jsfiddle.net/er7hm/2/;

The code below prevents onMousemove got called constantly by checking if the cursor actually moved. 
It solves the problem. However, i don't know if the issue will be fixed by Chrome or if I have a valid fix.
