### PR TITLE
Do not fail when tap fires touchstart-touchmove-touchend

### DIFF
--- a/lib/OpenLayers/Events/buttonclick.js
+++ b/lib/OpenLayers/Events/buttonclick.js
@@ -180,6 +180,7 @@ OpenLayers.Events.buttonclick = OpenLayers.Class({
                     }
                 } else if (this.startEvt) {
                     if (this.completeRegEx.test(evt.type)) {
+                        delete this._cancelCount;
                         var pos = OpenLayers.Util.pagePosition(button);
                         var viewportElement = OpenLayers.Util.getViewportElement();
                         var scrollTop = window.pageYOffset || viewportElement.scrollTop;
@@ -196,12 +197,16 @@ OpenLayers.Events.buttonclick = OpenLayers.Class({
                         });
                     }
                     if (this.cancelRegEx.test(evt.type)) {
-                        delete this.startEvt;
+                        ++this._cancelCount;
+                        if (this._cancelCount > 1) {
+                          delete this.startEvt;
+                        }
                     }
                     OpenLayers.Event.stop(evt);
                     propagate = false;
                 }
                 if (this.startRegEx.test(evt.type)) {
+                    this._cancelCount = 0;
                     this.startEvt = evt;
                     OpenLayers.Event.stop(evt);
                     propagate = false;


### PR DESCRIPTION
If @pgiraud's observations are correct, then this closes #1376.
