### PR TITLE
Allow options for delay and pixelTolerance

### DIFF
--- a/lib/OpenLayers/Control/GetFeature.js
+++ b/lib/OpenLayers/Control/GetFeature.js
@@ -239,7 +239,7 @@ OpenLayers.Control.GetFeature = OpenLayers.Class(OpenLayers.Control, {
         if(this.hover) {
             this.handlers.hover = new OpenLayers.Handler.Hover(
                 this, {'move': this.cancelHover, 'pause': this.selectHover},
-                OpenLayers.Util.extend(this.handlerOptions.hover, {
+                OpenLayers.Util.applyDefaults(this.handlerOptions.hover, {
                     'delay': 250,
                     'pixelTolerance': 2
                 })


### PR DESCRIPTION
We should be able to set delay and pixelTolerance through options.handlerOptions.hover.  If we use OpenLayers.Util.extend, we're stuck with the hardcoded defaults.
