### PR TITLE
OWSContext: take into account the context obj

### DIFF
--- a/lib/OpenLayers/Format/OWSContext.js
+++ b/lib/OpenLayers/Format/OWSContext.js
@@ -77,6 +77,9 @@ OpenLayers.Format.OWSContext = OpenLayers.Class(OpenLayers.Format.Context,{
             context.projection = obj.projection;
             context.size = obj.getSize();
             context.layers = obj.layers;
+        } else {
+            // copy all obj properties
+            OpenLayers.Util.applyDefaults(context, obj);
         }
         return context;
     },


### PR DESCRIPTION
The `toContext` method currently does not make use of its input argument.
