### PR TITLE
Dimensions in getLayerFromContext()

### DIFF
--- a/lib/OpenLayers/Format/Context.js
+++ b/lib/OpenLayers/Format/Context.js
@@ -163,6 +163,18 @@ OpenLayers.Format.Context = OpenLayers.Class(OpenLayers.Format.XML.VersionedOGC,
                 }
             }
         }
+        if (layerContext.dimensions) {
+            for (var key in layerContext.dimensions) {
+                var dimension = layerContext.dimensions[key];
+                if (dimension.current == true) {
+                    if (dimension.name == "time" || dimension.name == "elevation"){
+                        params[dimension.name] = dimension.userValue;
+                    } else {
+                        params["dim_" + dimension.name] = dimension.userValue;
+                    }
+                }
+            }
+        }
         if (this.layerParams) {
             OpenLayers.Util.applyDefaults(params, this.layerParams);
         }


### PR DESCRIPTION
Properly handle dimensions to get the correct param values when creating a layer from a context.
This patch is related to this issue : https://github.com/openlayers/openlayers/issues/1373
