### PR TITLE
Standard id for PanZoomBar control div elements.

### DIFF
--- a/lib/OpenLayers/Control/PanZoomBar.js
+++ b/lib/OpenLayers/Control/PanZoomBar.js
@@ -198,7 +198,7 @@ OpenLayers.Control.PanZoomBar = OpenLayers.Class(OpenLayers.Control.PanZoom, {
     */
     _addZoomBar:function(centered) {
         var imgLocation = OpenLayers.Util.getImageLocation("slider.png");
-        var id = this.id + "_" + this.map.id;
+        var id = this.id + "_slider";
         var minZoom = this.map.getMinZoom();
         var zoomsToEnd = this.map.getNumZoomLevels() - 1 - this.map.getZoom();
         var slider = OpenLayers.Util.createAlphaImageDiv(id,
@@ -236,7 +236,7 @@ OpenLayers.Control.PanZoomBar = OpenLayers.Class(OpenLayers.Control.PanZoom, {
             div.style.height = sz.h + "px";
         } else {
             div = OpenLayers.Util.createDiv(
-                        'OpenLayers_Control_PanZoomBar_Zoombar' + this.map.id,
+                        this.id + '_zoombar',
                         centered,
                         sz,
                         imgLocation);


### PR DESCRIPTION
When customizing the PanZoomBar slider and zoombar elements via CSS rules, the selection of those elements couldn't be done via id previously because either they have a wrong id prefix or a confusing id sufix.

This change standardizes the id of the slider and zoombar to the same standard as the ids from their peer elements.
