### PR TITLE
Support Proj4js 2.x

### DIFF
--- a/lib/OpenLayers/Projection.js
+++ b/lib/OpenLayers/Projection.js
@@ -62,7 +62,7 @@ OpenLayers.Projection = OpenLayers.Class({
     initialize: function(projCode, options) {
         OpenLayers.Util.extend(this, options);
         this.projCode = projCode;
-        if (typeof Proj4js == "object") {
+        if (typeof Proj4js == "object" || typeof Proj4js == 'function') {
             this.proj = new Proj4js.Proj(projCode);
         }
     },
@@ -115,7 +115,7 @@ OpenLayers.Projection = OpenLayers.Class({
             if (!(p instanceof OpenLayers.Projection)) {
                 p = new OpenLayers.Projection(p);
             }
-            if ((typeof Proj4js == "object") && this.proj.defData && p.proj.defData) {
+            if ((typeof Proj4js == "object" || typeof Proj4js == 'function') && this.proj.defData && p.proj.defData) {
                 equals = this.proj.defData.replace(this.titleRegEx, "") ==
                     p.proj.defData.replace(this.titleRegEx, "");
             } else if (p.getCode) {


### PR DESCRIPTION
In versions 2.x, Proj4js is exported as a function and no longer as an object. IMHO, this is the only thing that need to be done to support Proj4js 2.x and it does not break backward compatibility.
