### PR TITLE
Correct touch events constant in MSPointer model

### DIFF
--- a/lib/OpenLayers/Events.js
+++ b/lib/OpenLayers/Events.js
@@ -137,7 +137,7 @@ OpenLayers.Event = {
     isTouchEvent: function(evt) {
         return ("" + evt.type).indexOf("touch") === 0 || (
                 "pointerType" in evt && (
-                     evt.pointerType === evt.MSPOINTER_TYPE_MOUSE /*IE10 pointer*/ ||
+                     evt.pointerType === evt.MSPOINTER_TYPE_TOUCH /*IE10 pointer*/ ||
                      evt.pointerType === "touch" /*W3C pointer*/));
     },
 


### PR DESCRIPTION
The constant indicating a touch event for the pointerType property of an
event is of course MSPOINTER_TYPE_TOUCH and not MSPOINTER_TYPE_MOUSE!