### PR TITLE
Update demo GeoServer location

### DIFF
--- a/examples/SLDSelect.html
+++ b/examples/SLDSelect.html
@@ -28,7 +28,7 @@
         function init(){
             OpenLayers.ProxyHost= "proxy.cgi?url=";
             map = new OpenLayers.Map('map', {allOverlays: true, controls: []});
-            var url = "http://demo.opengeo.org/geoserver/wms";
+            var url = "http://demo.boundlessgeo.com/geoserver/wms";
             layers = {
                 states: new OpenLayers.Layer.WMS("State boundary", url,
                     {layers: 'topp:tasmania_state_boundaries', format: 'image/gif', transparent: 'TRUE'},

--- a/examples/cql-format.html
+++ b/examples/cql-format.html
@@ -49,6 +49,6 @@
             </p>
         </div>
         <script src="cql-format.js"></script>
-        <script src="http://demo.opengeo.org/geoserver/wfs?service=WFS&amp;version=1.0.0&amp;request=GetFeature&amp;typename=topp:states&amp;outputFormat=text/javascript&amp;format_options=callback:loadFeatures" type="text/javascript"></script>
+        <script src="http://demo.boundlessgeo.com/geoserver/wfs?service=WFS&amp;version=1.0.0&amp;request=GetFeature&amp;typename=topp:states&amp;outputFormat=text/javascript&amp;format_options=callback:loadFeatures" type="text/javascript"></script>
     </body>
 </html>

--- a/examples/getfeatureinfo-control.html
+++ b/examples/getfeatureinfo-control.html
@@ -56,25 +56,25 @@
         });
 
         var political = new OpenLayers.Layer.WMS("State Boundaries",
-            "http://demo.opengeo.org/geoserver/wms", 
+            "http://demo.boundlessgeo.com/geoserver/wms", 
             {'layers': 'topp:tasmania_state_boundaries', transparent: true, format: 'image/gif'},
             {isBaseLayer: true}
         );
 
         var roads = new OpenLayers.Layer.WMS("Roads",
-            "http://demo.opengeo.org/geoserver/wms", 
+            "http://demo.boundlessgeo.com/geoserver/wms", 
             {'layers': 'topp:tasmania_roads', transparent: true, format: 'image/gif'},
             {isBaseLayer: false}
         );
 
         var cities = new OpenLayers.Layer.WMS("Cities",
-            "http://demo.opengeo.org/geoserver/wms", 
+            "http://demo.boundlessgeo.com/geoserver/wms", 
             {'layers': 'topp:tasmania_cities', transparent: true, format: 'image/gif'},
             {isBaseLayer: false}
         );
 
         water = new OpenLayers.Layer.WMS("Bodies of Water",
-            "http://demo.opengeo.org/geoserver/wms", 
+            "http://demo.boundlessgeo.com/geoserver/wms", 
             {'layers': 'topp:tasmania_water_bodies', transparent: true, format: 'image/gif'},
             {isBaseLayer: false}
         );
@@ -87,13 +87,13 @@
 
         infoControls = {
             click: new OpenLayers.Control.WMSGetFeatureInfo({
-                url: 'http://demo.opengeo.org/geoserver/wms', 
+                url: 'http://demo.boundlessgeo.com/geoserver/wms', 
                 title: 'Identify features by clicking',
                 layers: [water],
                 queryVisible: true
             }),
             hover: new OpenLayers.Control.WMSGetFeatureInfo({
-                url: 'http://demo.opengeo.org/geoserver/wms', 
+                url: 'http://demo.boundlessgeo.com/geoserver/wms', 
                 title: 'Identify features by clicking',
                 layers: [water],
                 hover: true,

--- a/examples/getfeatureinfo-popup.html
+++ b/examples/getfeatureinfo-popup.html
@@ -20,25 +20,25 @@
         });
 
         var political = new OpenLayers.Layer.WMS("State Boundaries",
-            "http://demo.opengeo.org/geoserver/wms", 
+            "http://demo.boundlessgeo.com/geoserver/wms", 
             {'layers': 'topp:tasmania_state_boundaries', transparent: true, format: 'image/gif'},
             {isBaseLayer: true}
         );
 
         var roads = new OpenLayers.Layer.WMS("Roads",
-            "http://demo.opengeo.org/geoserver/wms", 
+            "http://demo.boundlessgeo.com/geoserver/wms", 
             {'layers': 'topp:tasmania_roads', transparent: true, format: 'image/gif'},
             {isBaseLayer: false}
         );
 
         var cities = new OpenLayers.Layer.WMS("Cities",
-            "http://demo.opengeo.org/geoserver/wms", 
+            "http://demo.boundlessgeo.com/geoserver/wms", 
             {'layers': 'topp:tasmania_cities', transparent: true, format: 'image/gif'},
             {isBaseLayer: false}
         );
 
         var water = new OpenLayers.Layer.WMS("Bodies of Water",
-            "http://demo.opengeo.org/geoserver/wms", 
+            "http://demo.boundlessgeo.com/geoserver/wms", 
             {'layers': 'topp:tasmania_water_bodies', transparent: true, format: 'image/gif'},
             {isBaseLayer: false}
         );
@@ -51,7 +51,7 @@
         map.addLayers([political, roads, cities, water, highlight]); 
 
         info = new OpenLayers.Control.WMSGetFeatureInfo({
-            url: 'http://demo.opengeo.org/geoserver/wms', 
+            url: 'http://demo.boundlessgeo.com/geoserver/wms', 
             title: 'Identify features by clicking',
             queryVisible: true,
             eventListeners: {

--- a/examples/image-layer.html
+++ b/examples/image-layer.html
@@ -38,7 +38,7 @@
 
             var jpl_wms = new OpenLayers.Layer.WMS(
                 "Global Imagery",
-                "http://demo.opengeo.org/geoserver/wms",
+                "http://demo.boundlessgeo.com/geoserver/wms",
                 {layers: "bluemarble"},
                 {maxExtent: [-160, -88.759, 160, 88.759], numZoomLevels: 3}
             );

--- a/examples/mobile-layers.js
+++ b/examples/mobile-layers.js
@@ -58,7 +58,7 @@ function init() {
     var wfs = new OpenLayers.Layer.Vector("States", {
         strategies: [new OpenLayers.Strategy.Fixed()],
         protocol: new OpenLayers.Protocol.WFS({
-            url: "http://demo.opengeo.org/geoserver/wfs",
+            url: "http://demo.boundlessgeo.com/geoserver/wfs",
             featureType: "states",
             featureNS: "http://www.openplans.org/topp"
         }),

--- a/examples/overviewmap.html
+++ b/examples/overviewmap.html
@@ -65,7 +65,7 @@
         // A more detailed layer of Manhattan for map2
         var ny = new OpenLayers.Layer.WMS(
             "Manhattan", 
-            "http://demo.opengeo.org/geoserver/wms",
+            "http://demo.boundlessgeo.com/geoserver/wms",
             {
                 layers: 'tiger-ny', 
                 format: 'image/png'

--- a/examples/proxy.cgi
+++ b/examples/proxy.cgi
@@ -18,7 +18,7 @@ import sys, os
 allowedHosts = ['www.openlayers.org', 'openlayers.org', 
                 'labs.metacarta.com', 'world.freemap.in', 
                 'prototype.openmnnd.org', 'geo.openplans.org',
-                'sigma.openplans.org', 'demo.opengeo.org',
+                'sigma.openplans.org', 'demo.boundlessgeo.com',
                 'www.openstreetmap.org', 'sample.azavea.com',
                 'v2.suite.opengeo.org', 'v-swe.uni-muenster.de:8080',
                 'vmap0.tiles.osgeo.org', 'www.openrouteservice.org',

--- a/examples/wfs-filter.js
+++ b/examples/wfs-filter.js
@@ -10,13 +10,13 @@ function init() {
         layers: [
             new OpenLayers.Layer.WMS(
                 "Natural Earth", 
-                "http://demo.opengeo.org/geoserver/wms",
+                "http://demo.boundlessgeo.com/geoserver/wms",
                 {layers: "topp:naturalearth"}
             ),
             new OpenLayers.Layer.Vector("WFS", {
                 strategies: [new OpenLayers.Strategy.BBOX()],
                 protocol: new OpenLayers.Protocol.WFS({
-                    url:  "http://demo.opengeo.org/geoserver/wfs",
+                    url:  "http://demo.boundlessgeo.com/geoserver/wfs",
                     featureType: "tasmania_roads",
                     featureNS: "http://www.openplans.org/topp"
                 }),

--- a/examples/wfs-protocol-transactions.js
+++ b/examples/wfs-protocol-transactions.js
@@ -57,11 +57,11 @@ function init() {
         protocol: new OpenLayers.Protocol.WFS({
             version: "1.1.0",
             srsName: "EPSG:4326",
-            url: "http://demo.opengeo.org/geoserver/wfs",
+            url: "http://demo.boundlessgeo.com/geoserver/wfs",
             featureNS :  "http://opengeo.org",
             featureType: "restricted",
             geometryName: "the_geom",
-            schema: "http://demo.opengeo.org/geoserver/wfs/DescribeFeatureType?version=1.1.0&typename=og:restricted"
+            schema: "http://demo.boundlessgeo.com/geoserver/wfs/DescribeFeatureType?version=1.1.0&typename=og:restricted"
         })
     }); 
    

--- a/examples/wfs-protocol.html
+++ b/examples/wfs-protocol.html
@@ -23,7 +23,7 @@
                 var layer = new OpenLayers.Layer.Vector("WFS", {
                     strategies: [new OpenLayers.Strategy.BBOX()],
                     protocol: new OpenLayers.Protocol.WFS({
-                        url:  "http://demo.opengeo.org/geoserver/wfs",
+                        url:  "http://demo.boundlessgeo.com/geoserver/wfs",
                         featureType: "tasmania_roads",
                         featureNS: "http://www.openplans.org/topp"
                     })

--- a/examples/wfs-reprojection.js
+++ b/examples/wfs-reprojection.js
@@ -41,7 +41,7 @@ function init() {
         protocol: new OpenLayers.Protocol.WFS({
             version: "1.0.0",
             srsName: "EPSG:4326", // this is the default
-            url:  "http://demo.opengeo.org/geoserver/wfs",
+            url:  "http://demo.boundlessgeo.com/geoserver/wfs",
             featureType: "states",
             featureNS: "http://www.openplans.org/topp"
         }),

--- a/examples/wfs-snap-split.html
+++ b/examples/wfs-snap-split.html
@@ -173,11 +173,11 @@
                 protocol: new OpenLayers.Protocol.WFS({
                     version: "1.1.0",
                     srsName: "EPSG:4326",
-                    url: "http://demo.opengeo.org/geoserver/wfs",
+                    url: "http://demo.boundlessgeo.com/geoserver/wfs",
                     featureNS :  "http://opengeo.org",
                     featureType: "roads",
                     geometryName: "the_geom",
-                    schema: "http://demo.opengeo.org/geoserver/wfs/DescribeFeatureType?version=1.1.0&typename=og:roads"
+                    schema: "http://demo.boundlessgeo.com/geoserver/wfs/DescribeFeatureType?version=1.1.0&typename=og:roads"
                 })
             }); 
            

--- a/examples/wfs-spatial-filter.js
+++ b/examples/wfs-spatial-filter.js
@@ -8,7 +8,7 @@ var wms = new OpenLayers.Layer.WMS(
 var layer = new OpenLayers.Layer.Vector("WFS", {
     strategies: [new OpenLayers.Strategy.BBOX()],
     protocol: new OpenLayers.Protocol.WFS({
-        url:  "http://demo.opengeo.org/geoserver/wfs",
+        url:  "http://demo.boundlessgeo.com/geoserver/wfs",
         featureType: "tasmania_roads",
         featureNS: "http://www.openplans.org/topp"
     })

--- a/examples/wfs-states.js
+++ b/examples/wfs-states.js
@@ -14,7 +14,7 @@ function init() {
                 {layers: "basic"} 
             ),
             new OpenLayers.Layer.WMS("States WMS",
-                "http://demo.opengeo.org/geoserver/wms",
+                "http://demo.boundlessgeo.com/geoserver/wms",
                 {layers: "topp:states", format: "image/png", transparent: true},
                 {maxScale: 15000000}
             ),
@@ -22,7 +22,7 @@ function init() {
                 minScale: 15000000,
                 strategies: [new OpenLayers.Strategy.BBOX()],
                 protocol: new OpenLayers.Protocol.WFS({
-                    url: "http://demo.opengeo.org/geoserver/wfs",
+                    url: "http://demo.boundlessgeo.com/geoserver/wfs",
                     featureType: "states",
                     featureNS: "http://www.openplans.org/topp"
                 }),

--- a/examples/wps-client.js
+++ b/examples/wps-client.js
@@ -23,7 +23,7 @@ function init() {
     
     client = new OpenLayers.WPSClient({
         servers: {
-            opengeo: 'http://demo.opengeo.org/geoserver/wps'
+            opengeo: 'http://demo.boundlessgeo.com/geoserver/wps'
         }
     });
     

--- a/examples/wps.js
+++ b/examples/wps.js
@@ -1,6 +1,6 @@
 OpenLayers.ProxyHost = "proxy.cgi?url=";
 
-var wps = "http://demo.opengeo.org/geoserver/wps",
+var wps = "http://demo.boundlessgeo.com/geoserver/wps",
     capabilities, // the capabilities, read by Format.WPSCapabilities::read
     process; // the process description from Format.WPSDescribeProcess::read
 

--- a/tests/manual/dateline-sketch.html
+++ b/tests/manual/dateline-sketch.html
@@ -36,7 +36,7 @@
         var map = new OpenLayers.Map('map');
 
         var base = new OpenLayers.Layer.WMS("marble", 
-            "http://demo.opengeo.org/geoserver/wms",
+            "http://demo.boundlessgeo.com/geoserver/wms",
             {layers: "topp:naturalearth"},
             {wrapDateLine: true}
         );

--- a/tests/manual/dateline-smallextent.html
+++ b/tests/manual/dateline-smallextent.html
@@ -23,13 +23,13 @@ function init(){
     map = new OpenLayers.Map('map');
 
     var base = new OpenLayers.Layer.WMS("marble", 
-        "http://demo.opengeo.org/geoserver/wms",
+        "http://demo.boundlessgeo.com/geoserver/wms",
         {layers: "topp:naturalearth"},
         {wrapDateLine: true}
     );
     var extent = new OpenLayers.Bounds(142.3828125,-70.902270266175,233.6171875,-12.039326531729);
     var wms = new OpenLayers.Layer.WMS( "world",
-        "http://demo.opengeo.org/geoserver/wms",
+        "http://demo.boundlessgeo.com/geoserver/wms",
         {layers: 'world', transparent: true},
         {maxExtent: extent}
     );

--- a/tests/manual/google-fullscreen-overlay.html
+++ b/tests/manual/google-fullscreen-overlay.html
@@ -44,7 +44,7 @@
             "Google Streets", {sphericalMercator: true}
         );
         var states = new OpenLayers.Layer.WMS(
-            "USA States", "http://demo.opengeo.org/geoserver/wms",
+            "USA States", "http://demo.boundlessgeo.com/geoserver/wms",
             {layers: "topp:states", transparent: true}
         );
         map.addLayers([gmap, states]);

--- a/tests/speed/wmscaps.js
+++ b/tests/speed/wmscaps.js
@@ -1,6 +1,6 @@
 var caps = 
 '<?xml version="1.0" encoding="UTF-8"?>' +
-'<!DOCTYPE WMT_MS_Capabilities SYSTEM "http://demo.opengeo.org/geoserver/schemas/wms/1.1.1/WMS_MS_Capabilities.dtd">' +
+'<!DOCTYPE WMT_MS_Capabilities SYSTEM "http://demo.boundlessgeo.com/geoserver/schemas/wms/1.1.1/WMS_MS_Capabilities.dtd">' +
 '<WMT_MS_Capabilities version="1.1.1" updateSequence="145">' +
 '  <Service>' +
 '    <Name>OGC:WMS</Name>' +
@@ -11,7 +11,7 @@ var caps =
 '      <Keyword>WMS</Keyword>' +
 '      <Keyword>GEOSERVER</Keyword>' +
 '    </KeywordList>' +
-'    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms"/>' +
+'    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms"/>' +
 '    <ContactInformation>' +
 '      <ContactPersonPrimary>' +
 '        <ContactPerson>Claudius Ptolomaeus</ContactPerson>' +
@@ -40,10 +40,10 @@ var caps =
 '        <DCPType>' +
 '          <HTTP>' +
 '            <Get>' +
-'              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&amp;"/>' +
+'              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&amp;"/>' +
 '            </Get>' +
 '            <Post>' +
-'              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&amp;"/>' +
+'              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&amp;"/>' +
 '            </Post>' +
 '          </HTTP>' +
 '        </DCPType>' +
@@ -80,7 +80,7 @@ var caps =
 '        <DCPType>' +
 '          <HTTP>' +
 '            <Get>' +
-'              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&amp;"/>' +
+'              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&amp;"/>' +
 '            </Get>' +
 '          </HTTP>' +
 '        </DCPType>' +
@@ -92,10 +92,10 @@ var caps =
 '        <DCPType>' +
 '          <HTTP>' +
 '            <Get>' +
-'              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&amp;"/>' +
+'              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&amp;"/>' +
 '            </Get>' +
 '            <Post>' +
-'              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&amp;"/>' +
+'              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&amp;"/>' +
 '            </Post>' +
 '          </HTTP>' +
 '        </DCPType>' +
@@ -105,7 +105,7 @@ var caps =
 '        <DCPType>' +
 '          <HTTP>' +
 '            <Get>' +
-'              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&amp;"/>' +
+'              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&amp;"/>' +
 '            </Get>' +
 '          </HTTP>' +
 '        </DCPType>' +
@@ -117,7 +117,7 @@ var caps =
 '        <DCPType>' +
 '          <HTTP>' +
 '            <Get>' +
-'              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&amp;"/>' +
+'              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&amp;"/>' +
 '            </Get>' +
 '          </HTTP>' +
 '        </DCPType>' +
@@ -4086,7 +4086,7 @@ var caps =
 '          <Abstract/>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:bugsites"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:bugsites"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4131,7 +4131,7 @@ var caps =
 '          <Abstract>A sample style that just prints out a transparent red interior with a red outline</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:restricted"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:restricted"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4176,7 +4176,7 @@ var caps =
 '          <Abstract>A sample style that just prints out a 6px wide red square</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:archsites"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:archsites"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4220,7 +4220,7 @@ var caps =
 '          <Abstract>Blue lines, 2px wide</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:streams"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:streams"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4253,7 +4253,7 @@ var caps =
 '          <Abstract/>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tiger:poly_landmarks"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tiger:poly_landmarks"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4286,7 +4286,7 @@ var caps =
 '          <Abstract>Manhattan points of interest</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tiger:poi"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tiger:poi"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4318,7 +4318,7 @@ var caps =
 '          <Abstract/>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tiger:tiger_roads"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tiger:tiger_roads"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4353,7 +4353,7 @@ var caps =
 '          <Abstract/>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_natural"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_natural"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4393,7 +4393,7 @@ var caps =
 '          <Abstract/>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_points"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_points"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4425,7 +4425,7 @@ var caps =
 '          <Abstract/>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_roads"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_roads"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4457,7 +4457,7 @@ var caps =
 '          <Abstract/>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_vegetation"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_vegetation"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4488,7 +4488,7 @@ var caps =
 '          <Abstract/>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_cities"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_cities"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4519,7 +4519,7 @@ var caps =
 '          <Abstract>Light red line, 2px wide</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_roads"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_roads"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4551,7 +4551,7 @@ var caps =
 '          <Abstract>Green fill with black outline</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_state_boundaries"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_state_boundaries"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4585,7 +4585,7 @@ var caps =
 '          <Abstract>A blue fill, solid black outline style</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_water_bodies"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_water_bodies"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4620,7 +4620,7 @@ var caps =
 '        categories of population, drawn in different colors</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:states"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:states"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4651,7 +4651,7 @@ var caps =
 '          <Abstract>Default line style, 1 pixel wide blue</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:waterways"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:waterways"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4682,7 +4682,7 @@ var caps =
 '          <Abstract>Default line style, 1 pixel wide blue</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:railways"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:railways"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4713,7 +4713,7 @@ var caps =
 '          <Abstract>Default line style, 1 pixel wide blue</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:roads"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:roads"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4756,7 +4756,7 @@ var caps =
 '          <Abstract>Light red line, 2px wide</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:roads"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:roads"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4787,7 +4787,7 @@ var caps =
 '          <Abstract>Default line style, 1 pixel wide blue</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:points"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:points"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4819,7 +4819,7 @@ var caps =
 '          <Abstract>A sample style for rasters, good for displaying imagery</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:bluemarble"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:bluemarble"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4851,7 +4851,7 @@ var caps =
 '          <Abstract>A sample style for rasters, good for displaying imagery</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=nurc:Arc_Sample"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=nurc:Arc_Sample"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4883,7 +4883,7 @@ var caps =
 '          <Abstract>A sample style for rasters, good for displaying imagery</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=nurc:Img_Sample"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=nurc:Img_Sample"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +
@@ -4930,7 +4930,7 @@ var caps =
 '          <Abstract>Classic elevation color progression</Abstract>' +
 '          <LegendURL width="20" height="20">' +
 '            <Format>image/png</Format>' +
-'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=sf:sfdem"/>' +
+'            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=sf:sfdem"/>' +
 '          </LegendURL>' +
 '        </Style>' +
 '      </Layer>' +

--- a/tests/speed/wmscaps.xml
+++ b/tests/speed/wmscaps.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE WMT_MS_Capabilities SYSTEM "http://demo.opengeo.org/geoserver/schemas/wms/1.1.1/WMS_MS_Capabilities.dtd">
+<!DOCTYPE WMT_MS_Capabilities SYSTEM "http://demo.boundlessgeo.com/geoserver/schemas/wms/1.1.1/WMS_MS_Capabilities.dtd">
 <WMT_MS_Capabilities version="1.1.1" updateSequence="145">
   <Service>
     <Name>OGC:WMS</Name>
@@ -10,7 +10,7 @@
       <Keyword>WMS</Keyword>
       <Keyword>GEOSERVER</Keyword>
     </KeywordList>
-    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms"/>
+    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms"/>
     <ContactInformation>
       <ContactPersonPrimary>
         <ContactPerson>Claudius Ptolomaeus</ContactPerson>
@@ -39,10 +39,10 @@
         <DCPType>
           <HTTP>
             <Get>
-              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&amp;"/>
+              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&amp;"/>
             </Get>
             <Post>
-              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&amp;"/>
+              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&amp;"/>
             </Post>
           </HTTP>
         </DCPType>
@@ -79,7 +79,7 @@
         <DCPType>
           <HTTP>
             <Get>
-              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&amp;"/>
+              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&amp;"/>
             </Get>
           </HTTP>
         </DCPType>
@@ -91,10 +91,10 @@
         <DCPType>
           <HTTP>
             <Get>
-              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&amp;"/>
+              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&amp;"/>
             </Get>
             <Post>
-              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&amp;"/>
+              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&amp;"/>
             </Post>
           </HTTP>
         </DCPType>
@@ -104,7 +104,7 @@
         <DCPType>
           <HTTP>
             <Get>
-              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&amp;"/>
+              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&amp;"/>
             </Get>
           </HTTP>
         </DCPType>
@@ -116,7 +116,7 @@
         <DCPType>
           <HTTP>
             <Get>
-              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&amp;"/>
+              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&amp;"/>
             </Get>
           </HTTP>
         </DCPType>
@@ -4085,7 +4085,7 @@ PROJCS["NAD27 / UTM zone 13N",
           <Abstract/>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:bugsites"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:bugsites"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4130,7 +4130,7 @@ PROJCS["NAD27 / UTM zone 13N",
           <Abstract>A sample style that just prints out a transparent red interior with a red outline</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:restricted"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:restricted"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4175,7 +4175,7 @@ PROJCS["NAD27 / UTM zone 13N",
           <Abstract>A sample style that just prints out a 6px wide red square</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:archsites"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:archsites"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4219,7 +4219,7 @@ PROJCS["NAD27 / UTM zone 13N",
           <Abstract>Blue lines, 2px wide</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:streams"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:streams"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4252,7 +4252,7 @@ GEOGCS["WGS 84",
           <Abstract/>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tiger:poly_landmarks"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tiger:poly_landmarks"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4285,7 +4285,7 @@ GEOGCS["WGS 84",
           <Abstract>Manhattan points of interest</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tiger:poi"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tiger:poi"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4317,7 +4317,7 @@ GEOGCS["WGS 84",
           <Abstract/>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tiger:tiger_roads"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tiger:tiger_roads"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4352,7 +4352,7 @@ GEOGCS["WGS 84",
           <Abstract/>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_natural"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_natural"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4392,7 +4392,7 @@ GEOGCS["WGS 84",
           <Abstract/>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_points"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_points"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4424,7 +4424,7 @@ GEOGCS["WGS 84",
           <Abstract/>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_roads"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_roads"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4456,7 +4456,7 @@ GEOGCS["WGS 84",
           <Abstract/>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_vegetation"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=za:za_vegetation"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4487,7 +4487,7 @@ GEOGCS["WGS 84",
           <Abstract/>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_cities"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_cities"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4518,7 +4518,7 @@ GEOGCS["WGS 84",
           <Abstract>Light red line, 2px wide</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_roads"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_roads"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4550,7 +4550,7 @@ GEOGCS["WGS 84",
           <Abstract>Green fill with black outline</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_state_boundaries"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_state_boundaries"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4584,7 +4584,7 @@ GEOGCS["WGS 84",
           <Abstract>A blue fill, solid black outline style</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_water_bodies"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:tasmania_water_bodies"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4619,7 +4619,7 @@ GEOGCS["WGS 84",
         categories of population, drawn in different colors</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:states"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:states"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4650,7 +4650,7 @@ GEOGCS["WGS 84",
           <Abstract>Default line style, 1 pixel wide blue</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:waterways"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:waterways"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4681,7 +4681,7 @@ GEOGCS["WGS 84",
           <Abstract>Default line style, 1 pixel wide blue</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:railways"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:railways"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4712,7 +4712,7 @@ GEOGCS["WGS 84",
           <Abstract>Default line style, 1 pixel wide blue</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:roads"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:roads"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4755,7 +4755,7 @@ PROJCS["NAD27 / UTM zone 13N",
           <Abstract>Light red line, 2px wide</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:roads"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=og:roads"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4786,7 +4786,7 @@ GEOGCS["WGS 84",
           <Abstract>Default line style, 1 pixel wide blue</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:points"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=tike:points"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4818,7 +4818,7 @@ GEOGCS["WGS 84",
           <Abstract>A sample style for rasters, good for displaying imagery</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:bluemarble"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=topp:bluemarble"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4850,7 +4850,7 @@ GEOGCS["WGS 84",
           <Abstract>A sample style for rasters, good for displaying imagery</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=nurc:Arc_Sample"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=nurc:Arc_Sample"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4882,7 +4882,7 @@ GEOGCS["WGS 84",
           <Abstract>A sample style for rasters, good for displaying imagery</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=nurc:Img_Sample"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=nurc:Img_Sample"/>
           </LegendURL>
         </Style>
       </Layer>
@@ -4929,7 +4929,7 @@ PROJCS["NAD27 / UTM zone 13N",
           <Abstract>Classic elevation color progression</Abstract>
           <LegendURL width="20" height="20">
             <Format>image/png</Format>
-            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.opengeo.org/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=sf:sfdem"/>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://demo.boundlessgeo.com/geoserver/wms/GetLegendGraphic?VERSION=1.0.0&amp;FORMAT=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=sf:sfdem"/>
           </LegendURL>
         </Style>
       </Layer>


### PR DESCRIPTION
Currently demo.opengeo.org redirects to demo.boundlessgeo.com. This change
makes it so demo.boundlessgeo.com is used directly.
