### PR TITLE
Fix touchmove logic in buttonclick.

### DIFF
--- a/lib/OpenLayers/Events/buttonclick.js
+++ b/lib/OpenLayers/Events/buttonclick.js
@@ -198,7 +198,7 @@ OpenLayers.Events.buttonclick = OpenLayers.Class({
                     if (this.cancelRegEx.test(evt.type)) {
                         if (evt.touches && this.startEvt.touches &&
                                 (Math.abs(evt.touches[0].olClientX - this.startEvt.touches[0].olClientX) > 4 ||
-                                Math.abs(evt.touches[0].olClientY - this.startEvt.touches[0].olClientY)) > 4) {
+                                Math.abs(evt.touches[0].olClientY - this.startEvt.touches[0].olClientY) > 4)) {
                             delete this.startEvt;
                         }
                     }


### PR DESCRIPTION
The incorrect bracket placement meant that touch events were not being cancelled should you move your finger, meaning e.g. a zoom would still occur if you touched a zoom, moved your finger off, then lifted.

I submit this PR not in the expectation it'll get merged, but more to document this for anyone else finding themselves in the same situation.