### PR TITLE
Added the "index" property to the "vertexremoved" event.

### DIFF
--- a/lib/OpenLayers/Control/ModifyFeature.js
+++ b/lib/OpenLayers/Control/ModifyFeature.js
@@ -666,15 +666,16 @@ OpenLayers.Control.ModifyFeature = OpenLayers.Class(OpenLayers.Control, {
         if(this.feature &&
            OpenLayers.Util.indexOf(this.deleteCodes, code) != -1) {
             var vertex = this._lastVertex;
-            if (vertex &&
-                    OpenLayers.Util.indexOf(this.vertices, vertex) != -1 &&
+            var index = OpenLayers.Util.indexOf(this.vertices, vertex);
+            if (vertex && index != -1 &&
                     !this.handlers.drag.dragging && vertex.geometry.parent) {
                 // remove the vertex
                 vertex.geometry.parent.removeComponent(vertex.geometry);
                 this.layer.events.triggerEvent("vertexremoved", {
                     vertex: vertex.geometry,
                     feature: this.feature,
-                    pixel: evt.xy
+                    pixel: evt.xy,
+                    index: index
                 });
                 this.layer.drawFeature(this.feature, this.standalone ?
                                        undefined : 'select');

--- a/lib/OpenLayers/Layer/Vector.js
+++ b/lib/OpenLayers/Layer/Vector.js
@@ -95,8 +95,10 @@ OpenLayers.Layer.Vector = OpenLayers.Class(OpenLayers.Layer, {
      *      has been deleted.  Listeners will receive an object with a
      *      *feature* property referencing the modified feature, a *vertex*
      *      property referencing the vertex modified (always a point geometry),
-     *      and a *pixel* property referencing the pixel location of the
-     *      removal.
+     *      a *pixel* property referencing the pixel location of the
+     *      removal, and an *index* property referencing the index in the
+     *      parent component that the point geometry occupied prior to being
+     *      removed.
      * sketchstarted - Triggered when a feature sketch bound for this layer
      *      is started.  Listeners will receive an object with a *feature*
      *      property referencing the new sketch feature and a *vertex* property


### PR DESCRIPTION
This pull request resolves issue #1408.
