### PR TITLE
featureclick.js update for Chrome 34

### DIFF
--- a/lib/OpenLayers/Events/featureclick.js
+++ b/lib/OpenLayers/Events/featureclick.js
@@ -152,10 +152,8 @@ OpenLayers.Events.featureclick = OpenLayers.Class({
      */
     onMousemove: function(evt) {
         delete this.startEvt;
-    	
         var clientX = evt.clientX;
         var clientY = evt.clientY;
-	
 	//this is a fix for Chrome 34. Mousemove event is triggered even cursor did not move.
         if (this.lastClientX == clientX && this.lastClientY == clientY) {
             return;


### PR DESCRIPTION
events/featureclick.js uses technique layer.div.style.display = "none" and layer.div.style.display = "block" to loop through layers to find all features that exists on certain screen x,y point;

Currently, on Chrome 34.0.1847.131m and 35.0.1916.99 beta-m, the hide and show technique triggers mousemove event, which causes the onMousemove method get called constantly, resulting a big performance impact. However, This won't happen on Internet Explorer and Firefox.
An test can be found http://jsfiddle.net/er7hm/2/;

The code below prevents onMousemove got called constantly by checking if the cursor actually moved. 
It solves the problem. However, i don't know if the issue will be fixed by Chrome or if I have a valid fix.
