### PR TITLE
Fix two bug in WMTS layer with dimensions in REST mode.

### DIFF
--- a/lib/OpenLayers/Layer/WMTS.js
+++ b/lib/OpenLayers/Layer/WMTS.js
@@ -453,7 +453,7 @@ OpenLayers.Layer.WMTS = OpenLayers.Class(OpenLayers.Layer.Grid, {
                     // append optional dimension path elements
                     if (dimensions) {
                         for (var i=0; i<dimensions.length; i++) {
-                            if (params[dimensions[i]]) {
+                            if (params[dimensions[i]] !== undefined) {
                                 path = path + params[dimensions[i]] + "/";
                             }
                         }
@@ -499,11 +499,9 @@ OpenLayers.Layer.WMTS = OpenLayers.Class(OpenLayers.Layer.Grid, {
      * newParams - {Object} Properties to extend to existing <params>.
      */
     mergeNewParams: function(newParams) {
-        if (this.requestEncoding.toUpperCase() === "KVP") {
-            return OpenLayers.Layer.Grid.prototype.mergeNewParams.apply(
-                this, [OpenLayers.Util.upperCaseObject(newParams)]
-            );
-        }
+        return OpenLayers.Layer.Grid.prototype.mergeNewParams.apply(
+            this, [OpenLayers.Util.upperCaseObject(newParams)]
+        );
     },
 
     CLASS_NAME: "OpenLayers.Layer.WMTS"


### PR DESCRIPTION
- When the dimension value was 0, the dimension was not added to the
  URL.

- mergeNewParams was a noop in REST mode.