### PR TITLE
fix WMS with long URLs using POST and a gutter

### DIFF
--- a/examples/wms-long-url.js
+++ b/examples/wms-long-url.js
@@ -8,19 +8,26 @@ var base = new OpenLayers.Layer.WMS( "OpenLayers WMS",
     {tileOptions: {maxGetUrlLength: 2048}, transitionEffect: 'resize'}
 );
 var overlay = new OpenLayers.Layer.WMS("Overlay",
-    "http://suite.opengeo.org/geoserver/wms",
-    {layers: "usa:states", transparent: true, makeTheUrlLong: longText},
+    "http://demo.boundlessgeo.com/geoserver/wms",
+    {layers: "topp:states", transparent: true, makeTheUrlLong: longText},
     {ratio: 1, singleTile: true, tileOptions: {maxGetUrlLength: 2048}, transitionEffect: 'resize'}
 );
-map.addLayers([base, overlay]);
+var overlay2 = new OpenLayers.Layer.WMS("Overlay with gutter",
+    "http://demo.boundlessgeo.com/geoserver/wms",
+    {layers: "topp:states", transparent: true, makeTheUrlLong: longText},
+    {tileOptions: {maxGetUrlLength: 2048}, transitionEffect: 'resize', opacity: 0.5, gutter: 32}
+);
+map.addLayers([base, overlay, overlay2]);
 map.zoomToMaxExtent();
 
 // add behavior to dom elements
 document.getElementById("longurl").onclick = function() {
     base.mergeNewParams({makeTheUrlLong: longText});
     overlay.mergeNewParams({makeTheUrlLong: longText});
+    overlay2.mergeNewParams({makeTheUrlLong: longText});
 };
 document.getElementById("shorturl").onclick = function() {
     base.mergeNewParams({makeTheUrlLong: null});
     overlay.mergeNewParams({makeTheUrlLong: null});
+    overlay2.mergeNewParams({makeTheUrlLong: null});
 };

--- a/lib/OpenLayers/Tile/Image/IFrame.js
+++ b/lib/OpenLayers/Tile/Image/IFrame.js
@@ -127,8 +127,15 @@ OpenLayers.Tile.Image.IFrame = {
             iframe.frameBorder    = '0';
 
             iframe.style.position = "absolute";
-            iframe.style.width    = "100%";
-            iframe.style.height   = "100%";
+            var left = 0, top = 0;
+            if (this.layer.gutter) {
+                left = this.layer.gutter / this.layer.tileSize.w * 100;
+                top = this.layer.gutter / this.layer.tileSize.h * 100;
+            }
+            iframe.style.left = -left + "%";
+            iframe.style.top = -top + "%";
+            iframe.style.width = (2 * left + 100) + "%";
+            iframe.style.height = (2 * top + 100) + "%";
 
             if (this.layer.opacity < 1) {
                 OpenLayers.Util.modifyDOMElement(iframe, null, null, null,
@@ -162,7 +169,7 @@ OpenLayers.Tile.Image.IFrame = {
 
         // adding all parameters in layer params as hidden fields to the html
         // form element
-        var imageSize = this.layer.getImageSize(),
+        var imageSize = this.layer.getImageSize(this.bounds),
             params = OpenLayers.Util.getParameters(this.url),
             field;
             


### PR DESCRIPTION
1) examples/wms-long-url.js: added additional overlay in example
2) Tile/Image/IFrame.js:
a) adapt style of iframe: use same idea as line 267-277 of Tile/Image.js (in getImage(), line 130ff.)
b) make sure bounds are set for getImageSize() (in createRequestForm(), line 172)