### PR TITLE
Update setFeatureType

### DIFF
--- a/lib/OpenLayers/Protocol/WFS/v1.js
+++ b/lib/OpenLayers/Protocol/WFS/v1.js
@@ -222,6 +222,7 @@ OpenLayers.Protocol.WFS.v1 = OpenLayers.Class(OpenLayers.Protocol, {
     setFeatureType: function(featureType) {
         this.featureType = featureType;
         this.format.featureType = featureType;
+        this.options.featureType = featureType;
     },
  
     /**


### PR DESCRIPTION
The requests from this protocol seem to use all three of the listed feature types, but setFeatureType was updating two of them from the given typeName.
