### PR TITLE
Correct the equation for computeHeading() in Spherical.js, incorrect delta Longitude

### DIFF
--- a/lib/OpenLayers/Spherical.js
+++ b/lib/OpenLayers/Spherical.js
@@ -60,8 +60,8 @@ OpenLayers.Spherical.computeDistanceBetween = function(from, to, radius) {
  * {Float} The heading in degrees.
  */
 OpenLayers.Spherical.computeHeading = function(from, to) {
-    var y = Math.sin(Math.PI * (from.lon - to.lon) / 180) * Math.cos(Math.PI * to.lat / 180);
+    var y = Math.sin(Math.PI * (to.lon - from.lon) / 180) * Math.cos(Math.PI * to.lat / 180);
     var x = Math.cos(Math.PI * from.lat / 180) * Math.sin(Math.PI * to.lat / 180) -
-        Math.sin(Math.PI * from.lat / 180) * Math.cos(Math.PI * to.lat / 180) * Math.cos(Math.PI * (from.lon - to.lon) / 180);
+        Math.sin(Math.PI * from.lat / 180) * Math.cos(Math.PI * to.lat / 180) * Math.cos(Math.PI * (to.lon - from.lon) / 180);
     return 180 * Math.atan2(y, x) / Math.PI;
 };


### PR DESCRIPTION
The current implementation of OpenLayers.Spherical.computeHeading() is wrong based on the relevant [link](http://www.movable-type.co.uk/scripts/latlong.html) listed in Spherical.js. The delta of the longitudes is reversed in both the 'y' and the 'x' portion of the equations. Instead of `from.lon - to.lon`, it should be `to.lon - from.lon`.
