### PR TITLE
optionally use POST insetad of GET for WMSGetFeatureInfo - trac ticket 3357

### DIFF
--- a/lib/OpenLayers/Control/WMSGetFeatureInfo.js
+++ b/lib/OpenLayers/Control/WMSGetFeatureInfo.js
@@ -157,6 +157,13 @@ OpenLayers.Control.WMSGetFeatureInfo = OpenLayers.Class(OpenLayers.Control, {
     hoverRequest: null,
 
     /**
+     * APIProperty: usePOST
+     * {Boolean} true if the GetFeatureInfo request are done with POST requests
+     *     instead of GET, defaults to false.
+     */
+    usePOST: false,
+
+    /**
      * APIProperty: events
      * {<OpenLayers.Events>} Events instance for listeners and triggering
      *     control specific events.
@@ -435,7 +442,7 @@ OpenLayers.Control.WMSGetFeatureInfo = OpenLayers.Class(OpenLayers.Control, {
         if(this.drillDown === false) {
             var wmsOptions = this.buildWMSOptions(this.url, layers,
                 clickPosition, layers[0].params.FORMAT);
-            var request = OpenLayers.Request.GET(wmsOptions);
+            var request = this.doRequest(clickPosition, options, wmsOptions);
 
             if (options.hover === true) {
                 this.hoverRequest = request;
@@ -448,7 +455,6 @@ OpenLayers.Control.WMSGetFeatureInfo = OpenLayers.Class(OpenLayers.Control, {
             var services = {}, url;
             for(var i=0, len=layers.length; i<len; i++) {
                 var layer = layers[i];
-                var service, found = false;
                 url = OpenLayers.Util.isArray(layer.url) ? layer.url[0] : layer.url;
                 if(url in services) {
                     services[url].push(layer);
@@ -457,14 +463,46 @@ OpenLayers.Control.WMSGetFeatureInfo = OpenLayers.Class(OpenLayers.Control, {
                     services[url] = [layer];
                 }
             }
-            var layers;
-            for (var url in services) {
-                layers = services[url];
-                var wmsOptions = this.buildWMSOptions(url, layers,
+            for (var urlService in services) {
+                layers = services[urlService];
+                var wmsOptions2 = this.buildWMSOptions(urlService, layers,
                     clickPosition, layers[0].params.FORMAT);
-                OpenLayers.Request.GET(wmsOptions);
+                this.doRequest(clickPosition, options, wmsOptions2);
             }
         }
+    },
+
+    /**
+     * Method: doRequest
+     * Sends a GetFeatureInfo request to the WMS depending on option usePOST
+     *
+     * Parameters:
+     * clickPosition - {<OpenLayers.Pixel>} The position on the map where the
+     *     mouse event occurred.
+     * options - {Object} additional options for this method.
+     * wmsOptions - {Array({Object})} with the relevant WMS options for the
+     *    GetFeatureInfo request gotten by buildWMSOptions.
+     */
+    doRequest: function (clickPosition, options, wmsOptions) {
+        var usePOST = (options.usePOST !== undefined) ?
+            options.usePOST : this.usePOST;
+        var request;
+        if (usePOST) {
+            var headers = wmsOptions.headers || {};
+            headers["Content-Type"] = "application/x-www-form-urlencoded";
+            request = OpenLayers.Request.POST({
+                url: wmsOptions.url,
+                callback: function (request) {
+                    this.handleResponse(clickPosition, request, wmsOptions.url);
+                },
+                data: OpenLayers.Util.getParameterString(wmsOptions.params),
+                headers: headers,
+                scope: this
+            });
+        } else {
+            request = OpenLayers.Request.GET(wmsOptions);
+        }
+        return request;
     },
 
     /**


### PR DESCRIPTION
add option usePOST for optionally using POST insetad of GET for WMSGetFeatureInfo requests (idea from Protocol/HTTP.js)

fixes https://trac.osgeo.org/openlayers/ticket/3357