### PR TITLE
No support for viewParams in WFS protocols 

### DIFF
--- a/lib/OpenLayers/Format/WFST/v1.js
+++ b/lib/OpenLayers/Format/WFST/v1.js
@@ -230,6 +230,7 @@ OpenLayers.Format.WFST.v1 = OpenLayers.Class(OpenLayers.Format.XML, {
                         handle: options && options.handle,
                         outputFormat: options && options.outputFormat,
                         maxFeatures: options && options.maxFeatures,
+                        viewParams: options && options.viewParams,
                         "xsi:schemaLocation": this.schemaLocationAttr(options)
                     }
                 });

--- a/tests/Format/WFST/v1.html
+++ b/tests/Format/WFST/v1.html
@@ -47,7 +47,7 @@
 
         t.plan(9);
         var snippets = {
-            "GetFeature": {handle: "handle_g", maxFeatures: 1, outputFormat: 'json'},
+            "GetFeature": {handle: "handle_g", viewParams: "text:Test", maxFeatures: 1, outputFormat: 'json'},
             "Transaction": {handle: "handle_t"},
             "Insert": {feature: insertFeature, options: {handle: "handle_i"}},
             "Update": {feature: updateFeature, options: {handle: "handle_u"}},
@@ -304,7 +304,7 @@
 --></div>
 
 <div id="GetFeature"><!--
-<wfs:GetFeature xmlns:wfs="http://www.opengis.net/wfs" service="WFS" version="1.0.0" handle="handle_g" outputFormat="json" maxFeatures="1" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-transaction.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<wfs:GetFeature xmlns:wfs="http://www.opengis.net/wfs" service="WFS" version="1.0.0" viewParams="text:Test" handle="handle_g" outputFormat="json" maxFeatures="1" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-transaction.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <wfs:Query typeName="topp:states" xmlns:topp="http://www.openplans.org/topp"/>
 </wfs:GetFeature>
 --></div>


### PR DESCRIPTION
## Summary

[Geoserver recently gained support](http://jira.codehaus.org/browse/GEOS-5160) for the viewParams parameter in WFS requests.  However, currently Openlayers has no facility to pass these requests on. So this ticket is for adding viewparams support (which is really simple btw).
## Functionality

Openlayers passing viewparams values across to the WFS server for WFS requests.
## Interdependencies

viewparams is a Geoserver vendor extension, so it's use is really dependant on Geoserver being the back end. However I can't imagine, given the implementation, it breaking interoperability with other implementations.
## Changes to API

All WFS requests would need to take a viewParams parameter. This could be passed in the options object and would therefore only require something like the following in the inline documentation:

```
     * viewParams - {String} Geoserver vendor extension parameters that will be 
     *                       added to the request
```

(in my version this is at line 117 of lib/OpenLayers/Protocol/WFS/v1.js)
## Suggested strategies

I recommend simply adding the option to the documentation and passing the parameter through in the format object where the element is created.  So where the code is:

```
var node = this.createElementNSPlus("wfs:GetFeature", {
                attributes: {
                    service: "WFS",
                    version: this.version,
                    handle: options && options.handle,
                    outputFormat: options && options.outputFormat,
                    maxFeatures: options && options.maxFeatures,
                    "xsi:schemaLocation": this.schemaLocationAttr(options)
                }
```

a line could be inserted to the attributes being:

```
viewParams: options && options.viewParams,
```

(I've got this at line 232 in lib/OpenLayers/Format/WFST/v1.js in my version)
## Alternatives

I'm not aware of any alternative mechanism of supplying vendor viewparams to Geoserver, nor any other reasonable way of implementing it relative to how OpenLayers is written
## Side-effects/Complications

Probably the most significant side-effect of this is that someone could pass a viewParams parameter to a non-geoserver back end. However given it adds an attribute to the XML, and given the generally extensible nature of XML, it's likely that only the most strict of parsers would pick this up as an error (eg. if all requests were validated against a DTD).

Since it is the users choice to include this parameter, though, and they would be doing it knowing it's a vendor extension specific to Geoserver; this would be unlikely in reality to cause any issues.
## Note

Please note that I based the above suggested changes on commit 5b98769234dc20172a3cb6eeb77e60b297766e45, which was a while ago. If a more up-to-date recommendation is needed, I'm happy to grab the latest version and locate the appropriate parts of the code matching the above changes.
