### PR TITLE
Update Util.js,fix a bug

### DIFF
--- a/lib/OpenLayers/Util.js
+++ b/lib/OpenLayers/Util.js
@@ -1371,7 +1371,7 @@ OpenLayers.Util.createUrlObject = function(url, options) {
             // relative to current path
             var parts = loc.pathname.split("/");
             parts.pop();
-            url = fullUrl + parts.join("/") + "/" + url;
+            url = fullUrl + '/' + parts.join("/") + "/" + url;
         }
     }
   


### PR DESCRIPTION
function createUrlObject does not work in ie8 when your page was opened by window.showModalDialog.It links port and web context directly,lacks of '/'