### PR TITLE
Update distanceTo function to work for line on same plane

### DIFF
--- a/lib/OpenLayers/Geometry.js
+++ b/lib/OpenLayers/Geometry.js
@@ -329,7 +329,7 @@ OpenLayers.Geometry.fromWKT = function(wkt) {
  *     is within the tolerance distance of an end point, the endpoint will be
  *     returned instead of the calculated intersection.  Further, if the
  *     intersection is within the tolerance of endpoints on both segments, or
- *     if two segment endpoints are within the tolerance distance of eachother
+ *     if two segment endpoints are within the tolerance distance of each other
  *     (but no intersection is otherwise calculated), an endpoint on the
  *     first segment provided will be returned.
  *
@@ -337,19 +337,34 @@ OpenLayers.Geometry.fromWKT = function(wkt) {
  * {Boolean | <OpenLayers.Geometry.Point>}  The two segments intersect.
  *     If the point argument is true, the return will be the intersection
  *     point or false if none exists.  If point is true and the segments
- *     are coincident, return will be true (and the instersection is equal
+ *     are coincident, return will be true (and the intersection is equal
  *     to the shorter segment).
  */
 OpenLayers.Geometry.segmentsIntersect = function(seg1, seg2, options) {
     var point = options && options.point;
     var tolerance = options && options.tolerance;
     var intersection = false;
+
     var x11_21 = seg1.x1 - seg2.x1;
     var y11_21 = seg1.y1 - seg2.y1;
     var x12_11 = seg1.x2 - seg1.x1;
     var y12_11 = seg1.y2 - seg1.y1;
     var y22_21 = seg2.y2 - seg2.y1;
     var x22_21 = seg2.x2 - seg2.x1;
+
+    // multiply by one if line is on same plane
+    if ((seg1.y1 === seg1.y2) && (seg1.y2 === seg2.y1) && (seg2.y1 === seg2.y2))
+    {
+        y11_21 = 1;     
+        y12_11 = 1;         
+    }
+
+    if ((seg1.x1 === seg1.x2) && (seg1.x2 === seg2.x1) && (seg2.x1 === seg2.x2))
+    {
+        x11_21 = 1;     
+        x12_11 = 1;         
+    }
+    
     var d = (y22_21 * x12_11) - (x22_21 * y12_11);
     var n1 = (x22_21 * y11_21) - (y22_21 * x11_21);
     var n2 = (x12_11 * y11_21) - (y12_11 * x11_21);

--- a/tests/Geometry/LineString.html
+++ b/tests/Geometry/LineString.html
@@ -252,7 +252,19 @@
         var wkt = OpenLayers.Geometry.fromWKT;
         var geoms = [
             wkt("POINT(0 0)"),
-            wkt("LINESTRING(-2 0, 0 -2, 2 -1, 2 0)")
+            wkt("LINESTRING(-2 0, 0 -2, 2 -1, 2 0)"),
+            wkt('LINESTRING(0 0, 1 0)'),
+            wkt('LINESTRING(2 0, 3 0)'),
+            wkt('LINESTRING(0 0, 0 1)'),
+            wkt('LINESTRING(0 2, 0 3)'),
+            wkt('LINESTRING(0 0, 1 0)'),
+            wkt('LINESTRING(1 0, 2 0)'),			
+            wkt('LINESTRING(0 0, 0 1)'),
+            wkt('LINESTRING(0 1, 0 2)'),
+            wkt('LINESTRING(0 1, 1 1)'),
+            wkt('LINESTRING(2 1, 3 1)'),
+            wkt('LINESTRING(0 1, 0 1)'),
+            wkt('LINESTRING(0 1, 0 1)')					
         ];
 
         var cases = [{
@@ -267,6 +279,24 @@
                 x0: -1, y0: -1,
                 x1: 0, y1: 0
             }
+        }, {
+            got: geoms[2].distanceTo(geoms[3]),
+            expected: 1
+        }, {
+            got: geoms[4].distanceTo(geoms[5]),
+            expected: 1
+        }, {
+            got: geoms[6].distanceTo(geoms[7]),
+            expected: 0
+        }, {
+            got: geoms[8].distanceTo(geoms[9]),
+            expected: 0
+        }, {
+            got: geoms[10].distanceTo(geoms[11]),
+            expected: 1
+        }, {
+            got: geoms[12].distanceTo(geoms[13]),
+            expected: 0
         }];
         
         t.plan(cases.length);


### PR DESCRIPTION
Fix distanceTo function when both line segments are on the same plane (issue #1391). Add associated unit tests.
