### PR TITLE
fix to: https://github.com/openlayers/openlayers/issues/1404

### DIFF
--- a/lib/OpenLayers/Control/WMSGetFeatureInfo.js
+++ b/lib/OpenLayers/Control/WMSGetFeatureInfo.js
@@ -364,6 +364,23 @@ OpenLayers.Control.WMSGetFeatureInfo = OpenLayers.Class(OpenLayers.Control, {
                 y: parseInt(clickPosition.y)
             }
         );
+        
+        var len = Object.keys(firstLayer.params).length;
+        for (var i =0; i < len; i++) {
+        	var otherKey = Object.keys(firstLayer.params)[i];
+            if ( !( otherKey == 'LAYERS' ||
+            		otherKey == 'TRANSPARENT' ||
+            		otherKey == 'STYLES' ||
+            		otherKey == 'SERVICE' ||
+            		otherKey == 'VERSION' ||
+            		otherKey == 'REQUEST' ||
+            		otherKey == 'FORMAT' ||
+            		otherKey == 'SRS') ) {
+            	
+            	params[otherKey] = firstLayer.params[otherKey];
+            }
+        }
+        
         if (layerNames.length != 0) {
             params = OpenLayers.Util.extend({
                 layers: layerNames,


### PR DESCRIPTION
Add viewparams to list of params when building url for getFeatureInfo.
This enables requesting getFeatureInfo for WMS layers that are from the database - defined as sql-view layers in geoserver.
