### PR TITLE
Update shouldDraw function in Tile.js

### DIFF
--- a/lib/OpenLayers/Tile.js
+++ b/lib/OpenLayers/Tile.js
@@ -226,13 +226,31 @@ OpenLayers.Tile = OpenLayers.Class({
     shouldDraw: function() {        
         var withinMaxExtent = false,
             maxExtent = this.layer.maxExtent;
-        if (maxExtent) {
-            var map = this.layer.map;
-            var worldBounds = map.baseLayer.wrapDateLine && map.getMaxExtent();
-            if (this.bounds.intersectsBounds(maxExtent, {inclusive: false, worldBounds: worldBounds})) {
-                withinMaxExtent = true;
-            }
-        }
+		if (maxExtent) {
+			var map = this.layer.map;
+
+			var mapProjection = map.getProjectionObject();
+			var layerProjection = this.layer.projection;
+			
+			var tileBounds = this.bounds.clone;
+			var layerMaxExtent = maxExtent.clone();
+			
+			// if map and layer has different projections we should reproject layer maxExtent to check intersection right
+			if (layerProjection && (!layerProjection.equals(mapProjection))){
+				if ((mapProjection.proj.units === "m") & (layerProjection.proj.units === "degrees")){
+					tileBounds.transform(mapProjection,layerProjection);
+				}
+				else{
+					layerMaxExtent.transform(layerProjection,mapProjection);
+				}
+			}
+
+			var worldBounds = map.baseLayer.wrapDateLine && map.getMaxExtent();
+			if (tileBounds.intersectsBounds(layerMaxExtent, {inclusive: false, worldBounds: worldBounds})) {
+				withinMaxExtent = true;
+			}
+
+		}
         
         return withinMaxExtent || this.layer.displayOutsideMaxExtent;
     },


### PR DESCRIPTION
This code handles situation when base layer and layer of current tile has different projections, to check intersection right we should reproject maxExtent of layer.
