### PR TITLE
+) Fixed multitouch zoom when first touchpoint is outside map

### DIFF
--- a/lib/OpenLayers/Handler/Pinch.js
+++ b/lib/OpenLayers/Handler/Pinch.js
@@ -86,6 +86,14 @@ OpenLayers.Handler.Pinch = OpenLayers.Class(OpenLayers.Handler, {
      * {Boolean} Let the event propagate.
      */
     touchstart: function(evt) {
+		// Check if first touch point is outside map
+		// Sometimes this is necessary for multitouch to disable unwanted map zooming 
+		var id = evt.touches.item(0).target.id;
+		if(id){
+			if(id.indexOf("OpenLayers") === -1){
+				return false;
+			}
+		}
         var propagate = true;
         this.pinching = false;
         if (OpenLayers.Event.isMultiTouch(evt)) {


### PR DESCRIPTION
Sometimes it is necessary to touch outside the map (e.g.: a button) and then scroll over the map with the second finger. This fix is to prevent zooming the map.
