### PR TITLE
Only register one type of pointer/touch handler.

### DIFF
--- a/lib/OpenLayers/Events.js
+++ b/lib/OpenLayers/Events.js
@@ -673,12 +673,12 @@ OpenLayers.Events = OpenLayers.Class({
         for (var i = 0, len = this.BROWSER_EVENTS.length; i < len; i++) {
             type = this.BROWSER_EVENTS[i];
             // register the event cross-browser
-            OpenLayers.Event.observe(element, type, this.eventHandler
-            );
             if ((touchModel === this.TOUCH_MODEL_POINTER ||
                     touchModel === this.TOUCH_MODEL_MSPOINTER) &&
                     type.indexOf('touch') === 0) {
                 this.addPointerTouchListener(element, type, this.eventHandler);
+            } else {
+                OpenLayers.Event.observe(element, type, this.eventHandler);
             }
         }
         // disable dragstart in IE so that mousedown/move/up works normally

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -3,11 +3,12 @@ div.olMap {
     padding: 0 !important;
     margin: 0 !important;
     cursor: default;
+    -ms-touch-action: none;
+    touch-action: none;
 }
 
 div.olMapViewport {
     text-align: left;
-    -ms-touch-action: none;
 }
 
 div.olLayerDiv {


### PR DESCRIPTION
Also use the standard touch-action CSS, not just the Microsoft prefix,
and move it to olMap. Thanks to Dave Tapuska for investigating this.

Might fix #1510.