### PR TITLE
Add touch-action property to mobile style

### DIFF
--- a/theme/default/style.mobile.css
+++ b/theme/default/style.mobile.css
@@ -43,8 +43,9 @@ div.olControlZoom a:hover {
         background: rgba(0, 60, 136, 0.5);
     }
 }
-div.olMapViewport {
+div.olMap {
     -ms-touch-action: none;
+    touch-action: none;
 }
 .olLayerGrid .olTileImage {
     -webkit-transition: opacity 0.2s linear;


### PR DESCRIPTION
This pull request is an addition to https://github.com/openlayers/ol2/pull/1511

Adding "touch-action" CSS property and putting "touch-action" related properties at the `.olMap` level has only been done for the default main stylesheet. However, most of the "mobile-xxx" examples use a specific stylesheet and the map is not panning in these examples on recent versions of Chrome on Android.